### PR TITLE
feat(benchkit): add cursored CI run ingest action and docs

### DIFF
--- a/.github/workflows/actions-dist.yml
+++ b/.github/workflows/actions-dist.yml
@@ -74,7 +74,10 @@ jobs:
             octo11y/actions/parse-results/dist \
             octo11y/actions/repo-stats/action.yml \
             octo11y/actions/repo-stats/README.md \
-            octo11y/actions/repo-stats/dist
+            octo11y/actions/repo-stats/dist \
+            octo11y/actions/ingest-ci-runs/action.yml \
+            octo11y/actions/ingest-ci-runs/README.md \
+            octo11y/actions/ingest-ci-runs/dist
 
           if git diff --cached --quiet; then
             echo "No dist changes to publish."

--- a/actions/parse-results/README.md
+++ b/actions/parse-results/README.md
@@ -2,6 +2,9 @@
 
 Parses benchmark output into OTLP metrics JSON and stashes it to a data branch.
 
+Use a published dist ref (`@main-dist` or a version tag). Do not use `@main`
+for JS actions, because `@main` does not include compiled action bundles.
+
 ## Modes
 
 - `mode: auto` (default): downloads current run logs via GitHub Actions API using `github-token`.
@@ -32,7 +35,7 @@ permissions:
 steps:
   - uses: actions/checkout@v4
   - run: go test -bench=. -benchmem ./...
-  - uses: ./actions/parse-results
+  - uses: strawgate/o11ykit/actions/parse-results@main-dist
     with:
       mode: auto
       format: go

--- a/octo11y/DEVELOPING.md
+++ b/octo11y/DEVELOPING.md
@@ -25,6 +25,8 @@ Use the docs that match the audience you are working for:
 - `packages/chart/`: Preact dashboard components, chart primitives, fetch helpers
 - `packages/dashboard/`: private dogfood app deployed to [GitHub Pages](https://strawgate.github.io/octo11y/) — not a template (build from `@benchkit/chart` instead)
 - `actions/stash/`: GitHub Action to parse and store run data
+- `actions/parse-results/`: GitHub Action to parse logs/files and stash normalized OTLP
+- `actions/ingest-ci-runs/`: GitHub Action to discover completed CI runs for scheduled ingest
 - `actions/aggregate/`: GitHub Action to build indexes and views
 - `actions/compare/`: GitHub Action to compare results against a baseline
 - `actions/monitor/`: GitHub Action for collector-backed telemetry capture
@@ -55,6 +57,8 @@ npm run build --workspace=packages/format
 npm run build --workspace=packages/chart
 npm run build --workspace=packages/dashboard
 npm run build --workspace=actions/stash
+npm run build --workspace=actions/parse-results
+npm run build --workspace=actions/ingest-ci-runs
 npm run build --workspace=actions/aggregate
 npm run build --workspace=actions/compare
 npm run build --workspace=actions/monitor

--- a/octo11y/README.md
+++ b/octo11y/README.md
@@ -62,6 +62,7 @@ Works with Go, Rust, Hyperfine, pytest-benchmark, and more — see
 | `@benchkit/adapters` | Library-agnostic data transforms (filters, regressions) + Chart.js adapter | [`packages/adapters/README.md`](packages/adapters/README.md) |
 | `@benchkit/chart` | Preact dashboards, charts, and fetch helpers | [`packages/chart/README.md`](packages/chart/README.md) |
 | `actions/parse-results` | Parse benchmark output from logs/files and stash by default | [`actions/parse-results/README.md`](actions/parse-results/README.md) |
+| `actions/ingest-ci-runs` | Discover completed workflow runs for scheduled benchmark ingestion | [`actions/ingest-ci-runs/README.md`](actions/ingest-ci-runs/README.md) |
 | `actions/stash` | Store raw run results on the data branch | [`actions/stash/README.md`](actions/stash/README.md) |
 | `actions/aggregate` | Build derived indexes, series, and run views | [`actions/aggregate/README.md`](actions/aggregate/README.md) |
 | `actions/compare` | Compare current results to a baseline and comment on PRs | [`actions/compare/README.md`](actions/compare/README.md) |

--- a/octo11y/actions/ingest-ci-runs/README.md
+++ b/octo11y/actions/ingest-ci-runs/README.md
@@ -13,7 +13,9 @@ This action does discovery only. Pair it with
 ## Behavior
 
 - Scans all workflows by default.
-- Uses `data/state/ingest-cursor.json` on the data branch as a cursor.
+- Uses `data/state/benchkit-ci-run-ingest.cursor.json` on the data branch as a cursor.
+- Automatically reads the legacy cursor path (`data/state/ingest-cursor.json`) if
+  present, then migrates writes to the specific default path.
 - If no cursor (and no explicit `since`) exists, applies a bounded first-run
   lookback window (`lookback-hours`, default `72`).
 - Supports optional workflow/event/conclusion filters.
@@ -25,7 +27,7 @@ This action does discovery only. Pair it with
 | `github-token` | yes | `${{ github.token }}` | Token with `actions:read` and `contents:write` (when `commit-cursor=true`). |
 | `repository` | no | `${{ github.repository }}` | Repository to inspect (`owner/repo`). |
 | `data-branch` | no | `bench-data` | Data branch containing the cursor file. |
-| `cursor-path` | no | `data/state/ingest-cursor.json` | Cursor JSON path on the data branch. |
+| `cursor-path` | no | `data/state/benchkit-ci-run-ingest.cursor.json` | Cursor JSON path on the data branch. |
 | `commit-cursor` | no | `true` | Persist the updated cursor to `data-branch` after discovery. |
 | `since` | no | — | Explicit ISO lower-bound timestamp for `created_at` filtering. |
 | `lookback-hours` | no | `72` | Fallback lookback when no `since`/cursor is available. |

--- a/octo11y/actions/ingest-ci-runs/README.md
+++ b/octo11y/actions/ingest-ci-runs/README.md
@@ -1,0 +1,107 @@
+# Benchkit Ingest CI Runs
+
+Discover completed GitHub Actions workflow runs that should be parsed into
+bench data.
+
+Use a published dist ref (`@main-dist` or a version tag). Do not use `@main`
+for JS actions, because `@main` does not include compiled action bundles.
+
+This action does discovery only. Pair it with
+`strawgate/o11ykit/actions/parse-results@main-dist` in a matrix job, then run
+`strawgate/o11ykit/octo11y/actions/aggregate@main-dist`.
+
+## Behavior
+
+- Scans all workflows by default.
+- Uses `data/state/ingest-cursor.json` on the data branch as a cursor.
+- If no cursor (and no explicit `since`) exists, applies a bounded first-run
+  lookback window (`lookback-hours`, default `72`).
+- Supports optional workflow/event/conclusion filters.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `github-token` | yes | `${{ github.token }}` | Token with `actions:read` and `contents:write` (when `commit-cursor=true`). |
+| `repository` | no | `${{ github.repository }}` | Repository to inspect (`owner/repo`). |
+| `data-branch` | no | `bench-data` | Data branch containing the cursor file. |
+| `cursor-path` | no | `data/state/ingest-cursor.json` | Cursor JSON path on the data branch. |
+| `commit-cursor` | no | `true` | Persist the updated cursor to `data-branch` after discovery. |
+| `since` | no | — | Explicit ISO lower-bound timestamp for `created_at` filtering. |
+| `lookback-hours` | no | `72` | Fallback lookback when no `since`/cursor is available. |
+| `max-runs` | no | `50` | Maximum candidate runs returned after filtering. |
+| `workflows` | no | `` | Comma-separated workflow filters (name, filename, or workflow id). Empty scans all workflows. |
+| `events` | no | `push,pull_request,workflow_dispatch,schedule` | Comma-separated event filters. Empty means all events. |
+| `conclusions` | no | `success` | Comma-separated conclusion filters. Empty means all conclusions. |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `run-count` | Number of selected candidate runs. |
+| `runs-json` | JSON array of run objects (`id`, `run_attempt`, `workflow_name`, `event`, `created_at`, `html_url`). |
+| `run-ids-json` | JSON array of selected run ids. |
+| `since` | Effective timestamp lower bound used. |
+| `latest-created-at` | Latest selected `created_at` (or `since` when none selected). |
+| `cursor-json` | Cursor payload to persist to `bench-data` for the next ingest run. |
+
+## Nightly Ingest Example
+
+```yaml
+name: Benchkit Ingest
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+permissions:
+  actions: read
+  contents: write
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      runs: ${{ steps.discover.outputs.runs-json }}
+      cursor: ${{ steps.discover.outputs.cursor-json }}
+      run-count: ${{ steps.discover.outputs.run-count }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: discover
+        uses: strawgate/o11ykit/octo11y/actions/ingest-ci-runs@main-dist
+        with:
+          github-token: ${{ github.token }}
+          lookback-hours: 72
+          max-runs: 40
+
+  parse:
+    needs: discover
+    if: ${{ needs.discover.outputs.run-count != '0' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        run: ${{ fromJson(needs.discover.outputs.runs) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse source run logs
+        uses: strawgate/o11ykit/actions/parse-results@main-dist
+        with:
+          mode: auto
+          format: auto
+          github-token: ${{ github.token }}
+          source-run-id: ${{ matrix.run.id }}
+          source-run-attempt: ${{ matrix.run.run_attempt }}
+          run-id: ${{ matrix.run.id }}-${{ matrix.run.run_attempt }}
+
+  aggregate:
+    needs: [discover, parse]
+    if: ${{ always() && needs.discover.result == 'success' && (needs.parse.result == 'success' || needs.parse.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: strawgate/o11ykit/octo11y/actions/aggregate@main-dist
+        with:
+          github-token: ${{ github.token }}
+```
+
+Use the `workflows` input when you want to scope ingest to specific workflows
+instead of scanning all completed runs.

--- a/octo11y/actions/ingest-ci-runs/README.md
+++ b/octo11y/actions/ingest-ci-runs/README.md
@@ -14,8 +14,6 @@ This action does discovery only. Pair it with
 
 - Scans all workflows by default.
 - Uses `data/state/benchkit-ci-run-ingest.cursor.json` on the data branch as a cursor.
-- Automatically reads the legacy cursor path (`data/state/ingest-cursor.json`) if
-  present, then migrates writes to the specific default path.
 - If no cursor (and no explicit `since`) exists, applies a bounded first-run
   lookback window (`lookback-hours`, default `72`).
 - Supports optional workflow/event/conclusion filters.

--- a/octo11y/actions/ingest-ci-runs/action.yml
+++ b/octo11y/actions/ingest-ci-runs/action.yml
@@ -17,7 +17,7 @@ inputs:
   cursor-path:
     description: "Path to cursor JSON on data branch."
     required: false
-    default: "data/state/ingest-cursor.json"
+    default: "data/state/benchkit-ci-run-ingest.cursor.json"
   commit-cursor:
     description: "When true, writes cursor-json to cursor-path on data-branch."
     required: false
@@ -58,7 +58,7 @@ outputs:
   latest-created-at:
     description: "Latest created_at among discovered runs (or since when none found)."
   cursor-json:
-    description: "Cursor JSON payload to persist on bench-data branch."
+    description: "CI run ingest cursor JSON payload to persist on bench-data branch."
 
 runs:
   using: node24

--- a/octo11y/actions/ingest-ci-runs/action.yml
+++ b/octo11y/actions/ingest-ci-runs/action.yml
@@ -1,0 +1,65 @@
+name: "Benchkit Ingest CI Runs"
+description: "Discover completed workflow runs to ingest via parse-results."
+
+inputs:
+  github-token:
+    description: "GitHub token with actions:read and contents:write (when commit-cursor=true)."
+    required: true
+    default: ${{ github.token }}
+  repository:
+    description: "owner/repo to inspect. Defaults to current repository."
+    required: false
+    default: ${{ github.repository }}
+  data-branch:
+    description: "Data branch where ingest cursor is stored."
+    required: false
+    default: "bench-data"
+  cursor-path:
+    description: "Path to cursor JSON on data branch."
+    required: false
+    default: "data/state/ingest-cursor.json"
+  commit-cursor:
+    description: "When true, writes cursor-json to cursor-path on data-branch."
+    required: false
+    default: "true"
+  since:
+    description: "Optional ISO timestamp lower bound for workflow run created_at."
+    required: false
+  lookback-hours:
+    description: "Fallback lookback window when no cursor exists and since is empty."
+    required: false
+    default: "72"
+  max-runs:
+    description: "Maximum number of runs to return."
+    required: false
+    default: "50"
+  workflows:
+    description: "Optional comma-separated workflow filter (name, path basename, workflow id). Empty means all workflows."
+    required: false
+    default: ""
+  events:
+    description: "Comma-separated event filter. Empty means all events."
+    required: false
+    default: "push,pull_request,workflow_dispatch,schedule"
+  conclusions:
+    description: "Comma-separated run conclusion filter. Empty means all conclusions."
+    required: false
+    default: "success"
+
+outputs:
+  run-count:
+    description: "Number of candidate runs discovered."
+  runs-json:
+    description: "JSON array of run objects: id, run_attempt, workflow_name, event, created_at, html_url."
+  run-ids-json:
+    description: "JSON array of run ids (strings)."
+  since:
+    description: "Effective since timestamp used for discovery."
+  latest-created-at:
+    description: "Latest created_at among discovered runs (or since when none found)."
+  cursor-json:
+    description: "Cursor JSON payload to persist on bench-data branch."
+
+runs:
+  using: node24
+  main: dist/index.js

--- a/octo11y/actions/ingest-ci-runs/package.json
+++ b/octo11y/actions/ingest-ci-runs/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@benchkit/ingest-ci-runs",
+  "version": "0.1.0",
+  "private": true,
+  "description": "GitHub Action: discover candidate workflow runs for benchmark ingestion.",
+  "scripts": {
+    "build": "tsc && ncc build lib/main.js -o dist -s",
+    "test": "tsc && node --test lib/*.test.js",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@actions/core": "^1.11.0",
+    "@actions/exec": "^1.1.1",
+    "@benchkit/actions-common": "*",
+    "@octo11y/core": "*"
+  }
+}

--- a/octo11y/actions/ingest-ci-runs/src/ingest.test.ts
+++ b/octo11y/actions/ingest-ci-runs/src/ingest.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { filterRuns, resolveSince, type WorkflowRun } from "./ingest.js";
+
+describe("resolveSince", () => {
+  it("prefers explicit since", () => {
+    const resolved = resolveSince({
+      inputSince: "2026-01-02T03:04:05.000Z",
+      cursorSince: "2026-01-01T00:00:00.000Z",
+      lookbackHours: 72,
+      now: new Date("2026-04-01T00:00:00.000Z"),
+    });
+    assert.equal(resolved, "2026-01-02T03:04:05.000Z");
+  });
+
+  it("falls back to cursor", () => {
+    const resolved = resolveSince({
+      cursorSince: "2026-01-01T00:00:00.000Z",
+      lookbackHours: 72,
+      now: new Date("2026-04-01T00:00:00.000Z"),
+    });
+    assert.equal(resolved, "2026-01-01T00:00:00.000Z");
+  });
+
+  it("uses bounded lookback when no input or cursor", () => {
+    const now = new Date("2026-04-01T00:00:00.000Z");
+    const resolved = resolveSince({ lookbackHours: 24, now });
+    assert.equal(resolved, "2026-03-31T00:00:00.000Z");
+  });
+
+  it("ignores invalid cursor values and falls back to lookback", () => {
+    const now = new Date("2026-04-01T00:00:00.000Z");
+    const resolved = resolveSince({
+      cursorSince: "not-a-date",
+      lookbackHours: 12,
+      now,
+    });
+    assert.equal(resolved, "2026-03-31T12:00:00.000Z");
+  });
+});
+
+describe("filterRuns", () => {
+  const runs: WorkflowRun[] = [
+    {
+      id: 101,
+      run_attempt: 1,
+      name: "CI",
+      path: ".github/workflows/ci.yml",
+      workflow_id: 7,
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+      created_at: "2026-04-01T02:00:00.000Z",
+      html_url: "https://example/101",
+    },
+    {
+      id: 102,
+      run_attempt: 1,
+      name: "Pages",
+      path: ".github/workflows/pages.yml",
+      workflow_id: 8,
+      event: "schedule",
+      status: "completed",
+      conclusion: "failure",
+      created_at: "2026-04-01T03:00:00.000Z",
+      html_url: "https://example/102",
+    },
+  ];
+
+  it("includes all workflows when workflow filter is empty", () => {
+    const selected = filterRuns(runs, {
+      workflows: new Set(),
+      events: new Set(["push", "schedule"]),
+      conclusions: new Set(["success", "failure"]),
+    });
+    assert.equal(selected.length, 2);
+  });
+
+  it("filters by conclusion and workflow name", () => {
+    const selected = filterRuns(runs, {
+      workflows: new Set(["ci"]),
+      events: new Set(["push", "schedule"]),
+      conclusions: new Set(["success"]),
+    });
+    assert.equal(selected.length, 1);
+    assert.equal(selected[0]?.id, "101");
+  });
+});

--- a/octo11y/actions/ingest-ci-runs/src/ingest.ts
+++ b/octo11y/actions/ingest-ci-runs/src/ingest.ts
@@ -1,0 +1,336 @@
+import * as core from "@actions/core";
+import * as exec from "@actions/exec";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  checkoutDataBranch,
+  configureGit,
+  pushWithRetry,
+} from "@benchkit/actions-common";
+import { DEFAULT_PUSH_RETRY_COUNT } from "@octo11y/core";
+
+const GITHUB_API_VERSION = "2022-11-28";
+
+export interface WorkflowRun {
+  readonly id: number;
+  readonly run_attempt: number;
+  readonly name?: string;
+  readonly path?: string;
+  readonly workflow_id?: number;
+  readonly event?: string;
+  readonly status?: string;
+  readonly conclusion?: string | null;
+  readonly created_at?: string;
+  readonly html_url?: string;
+}
+
+export interface CursorFile {
+  readonly latestCreatedAt?: string;
+  readonly updatedAt?: string;
+  readonly source?: string;
+}
+
+export interface CandidateRun {
+  readonly id: string;
+  readonly run_attempt: string;
+  readonly workflow_name: string;
+  readonly event: string;
+  readonly created_at: string;
+  readonly html_url: string;
+}
+
+interface ListRunsResponse {
+  readonly workflow_runs?: WorkflowRun[];
+}
+
+function parseCsvSet(input: string): Set<string> {
+  return new Set(
+    input
+      .split(",")
+      .map((part) => part.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+function isValidIso(iso: string): boolean {
+  return Number.isFinite(Date.parse(iso));
+}
+
+function normalizeCursorPath(cursorPath: string): string {
+  if (!cursorPath.trim()) {
+    throw new Error("cursor-path must not be empty.");
+  }
+  if (path.isAbsolute(cursorPath)) {
+    throw new Error("cursor-path must be relative to the data branch root.");
+  }
+  const normalized = path.normalize(cursorPath).replace(/\\/g, "/");
+  if (normalized.startsWith("../") || normalized.includes("/../")) {
+    throw new Error(`cursor-path must stay within the repository root: ${cursorPath}`);
+  }
+  return normalized;
+}
+
+export function resolveSince(options: {
+  readonly inputSince?: string;
+  readonly cursorSince?: string;
+  readonly now?: Date;
+  readonly lookbackHours: number;
+}): string {
+  if (options.inputSince && isValidIso(options.inputSince)) return options.inputSince;
+  if (options.cursorSince && isValidIso(options.cursorSince)) return options.cursorSince;
+  const now = options.now ?? new Date();
+  const fallback = new Date(now.getTime() - options.lookbackHours * 60 * 60 * 1000);
+  return fallback.toISOString();
+}
+
+function getHeaders(token: string): Record<string, string> {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": GITHUB_API_VERSION,
+  };
+}
+
+async function fetchJson<T>(url: string, token: string): Promise<T> {
+  const res = await fetch(url, { headers: getHeaders(token) });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GitHub API ${res.status} for ${url}: ${body.slice(0, 300)}`);
+  }
+  return (await res.json()) as T;
+}
+
+export async function readCursorFile(options: {
+  readonly token: string;
+  readonly repository: string;
+  readonly dataBranch: string;
+  readonly cursorPath: string;
+  readonly apiBase?: string;
+}): Promise<CursorFile | undefined> {
+  const apiBase = options.apiBase ?? process.env.GITHUB_API_URL ?? "https://api.github.com";
+  const url = `${apiBase}/repos/${options.repository}/contents/${options.cursorPath}?ref=${encodeURIComponent(options.dataBranch)}`;
+  const res = await fetch(url, { headers: getHeaders(options.token) });
+
+  if (res.status === 404) return undefined;
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Failed to read cursor file (${res.status}): ${body.slice(0, 300)}`);
+  }
+
+  const payload = (await res.json()) as { content?: string; encoding?: string };
+  if (!payload.content || payload.encoding !== "base64") return undefined;
+  const raw = Buffer.from(payload.content, "base64").toString("utf-8");
+  const parsed = JSON.parse(raw) as CursorFile;
+  return parsed;
+}
+
+function workflowPathBasename(run: WorkflowRun): string {
+  if (!run.path) return "";
+  const trimmed = run.path.split("/").pop() ?? "";
+  return trimmed.toLowerCase();
+}
+
+export function filterRuns(
+  runs: readonly WorkflowRun[],
+  options: {
+    readonly workflows: Set<string>;
+    readonly events: Set<string>;
+    readonly conclusions: Set<string>;
+  },
+): CandidateRun[] {
+  const out: CandidateRun[] = [];
+  for (const run of runs) {
+    const createdAt = run.created_at;
+    if (!createdAt || !isValidIso(createdAt)) continue;
+
+    const event = (run.event ?? "").toLowerCase();
+    if (options.events.size > 0 && !options.events.has(event)) continue;
+
+    const conclusion = (run.conclusion ?? "").toLowerCase();
+    if (options.conclusions.size > 0 && !options.conclusions.has(conclusion)) continue;
+
+    if (options.workflows.size > 0) {
+      const candidates = [
+        (run.name ?? "").toLowerCase(),
+        workflowPathBasename(run),
+        String(run.workflow_id ?? "").toLowerCase(),
+      ];
+      if (!candidates.some((c) => c && options.workflows.has(c))) continue;
+    }
+
+    out.push({
+      id: String(run.id),
+      run_attempt: String(run.run_attempt || 1),
+      workflow_name: run.name ?? "unknown-workflow",
+      event: run.event ?? "unknown",
+      created_at: createdAt,
+      html_url: run.html_url ?? "",
+    });
+  }
+  return out;
+}
+
+export async function listWorkflowRuns(options: {
+  readonly token: string;
+  readonly repository: string;
+  readonly since: string;
+  readonly maxRuns: number;
+  readonly workflows: Set<string>;
+  readonly events: Set<string>;
+  readonly conclusions: Set<string>;
+  readonly apiBase?: string;
+}): Promise<CandidateRun[]> {
+  const apiBase = options.apiBase ?? process.env.GITHUB_API_URL ?? "https://api.github.com";
+  const selected: CandidateRun[] = [];
+
+  for (let page = 1; page <= 10; page += 1) {
+    const url = new URL(`${apiBase}/repos/${options.repository}/actions/runs`);
+    url.searchParams.set("per_page", "100");
+    url.searchParams.set("page", String(page));
+    url.searchParams.set("status", "completed");
+    url.searchParams.set("created", `>=${options.since}`);
+
+    const payload = await fetchJson<ListRunsResponse>(url.toString(), options.token);
+    const runs = payload.workflow_runs ?? [];
+    if (runs.length === 0) break;
+
+    const filtered = filterRuns(runs, {
+      workflows: options.workflows,
+      events: options.events,
+      conclusions: options.conclusions,
+    });
+    selected.push(...filtered);
+
+    if (selected.length >= options.maxRuns) break;
+  }
+
+  selected.sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
+  if (selected.length > options.maxRuns) {
+    return selected.slice(selected.length - options.maxRuns);
+  }
+  return selected;
+}
+
+export async function runIngestDiscovery(): Promise<void> {
+  const token = core.getInput("github-token", { required: true });
+  const repository = core.getInput("repository") || process.env.GITHUB_REPOSITORY || "";
+  if (!repository) {
+    throw new Error("repository input is required when GITHUB_REPOSITORY is not set.");
+  }
+
+  const dataBranch = core.getInput("data-branch") || "bench-data";
+  const cursorPath = normalizeCursorPath(
+    core.getInput("cursor-path") || "data/state/ingest-cursor.json",
+  );
+  const commitCursor = core.getBooleanInput("commit-cursor");
+
+  const lookbackHours = Number.parseInt(core.getInput("lookback-hours") || "72", 10);
+  if (!Number.isFinite(lookbackHours) || lookbackHours < 1 || lookbackHours > 24 * 30) {
+    throw new Error(`lookback-hours must be between 1 and ${24 * 30}`);
+  }
+
+  const maxRuns = Number.parseInt(core.getInput("max-runs") || "50", 10);
+  if (!Number.isFinite(maxRuns) || maxRuns < 1 || maxRuns > 500) {
+    throw new Error("max-runs must be between 1 and 500");
+  }
+
+  const workflows = parseCsvSet(core.getInput("workflows") || "");
+  const events = parseCsvSet(core.getInput("events") || "");
+  const conclusions = parseCsvSet(core.getInput("conclusions") || "");
+
+  const inputSince = core.getInput("since") || undefined;
+  if (inputSince && !isValidIso(inputSince)) {
+    throw new Error(`since must be a valid ISO timestamp, received "${inputSince}"`);
+  }
+
+  let cursor: CursorFile | undefined;
+  try {
+    cursor = await readCursorFile({ token, repository, dataBranch, cursorPath });
+  } catch (error) {
+    core.warning(
+      `Could not read ingest cursor at ${dataBranch}:${cursorPath}; using lookback fallback. ` +
+      `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const since = resolveSince({
+    inputSince,
+    cursorSince: cursor?.latestCreatedAt,
+    lookbackHours,
+  });
+
+  const runs = await listWorkflowRuns({
+    token,
+    repository,
+    since,
+    maxRuns,
+    workflows,
+    events,
+    conclusions,
+  });
+
+  const latestCreatedAt = runs.length > 0
+    ? runs[runs.length - 1]?.created_at ?? since
+    : since;
+
+  const cursorJson = JSON.stringify(
+    {
+      latestCreatedAt,
+      updatedAt: new Date().toISOString(),
+      source: "benchkit-ingest-ci-runs",
+    },
+    null,
+    2,
+  );
+
+  if (!cursor?.latestCreatedAt && !inputSince) {
+    core.info(
+      `No explicit since/cursor found. Using bounded first-run lookback: ${lookbackHours}h (${since}).`,
+    );
+  }
+  core.info(`Ingest discovery since ${since}: selected ${runs.length} run(s).`);
+
+  core.setOutput("run-count", String(runs.length));
+  core.setOutput("runs-json", JSON.stringify(runs));
+  core.setOutput("run-ids-json", JSON.stringify(runs.map((run) => run.id)));
+  core.setOutput("since", since);
+  core.setOutput("latest-created-at", latestCreatedAt);
+  core.setOutput("cursor-json", cursorJson);
+
+  if (commitCursor) {
+    await configureGit(token);
+    const worktree = await checkoutDataBranch(dataBranch, "benchkit-ingest-ci-runs");
+    try {
+      const outPath = path.join(worktree, cursorPath);
+      fs.mkdirSync(path.dirname(outPath), { recursive: true });
+      fs.writeFileSync(outPath, `${cursorJson}\n`);
+
+      await exec.exec("git", ["-C", worktree, "add", cursorPath]);
+      const commitExit = await exec.exec(
+        "git",
+        ["-C", worktree, "commit", "-m", `bench: update ingest cursor (${latestCreatedAt})`],
+        { ignoreReturnCode: true },
+      );
+
+      if (commitExit === 0) {
+        await pushWithRetry(worktree, dataBranch, DEFAULT_PUSH_RETRY_COUNT);
+        core.info(`Updated ingest cursor at ${dataBranch}:${cursorPath}`);
+      } else {
+        core.info(`Ingest cursor unchanged at ${dataBranch}:${cursorPath}`);
+      }
+    } finally {
+      await exec.exec("git", ["worktree", "remove", worktree, "--force"], {
+        ignoreReturnCode: true,
+      });
+    }
+  } else {
+    core.info("commit-cursor=false; skipping cursor write.");
+  }
+
+  await core.summary
+    .addHeading("Benchkit Ingest Discovery")
+    .addRaw(`Repository: \`${repository}\`\n`, true)
+    .addRaw(`Since: \`${since}\`\n`, true)
+    .addRaw(`Selected runs: **${runs.length}**\n`, true)
+    .write();
+}

--- a/octo11y/actions/ingest-ci-runs/src/ingest.ts
+++ b/octo11y/actions/ingest-ci-runs/src/ingest.ts
@@ -11,7 +11,6 @@ import { DEFAULT_PUSH_RETRY_COUNT } from "@octo11y/core";
 
 const GITHUB_API_VERSION = "2022-11-28";
 const DEFAULT_CURSOR_PATH = "data/state/benchkit-ci-run-ingest.cursor.json";
-const LEGACY_CURSOR_PATH = "data/state/ingest-cursor.json";
 
 export interface WorkflowRun {
   readonly id: number;
@@ -27,12 +26,11 @@ export interface WorkflowRun {
 }
 
 export interface CursorFile {
-  readonly latestWorkflowRunCreatedAt?: string;
-  // Legacy field retained for backward compatibility with earlier cursor files.
-  readonly latestCreatedAt?: string;
-  readonly updatedAt?: string;
-  readonly sourceAction?: string;
-  readonly source?: string;
+  readonly cursorKind: "benchkit.ci-run-ingest";
+  readonly cursorVersion: number;
+  readonly latestWorkflowRunCreatedAt: string;
+  readonly updatedAt: string;
+  readonly sourceAction: "benchkit.ingest-ci-runs";
 }
 
 export interface CandidateRun {
@@ -125,8 +123,26 @@ export async function readCursorFile(options: {
   const payload = (await res.json()) as { content?: string; encoding?: string };
   if (!payload.content || payload.encoding !== "base64") return undefined;
   const raw = Buffer.from(payload.content, "base64").toString("utf-8");
-  const parsed = JSON.parse(raw) as CursorFile;
-  return parsed;
+  const parsed = JSON.parse(raw) as Partial<CursorFile>;
+  if (parsed.cursorKind !== "benchkit.ci-run-ingest") {
+    throw new Error(`Invalid cursorKind in cursor file: ${String(parsed.cursorKind)}`);
+  }
+  if (!Number.isInteger(parsed.cursorVersion) || (parsed.cursorVersion ?? 0) < 1) {
+    throw new Error(`Invalid cursorVersion in cursor file: ${String(parsed.cursorVersion)}`);
+  }
+  if (!parsed.latestWorkflowRunCreatedAt || !isValidIso(parsed.latestWorkflowRunCreatedAt)) {
+    throw new Error(
+      `Invalid latestWorkflowRunCreatedAt in cursor file: ${String(parsed.latestWorkflowRunCreatedAt)}`,
+    );
+  }
+  if (!parsed.updatedAt || !isValidIso(parsed.updatedAt)) {
+    throw new Error(`Invalid updatedAt in cursor file: ${String(parsed.updatedAt)}`);
+  }
+  if (parsed.sourceAction !== "benchkit.ingest-ci-runs") {
+    throw new Error(`Invalid sourceAction in cursor file: ${String(parsed.sourceAction)}`);
+  }
+  const parsedTyped = parsed as CursorFile;
+  return parsedTyped;
 }
 
 function workflowPathBasename(run: WorkflowRun): string {
@@ -251,20 +267,6 @@ export async function runIngestDiscovery(): Promise<void> {
   let cursor: CursorFile | undefined;
   try {
     cursor = await readCursorFile({ token, repository, dataBranch, cursorPath });
-    if (!cursor && cursorPath === DEFAULT_CURSOR_PATH) {
-      cursor = await readCursorFile({
-        token,
-        repository,
-        dataBranch,
-        cursorPath: LEGACY_CURSOR_PATH,
-      });
-      if (cursor) {
-        core.info(
-          `Found legacy ingest cursor at ${dataBranch}:${LEGACY_CURSOR_PATH}; ` +
-          `it will be migrated to ${cursorPath}.`,
-        );
-      }
-    }
   } catch (error) {
     core.warning(
       `Could not read ingest cursor at ${dataBranch}:${cursorPath}; using lookback fallback. ` +
@@ -272,7 +274,7 @@ export async function runIngestDiscovery(): Promise<void> {
     );
   }
 
-  const cursorSince = cursor?.latestWorkflowRunCreatedAt ?? cursor?.latestCreatedAt;
+  const cursorSince = cursor?.latestWorkflowRunCreatedAt;
   const since = resolveSince({
     inputSince,
     cursorSince,
@@ -298,8 +300,6 @@ export async function runIngestDiscovery(): Promise<void> {
       cursorKind: "benchkit.ci-run-ingest",
       cursorVersion: 1,
       latestWorkflowRunCreatedAt: latestCreatedAt,
-      // Keep writing the legacy key so older readers continue to work.
-      latestCreatedAt,
       updatedAt: new Date().toISOString(),
       sourceAction: "benchkit.ingest-ci-runs",
     },

--- a/octo11y/actions/ingest-ci-runs/src/ingest.ts
+++ b/octo11y/actions/ingest-ci-runs/src/ingest.ts
@@ -10,6 +10,8 @@ import {
 import { DEFAULT_PUSH_RETRY_COUNT } from "@octo11y/core";
 
 const GITHUB_API_VERSION = "2022-11-28";
+const DEFAULT_CURSOR_PATH = "data/state/benchkit-ci-run-ingest.cursor.json";
+const LEGACY_CURSOR_PATH = "data/state/ingest-cursor.json";
 
 export interface WorkflowRun {
   readonly id: number;
@@ -25,8 +27,11 @@ export interface WorkflowRun {
 }
 
 export interface CursorFile {
+  readonly latestWorkflowRunCreatedAt?: string;
+  // Legacy field retained for backward compatibility with earlier cursor files.
   readonly latestCreatedAt?: string;
   readonly updatedAt?: string;
+  readonly sourceAction?: string;
   readonly source?: string;
 }
 
@@ -220,7 +225,7 @@ export async function runIngestDiscovery(): Promise<void> {
 
   const dataBranch = core.getInput("data-branch") || "bench-data";
   const cursorPath = normalizeCursorPath(
-    core.getInput("cursor-path") || "data/state/ingest-cursor.json",
+    core.getInput("cursor-path") || DEFAULT_CURSOR_PATH,
   );
   const commitCursor = core.getBooleanInput("commit-cursor");
 
@@ -246,6 +251,20 @@ export async function runIngestDiscovery(): Promise<void> {
   let cursor: CursorFile | undefined;
   try {
     cursor = await readCursorFile({ token, repository, dataBranch, cursorPath });
+    if (!cursor && cursorPath === DEFAULT_CURSOR_PATH) {
+      cursor = await readCursorFile({
+        token,
+        repository,
+        dataBranch,
+        cursorPath: LEGACY_CURSOR_PATH,
+      });
+      if (cursor) {
+        core.info(
+          `Found legacy ingest cursor at ${dataBranch}:${LEGACY_CURSOR_PATH}; ` +
+          `it will be migrated to ${cursorPath}.`,
+        );
+      }
+    }
   } catch (error) {
     core.warning(
       `Could not read ingest cursor at ${dataBranch}:${cursorPath}; using lookback fallback. ` +
@@ -253,9 +272,10 @@ export async function runIngestDiscovery(): Promise<void> {
     );
   }
 
+  const cursorSince = cursor?.latestWorkflowRunCreatedAt ?? cursor?.latestCreatedAt;
   const since = resolveSince({
     inputSince,
-    cursorSince: cursor?.latestCreatedAt,
+    cursorSince,
     lookbackHours,
   });
 
@@ -275,15 +295,19 @@ export async function runIngestDiscovery(): Promise<void> {
 
   const cursorJson = JSON.stringify(
     {
+      cursorKind: "benchkit.ci-run-ingest",
+      cursorVersion: 1,
+      latestWorkflowRunCreatedAt: latestCreatedAt,
+      // Keep writing the legacy key so older readers continue to work.
       latestCreatedAt,
       updatedAt: new Date().toISOString(),
-      source: "benchkit-ingest-ci-runs",
+      sourceAction: "benchkit.ingest-ci-runs",
     },
     null,
     2,
   );
 
-  if (!cursor?.latestCreatedAt && !inputSince) {
+  if (!cursorSince && !inputSince) {
     core.info(
       `No explicit since/cursor found. Using bounded first-run lookback: ${lookbackHours}h (${since}).`,
     );
@@ -299,7 +323,7 @@ export async function runIngestDiscovery(): Promise<void> {
 
   if (commitCursor) {
     await configureGit(token);
-    const worktree = await checkoutDataBranch(dataBranch, "benchkit-ingest-ci-runs");
+    const worktree = await checkoutDataBranch(dataBranch, "benchkit-ci-run-ingest");
     try {
       const outPath = path.join(worktree, cursorPath);
       fs.mkdirSync(path.dirname(outPath), { recursive: true });
@@ -308,7 +332,7 @@ export async function runIngestDiscovery(): Promise<void> {
       await exec.exec("git", ["-C", worktree, "add", cursorPath]);
       const commitExit = await exec.exec(
         "git",
-        ["-C", worktree, "commit", "-m", `bench: update ingest cursor (${latestCreatedAt})`],
+        ["-C", worktree, "commit", "-m", `bench: update ci-run-ingest cursor (${latestCreatedAt})`],
         { ignoreReturnCode: true },
       );
 

--- a/octo11y/actions/ingest-ci-runs/src/main.ts
+++ b/octo11y/actions/ingest-ci-runs/src/main.ts
@@ -1,0 +1,6 @@
+import * as core from "@actions/core";
+import { runIngestDiscovery } from "./ingest.js";
+
+runIngestDiscovery().catch((error: unknown) => {
+  core.setFailed(error instanceof Error ? error.message : String(error));
+});

--- a/octo11y/actions/ingest-ci-runs/tsconfig.json
+++ b/octo11y/actions/ingest-ci-runs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/octo11y/actions/monitor/README.md
+++ b/octo11y/actions/monitor/README.md
@@ -5,6 +5,9 @@ System and custom metrics collection via the OpenTelemetry Collector
 background process, exposes OTLP receivers for your benchmark code, and then
 stops and flushes telemetry automatically in the action post step.
 
+Use a published dist ref (`@main-dist` or a version tag). Do not use `@main`
+for JS actions, because `@main` does not include compiled action bundles.
+
 ## What it does
 
 - collects host metrics through the collector's `hostmetrics` receiver

--- a/octo11y/actions/parse-results/README.md
+++ b/octo11y/actions/parse-results/README.md
@@ -3,6 +3,9 @@
 Parse benchmark output from either GitHub Actions logs or explicit files, then
 stash the normalized OTLP JSON by default.
 
+Use a published dist ref (`@main-dist` or a version tag). Do not use `@main`
+for JS actions, because `@main` does not include compiled action bundles.
+
 ## Modes
 
 - `mode=auto` (default): downloads the current workflow run attempt logs through

--- a/octo11y/docs/migration-beats-bench.md
+++ b/octo11y/docs/migration-beats-bench.md
@@ -34,7 +34,7 @@ The `beats-bench summarize` command should be updated to emit OTLP JSON.
 - **Aggregate**: Replaces the custom index-building logic. It rebuilds `index.json` and time-series files.
 
 ### 3. Replace Custom PR Comparison
-Instead of custom inline arithmetic in the Python runner for PR comments, use `actions/compare@main`. This action:
+Instead of custom inline arithmetic in the Python runner for PR comments, use `actions/compare@main-dist`. This action:
 - Generates a markdown comparison table.
 - Posts a PR comment.
 - Fails the CI if regressions are detected (optional).

--- a/octo11y/docs/recipes.md
+++ b/octo11y/docs/recipes.md
@@ -115,6 +115,63 @@ jobs:
 These recipes use `emit-metric` to track any numeric value over time.
 They require `actions/monitor` to provide an OTLP collector endpoint.
 
+### Scheduled ingest from existing CI runs
+
+Backfill and continuously ingest benchmark output from completed workflow runs.
+This scans all workflows by default, then only new runs after the first pass.
+
+```yaml
+name: Ingest benchmark runs
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+permissions:
+  actions: read
+  contents: write
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      runs: ${{ steps.discover.outputs.runs-json }}
+      run-count: ${{ steps.discover.outputs.run-count }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: discover
+        uses: strawgate/o11ykit/octo11y/actions/ingest-ci-runs@main-dist
+        with:
+          github-token: ${{ github.token }}
+          lookback-hours: 72
+          max-runs: 40
+
+  parse:
+    needs: discover
+    if: ${{ needs.discover.outputs.run-count != '0' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        run: ${{ fromJson(needs.discover.outputs.runs) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: strawgate/o11ykit/actions/parse-results@main-dist
+        with:
+          mode: auto
+          format: auto
+          github-token: ${{ github.token }}
+          source-run-id: ${{ matrix.run.id }}
+          source-run-attempt: ${{ matrix.run.run_attempt }}
+          run-id: ${{ matrix.run.id }}-${{ matrix.run.run_attempt }}
+
+  aggregate:
+    needs: [discover, parse]
+    if: ${{ always() && needs.discover.result == 'success' && (needs.parse.result == 'success' || needs.parse.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: strawgate/o11ykit/octo11y/actions/aggregate@main-dist
+```
+
 ### Bundle size
 
 Track JavaScript bundle size and fail on bloat:

--- a/octo11y/docs/reference/actions.md
+++ b/octo11y/docs/reference/actions.md
@@ -17,6 +17,7 @@ A common end-to-end setup looks like this:
 | Action | Use it for | Produces | Reference |
 |---|---|---|---|
 | `actions/parse-results` | Parse benchmark logs/files and persist one raw run | `data/runs/{run-id}.json` | [`../../actions/parse-results/README.md`](../../actions/parse-results/README.md) |
+| `actions/ingest-ci-runs` | Discover completed workflow runs for scheduled ingestion | `runs-json`, `cursor-json` outputs | [`../../actions/ingest-ci-runs/README.md`](../../actions/ingest-ci-runs/README.md) |
 | `actions/stash` | Parse benchmark files and persist one raw run | `data/runs/{run-id}.json` | [`../../actions/stash/README.md`](../../actions/stash/README.md) |
 | `actions/aggregate` | Rebuild derived indexes, series, run views, and badges | `data/index.json`, `data/series/*`, `data/index/*`, `data/views/runs/*`, `data/badges/*` | [`../../actions/aggregate/README.md`](../../actions/aggregate/README.md) |
 | `actions/compare` | Compare current results to recent baselines | PR comment, step summary, regression status | [`../../actions/compare/README.md`](../../actions/compare/README.md) |
@@ -46,6 +47,17 @@ Best for:
 - no-file workflows where benchmark output is only in step logs
 - file-based workflows that still want one canonical parse+stash step
 - gradual migration from explicit stash-only pipelines
+
+### Ingest CI Runs
+
+Start here when you want a scheduled workflow that scans historical CI runs and
+backfills benchmark data automatically.
+
+Best for:
+
+- scanning all workflows by default, with optional workflow filters
+- first-time setup with bounded lookback instead of unbounded history scans
+- incremental ingest using a cursor persisted on the `bench-data` branch
 
 ### Aggregate
 

--- a/octo11y/package-lock.json
+++ b/octo11y/package-lock.json
@@ -61,6 +61,16 @@
         "@benchkit/format": "*"
       }
     },
+    "actions/ingest-ci-runs": {
+      "name": "@benchkit/ingest-ci-runs",
+      "version": "0.1.0",
+      "dependencies": {
+        "@actions/core": "^1.11.0",
+        "@actions/exec": "^1.1.1",
+        "@benchkit/actions-common": "*",
+        "@octo11y/core": "*"
+      }
+    },
     "actions/monitor": {
       "name": "@benchkit/monitor",
       "version": "0.2.0",
@@ -604,6 +614,10 @@
     },
     "node_modules/@benchkit/format": {
       "resolved": "packages/format",
+      "link": true
+    },
+    "node_modules/@benchkit/ingest-ci-runs": {
+      "resolved": "actions/ingest-ci-runs",
       "link": true
     },
     "node_modules/@benchkit/monitor": {
@@ -5170,7 +5184,7 @@
     },
     "packages/adapters": {
       "name": "@benchkit/adapters",
-      "version": "0.1.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@benchkit/format": "*",
@@ -5187,7 +5201,7 @@
     },
     "packages/chart": {
       "name": "@benchkit/chart",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@benchkit/format": "*",
@@ -5205,7 +5219,7 @@
     },
     "packages/core": {
       "name": "@octo11y/core",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT"
     },
     "packages/dashboard": {
@@ -5226,7 +5240,7 @@
     },
     "packages/format": {
       "name": "@benchkit/format",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@octo11y/core": "*"

--- a/octo11y/package.json
+++ b/octo11y/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "clean:artifacts": "rm -rf packages/*/dist actions/*/dist actions/*/lib",
-    "build": "npm run clean:artifacts && npm run build -w packages/core && npm run build -w packages/format && npm run build -w packages/adapters && npm run build -w packages/chart && npm run build -w packages/dashboard && npm run build -w actions/actions-common && npm run build -w actions/stash && npm run build -w actions/parse-results && npm run build -w actions/aggregate && npm run build -w actions/compare && npm run build -w actions/monitor && npm run build -w actions/emit-metric && npm run build -w actions/repo-stats",
+    "build": "npm run clean:artifacts && npm run build -w packages/core && npm run build -w packages/format && npm run build -w packages/adapters && npm run build -w packages/chart && npm run build -w packages/dashboard && npm run build -w actions/actions-common && npm run build -w actions/stash && npm run build -w actions/parse-results && npm run build -w actions/aggregate && npm run build -w actions/compare && npm run build -w actions/monitor && npm run build -w actions/emit-metric && npm run build -w actions/repo-stats && npm run build -w actions/ingest-ci-runs",
     "test": "npm run build && npm run test:workspaces",
     "test:workspaces": "npm run test --workspaces --if-present",
     "lint": "eslint . && npm run lint --workspaces --if-present",


### PR DESCRIPTION
## Summary
- add a new `octo11y/actions/ingest-ci-runs` action for scheduled CI run discovery
- default to scanning all completed workflows, with optional workflow/event/conclusion filters
- implement bounded first-run behavior (`lookback-hours`) and cursor continuation (`data/state/ingest-cursor.json`)
- persist cursor updates by default (`commit-cursor: true`) to avoid repeated backfills
- wire the new action into octo11y build/test/dist publishing
- add docs and recipe updates, plus explicit `@main-dist` guidance in action READMEs

## Validation
- `cd octo11y && npm run test`
- `cd /Users/billeaston/Documents/repos/o11ykit && npm run octo11y:lint`

## Notes
- This addresses the workflow-scan ergonomics and ref-guidance portions of #49.
- Parse-results strictness outputs and monitor noise profile changes are not part of this PR.
