### PR TITLE
fix: security hardening, correctness fixes, and robustness improvements

### DIFF
--- a/actions/parse-results/src/main.ts
+++ b/actions/parse-results/src/main.ts
@@ -70,6 +70,7 @@ async function run(): Promise<void> {
   const format = (core.getInput("format") || "auto") as Format;
   const dataBranch = core.getInput("data-branch") || "bench-data";
   const token = core.getInput("github-token");
+  if (token) core.setSecret(token);
   const resultsPattern = core.getInput("results");
   const monitorPath = core.getInput("monitor-results");
   const commitResults = core.getBooleanInput("commit-results");

--- a/actions/parse-results/src/stash.ts
+++ b/actions/parse-results/src/stash.ts
@@ -41,13 +41,18 @@ function pushWithRetry(worktree: string, branch: string, attempts = 3): void {
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
+/** Sanitize a runId for safe use as a filename (strip path separators and shell-unsafe chars). */
+function sanitizeRunId(raw: string): string {
+  return raw.replace(/[/\\:*?"<>|]/g, "_");
+}
+
 export function buildRunId(options: {
   readonly customRunId?: string;
   readonly githubRunId?: string;
   readonly githubRunAttempt?: string;
   readonly githubJob?: string;
 }): string {
-  if (options.customRunId) return options.customRunId;
+  if (options.customRunId) return sanitizeRunId(options.customRunId);
   const base = `${options.githubRunId ?? "local"}-${options.githubRunAttempt ?? "1"}`;
   if (!options.githubJob) return base;
   const sanitizedJob = options.githubJob

--- a/octo11y/actions/aggregate/src/main.ts
+++ b/octo11y/actions/aggregate/src/main.ts
@@ -35,6 +35,7 @@ interface AggregateOutputs {
 async function run(): Promise<void> {
   const dataBranch = core.getInput("data-branch") || DEFAULT_DATA_BRANCH;
   const token = core.getInput("github-token", { required: true });
+  core.setSecret(token);
   const maxRuns = parseInt(core.getInput("max-runs") || "0", 10);
   if (maxRuns < 0 || maxRuns > 10_000) {
     throw new Error(`max-runs must be between 0 and 10000, got ${maxRuns}`);
@@ -223,6 +224,9 @@ function writeAggregatedFiles(
   const dataDir = path.join(worktree, "data");
   fs.writeFileSync(path.join(dataDir, "index.json"), JSON.stringify(index, null, 2) + "\n");
 
+  /** Sanitize a name for safe use as a filename (strip path separators and shell-unsafe chars). */
+  const sanitizeName = (raw: string): string => raw.replace(/[/\\:*?"<>|]/g, "_");
+
   const seriesDir = path.join(dataDir, "series");
   fs.mkdirSync(seriesDir, { recursive: true });
 
@@ -233,7 +237,7 @@ function writeAggregatedFiles(
   fs.mkdirSync(seriesDir, { recursive: true });
 
   for (const [metricName, series] of seriesMap) {
-    const fileName = `${metricName}.json`;
+    const fileName = `${sanitizeName(metricName)}.json`;
     const filePath = path.join(seriesDir, fileName);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, JSON.stringify(series, null, 2) + "\n");
@@ -286,7 +290,7 @@ function writeAggregatedFiles(
 
     const badges = buildBadges(seriesMap);
     for (const [metric, badge] of badges) {
-      const fileName = `${metric}.json`;
+      const fileName = `${sanitizeName(metric)}.json`;
       const filePath = path.join(badgesDir, fileName);
       fs.mkdirSync(path.dirname(filePath), { recursive: true });
       fs.writeFileSync(filePath, JSON.stringify(badge, null, 2) + "\n");

--- a/octo11y/actions/compare/src/main.ts
+++ b/octo11y/actions/compare/src/main.ts
@@ -17,6 +17,7 @@ async function run(): Promise<void> {
   const failOnRegression = core.getBooleanInput("fail-on-regression");
   const commentOnPr = core.getBooleanInput("comment-on-pr");
   const token = core.getInput("github-token", { required: true });
+  core.setSecret(token);
 
   const globber = await glob.create(resultsPattern);
   const files = await globber.glob();
@@ -35,31 +36,33 @@ async function run(): Promise<void> {
     return;
   }
 
-  const runsDir = path.join(worktree, "data", "runs");
-  const { markdown, hasRegression } = runComparison({
-    files,
-    format,
-    runsDir,
-    baselineRuns,
-    threshold,
-    currentCommit: process.env.GITHUB_SHA,
-    currentRef: process.env.GITHUB_REF,
-  });
+  try {
+    const runsDir = path.join(worktree, "data", "runs");
+    const { markdown, hasRegression } = runComparison({
+      files,
+      format,
+      runsDir,
+      baselineRuns,
+      threshold,
+      currentCommit: process.env.GITHUB_SHA,
+      currentRef: process.env.GITHUB_REF,
+    });
 
-  await exec.exec("git", ["worktree", "remove", worktree, "--force"]);
+    core.setOutput("has-regression", String(hasRegression));
+    core.setOutput("summary", markdown);
+    await core.summary.addRaw(markdown, true).write();
 
-  core.setOutput("has-regression", String(hasRegression));
-  core.setOutput("summary", markdown);
-  await core.summary.addRaw(markdown, true).write();
+    if (commentOnPr && github.context.payload.pull_request) {
+      await postPrComment(token, markdown);
+    } else if (commentOnPr) {
+      core.info("Not a pull request event — skipping PR comment.");
+    }
 
-  if (commentOnPr && github.context.payload.pull_request) {
-    await postPrComment(token, markdown);
-  } else if (commentOnPr) {
-    core.info("Not a pull request event — skipping PR comment.");
-  }
-
-  if (failOnRegression && hasRegression) {
-    core.setFailed("Benchmark regression detected. See job summary for details.");
+    if (failOnRegression && hasRegression) {
+      core.setFailed("Benchmark regression detected. See job summary for details.");
+    }
+  } finally {
+    await exec.exec("git", ["worktree", "remove", worktree, "--force"], { ignoreReturnCode: true });
   }
 }
 
@@ -97,6 +100,7 @@ async function postPrComment(token: string, body: string): Promise<void> {
     owner,
     repo,
     issue_number: pullNumber,
+    per_page: 100,
   });
 
   const existing = comments.find((comment) => comment.body?.includes(marker));

--- a/octo11y/actions/monitor/src/otel-start.test.ts
+++ b/octo11y/actions/monitor/src/otel-start.test.ts
@@ -207,11 +207,8 @@ describe("validatePort", () => {
     );
   });
 
-  it("throws for port 0", () => {
-    assert.throws(
-      () => validatePort("otlp-grpc-port", "0"),
-      /Invalid port number for otlp-grpc-port: 0 is out of range/,
-    );
+  it("accepts port 0 (disable sentinel)", () => {
+    assert.equal(validatePort("otlp-grpc-port", "0"), 0);
   });
 
   it("throws for port above 65535", () => {
@@ -268,11 +265,8 @@ describe("validatePort — error paths", () => {
     );
   });
 
-  it("rejects port 0", () => {
-    assert.throws(
-      () => validatePort("otlp-http-port", "0"),
-      /out of range/,
-    );
+  it("accepts port 0 as disabled", () => {
+    assert.equal(validatePort("otlp-http-port", "0"), 0);
   });
 
   it("rejects port above 65535", () => {

--- a/octo11y/actions/monitor/src/otel-start.ts
+++ b/octo11y/actions/monitor/src/otel-start.ts
@@ -54,15 +54,16 @@ export function downloadUrl(version: string, os: string, arch: string, ext: stri
 
 /**
  * Parse and validate a port number input.
- * Throws a descriptive error if the value is not a valid integer in the range 1–65535.
+ * Throws a descriptive error if the value is not a valid integer in the range 0–65535.
+ * Port 0 means "disabled" — callers should check for 0 after validation.
  */
 export function validatePort(inputName: string, raw: string): number {
   const port = parseInt(raw, 10);
   if (isNaN(port)) {
     throw new Error(`Invalid port number for ${inputName}: expected a number, got '${raw}'`);
   }
-  if (port < 1 || port > 65535) {
-    throw new Error(`Invalid port number for ${inputName}: ${port} is out of range (1–65535)`);
+  if (port < 0 || port > 65535) {
+    throw new Error(`Invalid port number for ${inputName}: ${port} is out of range (0–65535)`);
   }
   return port;
 }

--- a/octo11y/actions/parse-results/src/main.ts
+++ b/octo11y/actions/parse-results/src/main.ts
@@ -49,6 +49,7 @@ async function run(): Promise<void> {
   const format = (core.getInput("format") || "auto") as Format;
   const dataBranch = core.getInput("data-branch") || DEFAULT_DATA_BRANCH;
   const token = core.getInput("github-token");
+  if (token) core.setSecret(token);
   const resultsPattern = core.getInput("results");
   const monitorPath = core.getInput("monitor-results");
   const writeSummary = core.getBooleanInput("summary");
@@ -113,19 +114,22 @@ async function run(): Promise<void> {
     }
     await configureGit(token);
     const worktree = await checkoutDataBranch(dataBranch, "benchkit-parse-results");
-    const resultPath = path.join(worktree, "data", "runs", runId, "benchmark.otlp.json");
-    if (fs.existsSync(resultPath)) {
-      throw new Error(
-        `Refusing to overwrite existing run document: data/runs/${runId}/benchmark.otlp.json already exists on '${dataBranch}'. `
-        + "run-id values must be unique per write.",
-      );
+    try {
+      const resultPath = path.join(worktree, "data", "runs", runId, "benchmark.otlp.json");
+      if (fs.existsSync(resultPath)) {
+        throw new Error(
+          `Refusing to overwrite existing run document: data/runs/${runId}/benchmark.otlp.json already exists on '${dataBranch}'. `
+          + "run-id values must be unique per write.",
+        );
+      }
+      writeResultFile(result, resultPath);
+      await exec.exec("git", ["-C", worktree, "add", "."]);
+      await exec.exec("git", ["-C", worktree, "commit", "-m", `bench: add run ${runId}`]);
+      await pushWithRetry(worktree, dataBranch, DEFAULT_PUSH_RETRY_COUNT);
+      filePathOutput = `data/runs/${runId}/benchmark.otlp.json`;
+    } finally {
+      await exec.exec("git", ["worktree", "remove", worktree, "--force"], { ignoreReturnCode: true });
     }
-    writeResultFile(result, resultPath);
-    await exec.exec("git", ["-C", worktree, "add", "."]);
-    await exec.exec("git", ["-C", worktree, "commit", "-m", `bench: add run ${runId}`]);
-    await pushWithRetry(worktree, dataBranch, DEFAULT_PUSH_RETRY_COUNT);
-    await exec.exec("git", ["worktree", "remove", worktree, "--force"]);
-    filePathOutput = `data/runs/${runId}/benchmark.otlp.json`;
   } else {
     core.info("commit-results=false; skipping data branch commit");
   }

--- a/octo11y/actions/parse-results/src/parse-results.ts
+++ b/octo11y/actions/parse-results/src/parse-results.ts
@@ -23,13 +23,18 @@ export function resolveMode(input: string): ParseMode {
   throw new Error(`Invalid mode '${input}'. Expected 'auto' or 'file'.`);
 }
 
+/** Sanitize a runId for safe use as a filename (strip path separators and shell-unsafe chars). */
+function sanitizeRunId(raw: string): string {
+  return raw.replace(/[/\\:*?"<>|]/g, "_");
+}
+
 export function buildRunId(options: {
   customRunId?: string;
   githubRunId?: string;
   githubRunAttempt?: string;
   githubJob?: string;
 }): string {
-  if (options.customRunId) return options.customRunId;
+  if (options.customRunId) return sanitizeRunId(options.customRunId);
   const base = `${options.githubRunId ?? "local"}-${options.githubRunAttempt ?? "1"}`;
   if (options.githubJob) {
     const sanitized = options.githubJob

--- a/octo11y/actions/stash/src/main.ts
+++ b/octo11y/actions/stash/src/main.ts
@@ -30,6 +30,7 @@ async function run(): Promise<void> {
   const format = (core.getInput("format") || "auto") as Format;
   const dataBranch = core.getInput("data-branch") || DEFAULT_DATA_BRANCH;
   const token = core.getInput("github-token", { required: true });
+  core.setSecret(token);
 
   const monitorPath = core.getInput("monitor-results") || "";
 
@@ -101,21 +102,24 @@ async function run(): Promise<void> {
     await configureGit(token);
     const worktree = await checkoutDataBranch(dataBranch, "benchkit-stash");
 
-    const resultPath = path.join(worktree, "data", "runs", runId, "benchmark.otlp.json");
-    if (fs.existsSync(resultPath)) {
-      throw new Error(
-        `Refusing to overwrite existing run document: data/runs/${runId}/benchmark.otlp.json already exists on '${dataBranch}'. `
-        + "run-id values must be unique per write.",
-      );
-    }
-    writeResultFile(result, runId, resultPath);
-    core.info(`Wrote ${resultPath}`);
+    try {
+      const resultPath = path.join(worktree, "data", "runs", runId, "benchmark.otlp.json");
+      if (fs.existsSync(resultPath)) {
+        throw new Error(
+          `Refusing to overwrite existing run document: data/runs/${runId}/benchmark.otlp.json already exists on '${dataBranch}'. `
+          + "run-id values must be unique per write.",
+        );
+      }
+      writeResultFile(result, runId, resultPath);
+      core.info(`Wrote ${resultPath}`);
 
-    await exec.exec("git", ["-C", worktree, "add", "."]);
-    await exec.exec("git", ["-C", worktree, "commit", "-m", `bench: add run ${runId}`]);
-    await pushWithRetry(worktree, dataBranch, DEFAULT_PUSH_RETRY_COUNT);
-    await exec.exec("git", ["worktree", "remove", worktree, "--force"]);
-    filePathOutput = `data/runs/${runId}/benchmark.otlp.json`;
+      await exec.exec("git", ["-C", worktree, "add", "."]);
+      await exec.exec("git", ["-C", worktree, "commit", "-m", `bench: add run ${runId}`]);
+      await pushWithRetry(worktree, dataBranch, DEFAULT_PUSH_RETRY_COUNT);
+      filePathOutput = `data/runs/${runId}/benchmark.otlp.json`;
+    } finally {
+      await exec.exec("git", ["worktree", "remove", worktree, "--force"], { ignoreReturnCode: true });
+    }
   } else {
     core.info(`${commitInputName}=false; skipping data branch commit`);
   }

--- a/octo11y/actions/stash/src/stash.ts
+++ b/octo11y/actions/stash/src/stash.ts
@@ -117,13 +117,18 @@ export function readMonitorOutput(monitorPath: string): OtlpMetricsDocument {
  * replaced with `-`, with consecutive dashes collapsed and leading/trailing
  * dashes stripped.
  */
+/** Sanitize a runId for safe use as a filename (strip path separators and shell-unsafe chars). */
+function sanitizeRunId(raw: string): string {
+  return raw.replace(/[/\\:*?"<>|]/g, "_");
+}
+
 export function buildRunId(options: {
   customRunId?: string;
   githubRunId?: string;
   githubRunAttempt?: string;
   githubJob?: string;
 }): string {
-  if (options.customRunId) return options.customRunId;
+  if (options.customRunId) return sanitizeRunId(options.customRunId);
   const base = `${options.githubRunId ?? "local"}-${options.githubRunAttempt ?? "1"}`;
   if (options.githubJob) {
     const sanitized = options.githubJob

--- a/octo11y/packages/adapters/src/transforms.ts
+++ b/octo11y/packages/adapters/src/transforms.ts
@@ -83,8 +83,8 @@ export function getUniqueTags(series: SeriesFile): Record<string, Set<string>> {
  */
 export function normalizeValues(values: number[]): number[] {
   if (!values.length) return [];
-  const min = Math.min(...values);
-  const max = Math.max(...values);
+  const min = values.reduce((a, b) => Math.min(a, b), Infinity);
+  const max = values.reduce((a, b) => Math.max(a, b), -Infinity);
   const range = max - min;
   if (range === 0) return values.map(() => 50);
   return values.map((v) => ((v - min) / range) * 100);

--- a/octo11y/packages/chart/src/Dashboard.tsx
+++ b/octo11y/packages/chart/src/Dashboard.tsx
@@ -111,6 +111,11 @@ export function Dashboard({
     [dateFilteredSeriesMap, regressionThreshold, regressionWindow],
   );
 
+  const [monitorSeriesMap, userMetrics] = useMemo(
+    () => partitionSeriesMap(dateFilteredSeriesMap, isMonitorMetric),
+    [dateFilteredSeriesMap],
+  );
+
   const rootClassName = ["bk-dashboard", className].filter(Boolean).join(" ");
   const formatMetric = metricLabelFormatter ?? defaultMetricLabel;
 
@@ -147,10 +152,6 @@ export function Dashboard({
     );
   }
 
-  const [monitorSeriesMap, userMetrics] = useMemo(
-    () => partitionSeriesMap(dateFilteredSeriesMap, isMonitorMetric),
-    [dateFilteredSeriesMap],
-  );
   const userMetricNames = (index.metrics ?? []).filter((m) => !isMonitorMetric(m));
 
   const selectedMetric = typeof view === "object" ? view.metric : null;

--- a/octo11y/packages/chart/src/RunDetail.test.ts
+++ b/octo11y/packages/chart/src/RunDetail.test.ts
@@ -68,12 +68,12 @@ function makeMonitorDetail(): RunDetailView {
         values: [{ name: "BenchFoo", value: 10.0, unit: "ms" }],
       },
       {
-        metric: "_monitor/cpu_percent",
+        metric: "_monitor.cpu_percent",
         unit: "%",
         values: [{ name: "default", value: 55.2, unit: "%" }],
       },
       {
-        metric: "_monitor/memory_mb",
+        metric: "_monitor.memory_mb",
         unit: "MB",
         values: [{ name: "default", value: 4096, unit: "MB" }],
       },
@@ -137,8 +137,8 @@ describe("RunDetail data model", () => {
     assert.equal(d.run.monitor?.runner_os, "Linux");
     assert.equal(d.run.monitor?.cpu_count, 4);
 
-    const userSnaps = d.metricSnapshots.filter((s) => !s.metric.startsWith("_monitor/"));
-    const monitorSnaps = d.metricSnapshots.filter((s) => s.metric.startsWith("_monitor/"));
+    const userSnaps = d.metricSnapshots.filter((s) => !s.metric.startsWith("_monitor."));
+    const monitorSnaps = d.metricSnapshots.filter((s) => s.metric.startsWith("_monitor."));
 
     assert.equal(userSnaps.length, 1);
     assert.equal(monitorSnaps.length, 2);

--- a/octo11y/packages/chart/src/labels.test.ts
+++ b/octo11y/packages/chart/src/labels.test.ts
@@ -15,18 +15,18 @@ describe("defaultMetricLabel", () => {
   });
 
   it("delegates monitor metrics to the monitor label formatter", () => {
-    assert.equal(defaultMetricLabel("_monitor/cpu_user_pct"), "CPU user %");
+    assert.equal(defaultMetricLabel("_monitor.cpu_user_pct"), "CPU user %");
   });
 });
 
 describe("defaultMonitorMetricLabel", () => {
   it("uses friendly labels for known monitor metrics", () => {
-    assert.equal(defaultMonitorMetricLabel("_monitor/wall_clock_ms"), "Wall clock time (ms)");
-    assert.equal(defaultMonitorMetricLabel("_monitor/mem_available_min_mb"), "Lowest available memory (MB)");
+    assert.equal(defaultMonitorMetricLabel("_monitor.wall_clock_ms"), "Wall clock time (ms)");
+    assert.equal(defaultMonitorMetricLabel("_monitor.mem_available_min_mb"), "Lowest available memory (MB)");
   });
 
   it("formats unknown monitor metrics into title case", () => {
-    assert.equal(defaultMonitorMetricLabel("_monitor/process/background_worker"), "Process Background Worker");
-    assert.equal(defaultMonitorMetricLabel("_monitor/custom_probe"), "Custom Probe");
+    assert.equal(defaultMonitorMetricLabel("_monitor.process/background_worker"), "Process Background Worker");
+    assert.equal(defaultMonitorMetricLabel("_monitor.custom_probe"), "Custom Probe");
   });
 });

--- a/octo11y/packages/chart/src/labels.ts
+++ b/octo11y/packages/chart/src/labels.ts
@@ -1,3 +1,5 @@
+import { MONITOR_METRIC_PREFIX } from "@benchkit/format";
+
 const MONITOR_METRIC_LABELS: Record<string, string> = {
   cpu_system_ms: "CPU system time (ms)",
   cpu_system_pct: "CPU system %",
@@ -19,7 +21,7 @@ function titleCase(input: string): string {
 }
 
 export function defaultMetricLabel(metric: string): string {
-  if (metric.startsWith("_monitor/")) {
+  if (metric.startsWith(MONITOR_METRIC_PREFIX)) {
     return defaultMonitorMetricLabel(metric);
   }
 
@@ -30,11 +32,11 @@ export function defaultMetricLabel(metric: string): string {
 
 /** Returns true when the metric name belongs to the monitor action's output. */
 export function isMonitorMetric(metric: string): boolean {
-  return metric.startsWith("_monitor/");
+  return metric.startsWith(MONITOR_METRIC_PREFIX);
 }
 
 export function defaultMonitorMetricLabel(metric: string): string {
-  const raw = metric.replace(/^_monitor\//, "");
+  const raw = metric.replace(new RegExp(`^${MONITOR_METRIC_PREFIX.replace(".", "\\.")}`), "");
   if (MONITOR_METRIC_LABELS[raw]) {
     return MONITOR_METRIC_LABELS[raw];
   }

--- a/octo11y/packages/dashboard/src/pages/RunDetailPage.tsx
+++ b/octo11y/packages/dashboard/src/pages/RunDetailPage.tsx
@@ -141,7 +141,7 @@ export function RunDetailPage(props: {
           </summary>
           {monitorSnapshots.map((snapshot) => (
             <Card key={snapshot.metric} style={{ marginTop: "8px" }}>
-              <div style={{ fontWeight: 600, fontSize: "0.8rem", marginBottom: "8px" }}>{snapshot.metric.replace("_monitor/", "")}</div>
+              <div style={{ fontWeight: 600, fontSize: "0.8rem", marginBottom: "8px" }}>{snapshot.metric.replace("_monitor.", "")}</div>
               <div style={{ fontSize: "0.8rem", color: T.textSecondary }}>
                 {(snapshot.values ?? []).map((v) => `${v.name}: ${fmtValue(v.value)}`).join(", ")}
               </div>

--- a/packages/views/src/index.ts
+++ b/packages/views/src/index.ts
@@ -226,6 +226,8 @@ function computeDepths(spans: readonly SpanRecord[]): Map<string, number> {
     if (existing !== undefined) {
       return existing;
     }
+    // Write a sentinel before recursing to break cycles.
+    depths.set(span.spanId, 0);
     const parent = span.parentSpanId ? byId.get(span.parentSpanId) : undefined;
     const depth = parent ? visit(parent) + 1 : 0;
     depths.set(span.spanId, depth);
@@ -341,8 +343,8 @@ export function buildHistogramFrame(
     };
   }
 
-  const minimum = Math.min(...values);
-  const maximum = Math.max(...values);
+  const minimum = values.reduce((a, b) => Math.min(a, b), Infinity);
+  const maximum = values.reduce((a, b) => Math.max(a, b), -Infinity);
   const binCount = Math.max(1, options.binCount ?? 10);
   const width = minimum === maximum ? 1 : (maximum - minimum) / binCount;
   const counts = Array.from({ length: binCount }, () => 0);
@@ -394,11 +396,11 @@ export function buildTraceWaterfallFrame(
     signal: "traces",
     title: options.title ?? "Trace waterfall",
     traces: [...traces.entries()].map(([traceId, spans]) => {
-      const sorted = [...spans].sort((left, right) =>
-        (toUnixNanos(left.startTimeUnixNano) ?? 0n) < (toUnixNanos(right.startTimeUnixNano) ?? 0n)
-          ? -1
-          : 1
-      );
+      const sorted = [...spans].sort((left, right) => {
+        const a = toUnixNanos(left.startTimeUnixNano) ?? 0n;
+        const b = toUnixNanos(right.startTimeUnixNano) ?? 0n;
+        return a < b ? -1 : a > b ? 1 : 0;
+      });
       const traceStart = sorted[0]?.startTimeUnixNano ?? null;
       const traceEnd =
         sorted.reduce<string | null>((latest, span) => {
@@ -474,9 +476,11 @@ export function buildEventTimelineFrame(
             scope: log.scope,
           })
         )
-        .sort((left, right) =>
-          (toUnixNanos(left.timeUnixNano) ?? 0n) < (toUnixNanos(right.timeUnixNano) ?? 0n) ? -1 : 1
-        ),
+        .sort((left, right) => {
+          const a = toUnixNanos(left.timeUnixNano) ?? 0n;
+          const b = toUnixNanos(right.timeUnixNano) ?? 0n;
+          return a < b ? -1 : a > b ? 1 : 0;
+        }),
     };
   }
 
@@ -502,8 +506,10 @@ export function buildEventTimelineFrame(
     kind: "event-timeline",
     signal: "traces",
     title: options.title ?? "Trace events",
-    events: events.sort((left, right) =>
-      (toUnixNanos(left.timeUnixNano) ?? 0n) < (toUnixNanos(right.timeUnixNano) ?? 0n) ? -1 : 1
-    ),
+    events: events.sort((left, right) => {
+      const a = toUnixNanos(left.timeUnixNano) ?? 0n;
+      const b = toUnixNanos(right.timeUnixNano) ?? 0n;
+      return a < b ? -1 : a > b ? 1 : 0;
+    }),
   };
 }


### PR DESCRIPTION
## Summary  Comprehensive code review fixes across the monorepo addressing security vulnerabilities, correctness bugs, and robustness issues.  ### Security Fixes - **Path traversal in buildRunId**: Sanitize `customRunId` inputs to strip `../`, leading `/`, and path-unsafe characters in `actions/parse-results`, `octo11y/actions/stash`, and `octo11y/actions/parse-results` - **Token exposure in logs**: Add `core.setSecret(token)` to mask GitHub tokens in 5 action entry points (`actions/parse-results`, `octo11y/actions/stash`, `octo11y/actions/parse-results`, `octo11y/actions/compare`, `octo11y/actions/aggregate`) - **Metric name injection**: Sanitize metric and badge file names in the aggregate action to prevent directory traversal via crafted metric names  ### Correctness Fixes - **React hooks violation**: Move `useMemo` call before conditional early returns in `Dashboard.tsx` (hooks must not be called conditionally) - **Unstable sort comparators**: Fix 3 sort comparators in `packages/views` to return `0` for equal elements (were returning `1`, causing non-deterministic sort order) - **Cycle detection in computeDepths**: Add sentinel to break infinite recursion in trace span depth computation when cyclic parent references exist - **Monitor metric prefix mismatch**: Align chart layer to canonical `_monitor.` prefix from `@benchkit/format` (was hardcoded as `_monitor/`) - **Port 0 rejection**: Accept port `0` (meaning disabled) in monitor `validatePort` — previously incorrectly rejected  ### Robustness Improvements - **Stack overflow on large arrays**: Replace `Math.min(...spread)` / `Math.max(...spread)` with `.reduce()` loops in `packages/views` and `octo11y/packages/adapters/transforms.ts` - **Leaked git worktrees**: Wrap worktree operations in `try/finally` in stash, parse-results, and compare actions to ensure cleanup on failure - **PR comment pagination**: Add `per_page: 100` to `listComments` in compare action to handle PRs with many bot comments  ### Validation - Root `typecheck:packages` passes - Octo11y `build` passes (all actions compile with ncc) - Octo11y tests pass (42/42, 0 failures) - Root vitest cannot run locally (Node 18 vs required 22+) — CI will validate  ### Files Changed (17) | File | Change | |------|--------| | `actions/parse-results/src/stash.ts` | Add `sanitizeRunId()` | | `actions/parse-results/src/main.ts` | Add `core.setSecret(token)` | | `octo11y/actions/stash/src/stash.ts` | Add `sanitizeRunId()` | | `octo11y/actions/stash/src/main.ts` | Add `core.setSecret(token)`, try/finally worktree | | `octo11y/actions/parse-results/src/parse-results.ts` | Add `sanitizeRunId()` | | `octo11y/actions/parse-results/src/main.ts` | Add `core.setSecret(token)`, try/finally worktree | | `octo11y/actions/compare/src/main.ts` | Add `core.setSecret(token)`, try/finally, per_page:100 | | `octo11y/actions/aggregate/src/main.ts` | Add `core.setSecret(token)`, `sanitizeName()` | | `octo11y/actions/monitor/src/otel-start.ts` | Accept port 0 | | `octo11y/actions/monitor/src/otel-start.test.ts` | Update test expectations | | `octo11y/packages/chart/src/Dashboard.tsx` | Move useMemo before early returns | | `octo11y/packages/chart/src/labels.ts` | Use MONITOR_METRIC_PREFIX constant | | `octo11y/packages/chart/src/labels.test.ts` | Update test expectations | | `octo11y/packages/chart/src/RunDetail.test.ts` | Update test data | | `octo11y/packages/dashboard/src/pages/RunDetailPage.tsx` | Fix prefix string | | `packages/views/src/index.ts` | Cycle detection, sort fix, reduce loops | | `octo11y/packages/adapters/src/transforms.ts` | Replace spread with reduce |