### PR TITLE
feat(views): add incremental telemetry store API

### DIFF
--- a/examples/chartjs/vite.config.ts
+++ b/examples/chartjs/vite.config.ts
@@ -1,3 +1,7 @@
 import { defineConfig } from "vite";
 
-export default defineConfig({});
+export default defineConfig({
+  build: {
+    chunkSizeWarningLimit: 700,
+  },
+});

--- a/examples/demo/vite.config.ts
+++ b/examples/demo/vite.config.ts
@@ -4,4 +4,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   base: process.env.BASE_PATH ?? "/",
   plugins: [react()],
+  build: {
+    chunkSizeWarningLimit: 700,
+  },
 });

--- a/examples/echarts/vite.config.ts
+++ b/examples/echarts/vite.config.ts
@@ -1,3 +1,7 @@
 import { defineConfig } from "vite";
 
-export default defineConfig({});
+export default defineConfig({
+  build: {
+    chunkSizeWarningLimit: 700,
+  },
+});

--- a/examples/recharts/vite.config.ts
+++ b/examples/recharts/vite.config.ts
@@ -3,4 +3,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    chunkSizeWarningLimit: 700,
+  },
 });

--- a/examples/uplot/vite.config.ts
+++ b/examples/uplot/vite.config.ts
@@ -1,3 +1,7 @@
 import { defineConfig } from "vite";
 
-export default defineConfig({});
+export default defineConfig({
+  build: {
+    chunkSizeWarningLimit: 700,
+  },
+});

--- a/packages/views/README.md
+++ b/packages/views/README.md
@@ -9,6 +9,7 @@ Build reusable telemetry view frames from OTLP JSON inputs.
 - `buildHistogramFrame`
 - `buildTraceWaterfallFrame`
 - `buildEventTimelineFrame`
+- `createTelemetryStore`
 
 Frames are plain JavaScript objects designed to be consumed by UI adapters.
 
@@ -23,3 +24,37 @@ const frame = buildTimeSeriesFrame(document, {
   splitBy: "output",
 });
 ```
+
+## Incremental Ingest Store
+
+Use `createTelemetryStore` when telemetry arrives in chunks and you want
+append-only ingest with reusable selectors.
+
+```ts
+import { createTelemetryStore } from "@otlpkit/views";
+
+const store = createTelemetryStore({
+  maxPoints: 10_000,
+  maxAgeMs: 5 * 60_000,
+});
+
+store.ingest(firstOtlpChunk);
+store.ingest(nextOtlpChunk);
+
+const timeSeries = store.selectTimeSeries({
+  metricName: "logfwd.inflight_batches",
+  intervalMs: 1000,
+});
+
+const latest = store.selectLatestValues({
+  metricName: "logfwd.inflight_batches",
+});
+```
+
+Store selectors map directly to existing frame builders:
+
+- `selectTimeSeries`
+- `selectLatestValues`
+- `selectHistogram`
+- `selectTraceWaterfall`
+- `selectEventTimeline`

--- a/packages/views/src/index.ts
+++ b/packages/views/src/index.ts
@@ -46,6 +46,19 @@ export interface TimeSeriesFrame {
   readonly series: readonly TimeSeriesSeries[];
 }
 
+export interface TimeSeriesFrameOptions {
+  readonly signal?: Signal;
+  readonly title?: string;
+  readonly metricName?: string;
+  readonly name?: string;
+  readonly intervalMs?: number;
+  readonly splitBy?: string;
+  readonly reduce?: "sum" | "avg" | "min" | "max" | "last" | "count";
+  readonly filters?: Record<string, unknown>;
+  readonly valueFn?: (record: TelemetryRecord) => number | null;
+  readonly unit?: string;
+}
+
 export interface LatestValueRow {
   readonly key: string;
   readonly label: string;
@@ -66,6 +79,17 @@ export interface LatestValuesFrame {
   readonly rows: readonly LatestValueRow[];
 }
 
+export interface LatestValuesFrameOptions {
+  readonly signal?: Signal;
+  readonly title?: string;
+  readonly metricName?: string;
+  readonly name?: string;
+  readonly splitBy?: string;
+  readonly filters?: Record<string, unknown>;
+  readonly valueFn?: (record: TelemetryRecord) => number | null;
+  readonly unit?: string;
+}
+
 export interface HistogramBin {
   readonly start: number;
   readonly end: number;
@@ -79,6 +103,17 @@ export interface HistogramFrame {
   readonly title: string;
   readonly unit: string | null;
   readonly bins: readonly HistogramBin[];
+}
+
+export interface HistogramFrameOptions {
+  readonly signal?: Signal;
+  readonly title?: string;
+  readonly metricName?: string;
+  readonly name?: string;
+  readonly filters?: Record<string, unknown>;
+  readonly valueFn?: (record: TelemetryRecord) => number | null;
+  readonly unit?: string;
+  readonly binCount?: number;
 }
 
 export interface TraceWaterfallSpan {
@@ -111,6 +146,11 @@ export interface TraceWaterfallFrame {
   readonly traces: readonly TraceWaterfallTrace[];
 }
 
+export interface TraceWaterfallFrameOptions {
+  readonly title?: string;
+  readonly filters?: Record<string, unknown>;
+}
+
 export interface EventTimelineEvent {
   readonly kind: "span-event" | "log";
   readonly timeUnixNano: string | null;
@@ -131,6 +171,37 @@ export interface EventTimelineFrame {
   readonly signal: "traces" | "logs";
   readonly title: string;
   readonly events: readonly EventTimelineEvent[];
+}
+
+export interface EventTimelineFrameOptions {
+  readonly signal?: "traces" | "logs";
+  readonly title?: string;
+  readonly filters?: Record<string, unknown>;
+}
+
+export interface TelemetryStoreOptions {
+  readonly maxPoints?: number;
+  readonly maxAgeMs?: number;
+}
+
+export interface TelemetryStoreIngestSummary {
+  readonly metrics: number;
+  readonly traces: number;
+  readonly logs: number;
+  readonly total: number;
+}
+
+export interface TelemetryStoreSize extends TelemetryStoreIngestSummary {}
+
+export interface TelemetryStore {
+  ingest(input: unknown): TelemetryStoreIngestSummary;
+  size(): TelemetryStoreSize;
+  clear(): void;
+  selectTimeSeries(options?: TimeSeriesFrameOptions): TimeSeriesFrame;
+  selectLatestValues(options?: LatestValuesFrameOptions): LatestValuesFrame;
+  selectHistogram(options?: HistogramFrameOptions): HistogramFrame;
+  selectTraceWaterfall(options?: TraceWaterfallFrameOptions): TraceWaterfallFrame;
+  selectEventTimeline(options?: EventTimelineFrameOptions): EventTimelineFrame;
 }
 
 function materialize(
@@ -241,18 +312,7 @@ function computeDepths(spans: readonly SpanRecord[]): Map<string, number> {
 
 export function buildTimeSeriesFrame(
   input: unknown,
-  options: {
-    readonly signal?: Signal;
-    readonly title?: string;
-    readonly metricName?: string;
-    readonly name?: string;
-    readonly intervalMs?: number;
-    readonly splitBy?: string;
-    readonly reduce?: "sum" | "avg" | "min" | "max" | "last" | "count";
-    readonly filters?: Record<string, unknown>;
-    readonly valueFn?: (record: TelemetryRecord) => number | null;
-    readonly unit?: string;
-  } = {}
+  options: TimeSeriesFrameOptions = {}
 ): TimeSeriesFrame {
   const { signal, records } = materialize(input, options.signal);
   const filters = {
@@ -281,16 +341,7 @@ export function buildTimeSeriesFrame(
 
 export function buildLatestValuesFrame(
   input: unknown,
-  options: {
-    readonly signal?: Signal;
-    readonly title?: string;
-    readonly metricName?: string;
-    readonly name?: string;
-    readonly splitBy?: string;
-    readonly filters?: Record<string, unknown>;
-    readonly valueFn?: (record: TelemetryRecord) => number | null;
-    readonly unit?: string;
-  } = {}
+  options: LatestValuesFrameOptions = {}
 ): LatestValuesFrame {
   const { signal, records } = materialize(input, options.signal);
   const filters = {
@@ -310,16 +361,7 @@ export function buildLatestValuesFrame(
 
 export function buildHistogramFrame(
   input: unknown,
-  options: {
-    readonly signal?: Signal;
-    readonly title?: string;
-    readonly metricName?: string;
-    readonly name?: string;
-    readonly filters?: Record<string, unknown>;
-    readonly valueFn?: (record: TelemetryRecord) => number | null;
-    readonly unit?: string;
-    readonly binCount?: number;
-  } = {}
+  options: HistogramFrameOptions = {}
 ): HistogramFrame {
   const { signal, records } = materialize(input, options.signal);
   const filters = {
@@ -374,10 +416,7 @@ export function buildHistogramFrame(
 
 export function buildTraceWaterfallFrame(
   input: unknown,
-  options: {
-    readonly title?: string;
-    readonly filters?: Record<string, unknown>;
-  } = {}
+  options: TraceWaterfallFrameOptions = {}
 ): TraceWaterfallFrame {
   const filtered = filterRecords(collectTraces(input), options.filters ?? {});
   const traces = new Map<string, SpanRecord[]>();
@@ -446,11 +485,7 @@ export function buildTraceWaterfallFrame(
 
 export function buildEventTimelineFrame(
   input: unknown,
-  options: {
-    readonly signal?: "traces" | "logs";
-    readonly title?: string;
-    readonly filters?: Record<string, unknown>;
-  } = {}
+  options: EventTimelineFrameOptions = {}
 ): EventTimelineFrame {
   if (options.signal === "logs") {
     const logs = filterRecords(collectLogs(input), options.filters ?? {});
@@ -505,5 +540,131 @@ export function buildEventTimelineFrame(
     events: events.sort((left, right) =>
       (toUnixNanos(left.timeUnixNano) ?? 0n) < (toUnixNanos(right.timeUnixNano) ?? 0n) ? -1 : 1
     ),
+  };
+}
+
+function validateStoreOptions(options: TelemetryStoreOptions): void {
+  if (options.maxPoints !== undefined) {
+    if (!Number.isInteger(options.maxPoints) || options.maxPoints < 1) {
+      throw new Error("maxPoints must be a positive integer when provided.");
+    }
+  }
+  if (options.maxAgeMs !== undefined) {
+    if (!Number.isFinite(options.maxAgeMs) || options.maxAgeMs <= 0) {
+      throw new Error("maxAgeMs must be a positive number when provided.");
+    }
+  }
+}
+
+function pruneByMaxAge(
+  records: TelemetryRecord[],
+  maxAgeMs: number | undefined
+): TelemetryRecord[] {
+  if (maxAgeMs === undefined || records.length === 0) {
+    return records;
+  }
+  let newest: bigint | null = null;
+  for (const record of records) {
+    const timestamp = toUnixNanos(recordTimestampNanos(record));
+    if (timestamp === null) {
+      continue;
+    }
+    if (newest === null || timestamp > newest) {
+      newest = timestamp;
+    }
+  }
+  if (newest === null) {
+    return records;
+  }
+  const maxAgeNanos = BigInt(Math.floor(maxAgeMs * 1_000_000));
+  const cutoff = newest - maxAgeNanos;
+  return records.filter((record) => {
+    const timestamp = toUnixNanos(recordTimestampNanos(record));
+    return timestamp === null || timestamp >= cutoff;
+  });
+}
+
+function pruneByMaxPoints(
+  records: TelemetryRecord[],
+  maxPoints: number | undefined
+): TelemetryRecord[] {
+  if (maxPoints === undefined || records.length <= maxPoints) {
+    return records;
+  }
+  return records.slice(records.length - maxPoints);
+}
+
+function applyRetention(
+  records: TelemetryRecord[],
+  options: TelemetryStoreOptions
+): TelemetryRecord[] {
+  return pruneByMaxPoints(pruneByMaxAge(records, options.maxAgeMs), options.maxPoints);
+}
+
+export function createTelemetryStore(options: TelemetryStoreOptions = {}): TelemetryStore {
+  validateStoreOptions(options);
+
+  let metricRecords: TelemetryRecord[] = [];
+  let traceRecords: TelemetryRecord[] = [];
+  let logRecords: TelemetryRecord[] = [];
+
+  const snapshot = (): readonly [
+    readonly TelemetryRecord[],
+    readonly TelemetryRecord[],
+    readonly TelemetryRecord[],
+  ] => [metricRecords, traceRecords, logRecords];
+
+  return {
+    ingest(input: unknown): TelemetryStoreIngestSummary {
+      const nextMetrics = collectMetrics(input);
+      const nextTraces = collectTraces(input);
+      const nextLogs = collectLogs(input);
+
+      metricRecords = applyRetention([...metricRecords, ...nextMetrics], options);
+      traceRecords = applyRetention([...traceRecords, ...nextTraces], options);
+      logRecords = applyRetention([...logRecords, ...nextLogs], options);
+
+      return {
+        metrics: nextMetrics.length,
+        traces: nextTraces.length,
+        logs: nextLogs.length,
+        total: nextMetrics.length + nextTraces.length + nextLogs.length,
+      };
+    },
+
+    size(): TelemetryStoreSize {
+      return {
+        metrics: metricRecords.length,
+        traces: traceRecords.length,
+        logs: logRecords.length,
+        total: metricRecords.length + traceRecords.length + logRecords.length,
+      };
+    },
+
+    clear(): void {
+      metricRecords = [];
+      traceRecords = [];
+      logRecords = [];
+    },
+
+    selectTimeSeries(frameOptions: TimeSeriesFrameOptions = {}): TimeSeriesFrame {
+      return buildTimeSeriesFrame(snapshot(), frameOptions);
+    },
+
+    selectLatestValues(frameOptions: LatestValuesFrameOptions = {}): LatestValuesFrame {
+      return buildLatestValuesFrame(snapshot(), frameOptions);
+    },
+
+    selectHistogram(frameOptions: HistogramFrameOptions = {}): HistogramFrame {
+      return buildHistogramFrame(snapshot(), frameOptions);
+    },
+
+    selectTraceWaterfall(frameOptions: TraceWaterfallFrameOptions = {}): TraceWaterfallFrame {
+      return buildTraceWaterfallFrame(snapshot(), frameOptions);
+    },
+
+    selectEventTimeline(frameOptions: EventTimelineFrameOptions = {}): EventTimelineFrame {
+      return buildEventTimelineFrame(snapshot(), frameOptions);
+    },
   };
 }

--- a/packages/views/test/index.test.ts
+++ b/packages/views/test/index.test.ts
@@ -7,6 +7,7 @@ import {
   buildLatestValuesFrame,
   buildTimeSeriesFrame,
   buildTraceWaterfallFrame,
+  createTelemetryStore,
 } from "../src/index.js";
 
 describe("@otlpkit/views", () => {
@@ -344,5 +345,210 @@ describe("@otlpkit/views", () => {
     expect(waterfall.traces[0]?.spans[0]?.spanId).toBe("null-time");
     expect(logEvents.events[0]?.body).toBe("null");
     expect(traceEvents.events[0]?.name).toBe("null");
+  });
+
+  it("matches batch frame output through an incremental store", () => {
+    const store = createTelemetryStore();
+    store.ingest(metricsDocument);
+
+    const batch = buildTimeSeriesFrame(metricsDocument, {
+      metricName: "logfwd.inflight_batches",
+      intervalMs: 1000,
+      splitBy: "output",
+    });
+    const fromStore = store.selectTimeSeries({
+      metricName: "logfwd.inflight_batches",
+      intervalMs: 1000,
+      splitBy: "output",
+    });
+
+    expect(fromStore).toEqual(batch);
+  });
+
+  it("supports append-only ingest across multiple calls", () => {
+    const store = createTelemetryStore();
+
+    const first = {
+      resourceMetrics: [
+        {
+          scopeMetrics: [
+            {
+              metrics: [
+                {
+                  name: "app.requests",
+                  gauge: {
+                    dataPoints: [{ timeUnixNano: "1000000", asInt: "3" }],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const second = {
+      resourceMetrics: [
+        {
+          scopeMetrics: [
+            {
+              metrics: [
+                {
+                  name: "app.requests",
+                  gauge: {
+                    dataPoints: [{ timeUnixNano: "2000000", asInt: "8" }],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(store.ingest(first).metrics).toBe(1);
+    expect(store.ingest(second).metrics).toBe(1);
+    expect(store.size().metrics).toBe(2);
+
+    const frame = store.selectTimeSeries({
+      metricName: "app.requests",
+      intervalMs: 1,
+    });
+    expect(frame.series).toHaveLength(1);
+    expect(frame.series[0]?.points).toHaveLength(2);
+    expect(frame.series[0]?.points[1]?.value).toBe(8);
+  });
+
+  it("applies maxPoints retention per signal", () => {
+    const store = createTelemetryStore({ maxPoints: 2 });
+
+    store.ingest({
+      resourceMetrics: [
+        {
+          scopeMetrics: [
+            {
+              metrics: [
+                {
+                  name: "queue.depth",
+                  gauge: {
+                    dataPoints: [
+                      { timeUnixNano: "1000000", asInt: "1" },
+                      { timeUnixNano: "2000000", asInt: "2" },
+                      { timeUnixNano: "3000000", asInt: "3" },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const frame = store.selectTimeSeries({
+      metricName: "queue.depth",
+      intervalMs: 1,
+    });
+    expect(store.size().metrics).toBe(2);
+    expect(frame.series[0]?.points).toHaveLength(2);
+    expect(frame.series[0]?.points[0]?.timeUnixNano).toBe("2000000");
+    expect(frame.series[0]?.points[1]?.timeUnixNano).toBe("3000000");
+  });
+
+  it("applies maxAgeMs retention per signal", () => {
+    const store = createTelemetryStore({ maxAgeMs: 2 });
+
+    store.ingest({
+      resourceMetrics: [
+        {
+          scopeMetrics: [
+            {
+              metrics: [
+                {
+                  name: "queue.latency",
+                  gauge: {
+                    dataPoints: [
+                      { timeUnixNano: "6000000", asInt: "6" },
+                      { timeUnixNano: "5000000", asInt: "5" },
+                      { timeUnixNano: "1000000", asInt: "1" },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const frame = store.selectTimeSeries({
+      metricName: "queue.latency",
+      intervalMs: 1,
+    });
+    expect(store.size().metrics).toBe(2);
+    expect(frame.series[0]?.points).toHaveLength(2);
+    expect(frame.series[0]?.points[0]?.timeUnixNano).toBe("5000000");
+    expect(frame.series[0]?.points[1]?.timeUnixNano).toBe("6000000");
+  });
+
+  it("supports traces/logs selectors from incremental ingest", () => {
+    const store = createTelemetryStore();
+    store.ingest(tracesDocument);
+    store.ingest(logsDocument);
+
+    expect(store.selectTraceWaterfall().traces.length).toBeGreaterThan(0);
+    expect(store.selectEventTimeline({ signal: "logs" }).events.length).toBeGreaterThan(0);
+  });
+
+  it("supports latest/histogram selectors and clear()", () => {
+    const store = createTelemetryStore();
+    store.ingest(metricsDocument);
+
+    expect(
+      store.selectLatestValues({ metricName: "logfwd.inflight_batches" }).rows.length
+    ).toBeGreaterThan(0);
+    expect(
+      store.selectHistogram({ metricName: "logfwd.output.duration" }).bins.length
+    ).toBeGreaterThan(0);
+
+    store.clear();
+    expect(store.size().total).toBe(0);
+    expect(store.selectLatestValues({ metricName: "logfwd.inflight_batches" }).rows).toHaveLength(
+      0
+    );
+  });
+
+  it("keeps records with missing timestamps when maxAgeMs is set", () => {
+    const store = createTelemetryStore({ maxAgeMs: 5 });
+    store.ingest({
+      resourceMetrics: [
+        {
+          scopeMetrics: [
+            {
+              metrics: [
+                {
+                  name: "untimed.metric",
+                  gauge: {
+                    dataPoints: [{ asInt: "42" }],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const latest = store.selectLatestValues({ metricName: "untimed.metric" });
+    expect(latest.rows).toHaveLength(1);
+    expect(latest.rows[0]?.value).toBe(42);
+  });
+
+  it("validates telemetry store retention options", () => {
+    expect(() => createTelemetryStore({ maxPoints: 0 })).toThrow(
+      /maxPoints must be a positive integer/
+    );
+    expect(() => createTelemetryStore({ maxAgeMs: 0 })).toThrow(
+      /maxAgeMs must be a positive number/
+    );
   });
 });

--- a/site/benchkit/index.html
+++ b/site/benchkit/index.html
@@ -139,7 +139,7 @@ jobs:
         </div>
       </section>
 
-      <footer>
+      <footer class="site-footer">
         <p>
           Benchkit builds on Octo11y data primitives. Read
           <a href="/o11ykit/octo11y/">Octo11y docs</a>

--- a/site/index.html
+++ b/site/index.html
@@ -145,7 +145,7 @@
         </div>
       </section>
 
-      <footer>
+      <footer class="site-footer">
         <p>
           Opinionated layering:
           <code>@benchkit/* -> @octo11y/* -> @otlpkit/*</code>

--- a/site/octo11y/index.html
+++ b/site/octo11y/index.html
@@ -113,7 +113,7 @@ jobs:
         </ul>
       </section>
 
-      <footer>
+      <footer class="site-footer">
         <p>
           Need performance-specific automation on top?
           <a href="/o11ykit/benchkit/">Go to Benchkit docs</a>

--- a/site/otlpkit-docs/index.html
+++ b/site/otlpkit-docs/index.html
@@ -115,7 +115,7 @@ const option = toEChartsTimeSeriesOption(latency);</code></pre>
         </p>
       </section>
 
-      <footer>
+      <footer class="site-footer">
         <p>
           Continue the story with GitHub telemetry automation:
           <a href="/o11ykit/octo11y/">Octo11y docs</a>

--- a/site/styles.css
+++ b/site/styles.css
@@ -367,13 +367,13 @@ code {
   color: inherit;
 }
 
-footer p {
+.site-footer p {
   margin: 0;
   color: #345166;
   font-size: 13px;
 }
 
-footer a {
+.site-footer a {
   color: #0e5d8f;
 }
 


### PR DESCRIPTION
## Summary

Implements issue #14 by adding a first-class incremental in-memory telemetry store to `@otlpkit/views`.

### Added

- `createTelemetryStore(options?)`
- `TelemetryStore` API with:
  - `ingest(input)`
  - `size()`
  - `clear()`
  - `selectTimeSeries(...)`
  - `selectLatestValues(...)`
  - `selectHistogram(...)`
  - `selectTraceWaterfall(...)`
  - `selectEventTimeline(...)`
- retention controls:
  - `maxPoints` (per-signal bounded in-memory count)
  - `maxAgeMs` (per-signal bounded age window based on newest seen timestamp)

### Refactors

- promoted frame-builder option types to exported named interfaces so selector signatures can share them cleanly:
  - `TimeSeriesFrameOptions`
  - `LatestValuesFrameOptions`
  - `HistogramFrameOptions`
  - `TraceWaterfallFrameOptions`
  - `EventTimelineFrameOptions`

### Tests

Added/expanded tests for:

- parity with batch frame output
- append-only incremental ingest behavior
- `maxPoints` retention behavior
- `maxAgeMs` retention behavior
- undated records retention with age windows
- traces/logs selectors from the same store
- option validation and `clear()` behavior

## Validation

- `npm run test`
- `npm run typecheck --workspace @otlpkit/views`
- `npm run build --workspace @otlpkit/views`
- `npm run lint` (passes; existing style warnings remain in `site/styles.css`)

Closes #14
