### PR TITLE
docs: post-merge naming and stale issue cleanup

### DIFF
--- a/octo11y/docs/README.md
+++ b/octo11y/docs/README.md
@@ -23,7 +23,7 @@
 ## Roadmap and planning
 
 - [`vision-and-roadmap.md`](vision-and-roadmap.md) — product direction and roadmap
-- [`metrickit-boundary-plan.md`](metrickit-boundary-plan.md) — metrickit/benchkit split boundary and compatibility plan
+- [`otlpkit-boundary-plan.md`](otlpkit-boundary-plan.md) — otlpkit/benchkit split boundary and compatibility plan
 - [`internal/agent-handoff.md`](internal/agent-handoff.md) — current execution queue for agents
 
 ## Package and action references

--- a/octo11y/docs/otlpkit-boundary-plan.md
+++ b/octo11y/docs/otlpkit-boundary-plan.md
@@ -1,14 +1,14 @@
-# Metrickit / Benchkit boundary plan
+# OTLPKit / Benchkit boundary plan
 
 This document defines the ownership boundary between the generic metric
-platform (**metrickit**) and the benchmark-specific product layer
+platform (**otlpkit**) and the benchmark-specific product layer
 (**benchkit**). It is the output of Phase 1 (#178) of the split epic (#183).
 
 ## Guiding principles
 
-1. **One-way dependency**: benchkit may depend on metrickit, never the reverse.
+1. **One-way dependency**: benchkit may depend on otlpkit, never the reverse.
 2. **No flag day**: existing `@benchkit/*` imports and `strawgate/octo11y/actions/*`
-   references continue to work. New `@metrickit/*` packages are additive.
+   references continue to work. New `@otlpkit/*` packages are additive.
 3. **Data contract stability**: existing `bench-data` branch files remain valid.
    Schema evolution is append-only or explicitly versioned.
 4. **Incremental extraction**: each phase produces a working, testable state.
@@ -21,9 +21,9 @@ platform (**metrickit**) and the benchmark-specific product layer
 
 | Surface | Owner | Rationale |
 |---|---|---|
-| OTLP types (`OtlpMetricsDocument`, etc.) | metrickit | Standard OpenTelemetry protocol encoding. |
-| OTLP parsing (`parseOtlp`, helpers) | metrickit | Pure OTLP deserialization, no benchmark logic. |
-| `MetricsBatch` (core: filter, groupBy, merge) | metrickit | Generic metric aggregation operations. |
+| OTLP types (`OtlpMetricsDocument`, etc.) | otlpkit | Standard OpenTelemetry protocol encoding. |
+| OTLP parsing (`parseOtlp`, helpers) | otlpkit | Pure OTLP deserialization, no benchmark logic. |
+| `MetricsBatch` (core: filter, groupBy, merge) | otlpkit | Generic metric aggregation operations. |
 | `buildOtlpResult()` | benchkit | Translates benchmark structures into OTLP with `benchkit.*` attributes. |
 | Benchmark parsers (Go, Rust, Hyperfine, pytest, benchmark-action) | benchkit | Format-specific parsing for benchmark tools. |
 | Semantic conventions (`ATTR_*`, `VALID_DIRECTIONS`, etc.) | benchkit | Benchmark-specific OTLP attribute vocabulary. |
@@ -35,10 +35,10 @@ platform (**metrickit**) and the benchmark-specific product layer
 
 | Surface | Owner | Rationale |
 |---|---|---|
-| `TrendChart`, `ComparisonChart`, `SampleChart`, `ComparisonBar` | metrickit | Generic time-series/comparison visualization. |
-| `TagFilter`, `DateRangeFilter` | metrickit | Generic series filtering. |
-| Fetch helpers (`fetchIndex`, `fetchSeries`, `fetchRun`, etc.) | metrickit | Generic HTTP data fetching. |
-| Data transforms (`dataPointsToComparisonData`, `samplesToDataPoints`) | metrickit | Generic data reshaping. |
+| `TrendChart`, `ComparisonChart`, `SampleChart`, `ComparisonBar` | otlpkit | Generic time-series/comparison visualization. |
+| `TagFilter`, `DateRangeFilter` | otlpkit | Generic series filtering. |
+| Fetch helpers (`fetchIndex`, `fetchSeries`, `fetchRun`, etc.) | otlpkit | Generic HTTP data fetching. |
+| Data transforms (`dataPointsToComparisonData`, `samplesToDataPoints`) | otlpkit | Generic data reshaping. |
 | `Dashboard` | benchkit | Benchmark-focused UI with monitor partitioning, regression detection. |
 | `RunDashboard`, `RunDetail` | benchkit | Benchmark run comparison and detail views. |
 | `RunTable`, `Leaderboard` | mixed | Core logic is generic; label defaults are benchmark-specific. |
@@ -48,8 +48,8 @@ platform (**metrickit**) and the benchmark-specific product layer
 
 | Surface | Owner | Rationale |
 |---|---|---|
-| `actions/monitor` | metrickit | Generic OTel Collector download, start/stop, host metrics. |
-| `actions/emit-metric` | metrickit | Generic OTLP HTTP metric emission. |
+| `actions/monitor` | otlpkit | Generic OTel Collector download, start/stop, host metrics. |
+| `actions/emit-metric` | otlpkit | Generic OTLP HTTP metric emission. |
 | `actions/stash` | benchkit | Benchmark file parsing, result assembly, data-branch push. |
 | `actions/aggregate` | mixed | Generic aggregation logic, but series key computation and `_monitor/` prefix are benchmark-specific. |
 | `actions/compare` | benchkit | Benchmark regression detection and PR commenting. |
@@ -58,11 +58,11 @@ platform (**metrickit**) and the benchmark-specific product layer
 
 | Schema | Owner | Rationale |
 |---|---|---|
-| `index.schema.json` | metrickit | Generic run index structure. |
-| `series.schema.json` | metrickit | Generic time-series structure. |
-| `index-refs.schema.json` | metrickit | Generic ref-based grouping. |
-| `index-prs.schema.json` | metrickit | Generic PR-based grouping. |
-| `index-metrics.schema.json` | metrickit | Generic metric navigation. |
+| `index.schema.json` | otlpkit | Generic run index structure. |
+| `series.schema.json` | otlpkit | Generic time-series structure. |
+| `index-refs.schema.json` | otlpkit | Generic ref-based grouping. |
+| `index-prs.schema.json` | otlpkit | Generic PR-based grouping. |
+| `index-metrics.schema.json` | otlpkit | Generic metric navigation. |
 | `comparison-result.schema.json` | benchkit | Benchmark comparison output. |
 | `view-run-detail.schema.json` | benchkit | Benchmark detail view with metric snapshots. |
 
@@ -81,13 +81,13 @@ These are the coupling points that must be cleanly split before extraction:
    the benchkit default.
 
 3. **`buildOtlpResult()`** — Benchmark-to-OTLP translator lives in `@benchkit/format`.
-   Should move to benchkit-only scope; metrickit should only consume and emit raw OTLP.
+   Should move to benchkit-only scope; otlpkit should only consume and emit raw OTLP.
 
 4. **Label defaults in chart** — `defaultMetricLabel` converts `ns_per_op` → "Throughput",
    assumes `_monitor/` partitioning. These should be injectable, not hardcoded.
 
 5. **Aggregate series key computation** — Currently reads `benchkit.scenario` + sorted
-   tags to build composite series keys. Metrickit should use a generic key strategy
+   tags to build composite series keys. OtlpKit should use a generic key strategy
    (e.g., resource attributes), with benchkit providing the scenario-aware override.
 
 ---
@@ -111,21 +111,21 @@ These are the coupling points that must be cleanly split before extraction:
 
 | New name | Contents |
 |---|---|
-| `@metrickit/core` | OTLP types, `MetricsBatch` (generic), OTLP parsing. |
-| `@metrickit/ui` | Chart primitives, fetch helpers, filters, data transforms. |
+| `@otlpkit/core` | OTLP types, `MetricsBatch` (generic), OTLP parsing. |
+| `@otlpkit/ui` | Chart primitives, fetch helpers, filters, data transforms. |
 
 ### Re-export strategy
 
 `@benchkit/format` and `@benchkit/chart` become thin re-export shims:
-- `@benchkit/format` re-exports `@metrickit/core` plus benchmark parsers, conventions, compare.
-- `@benchkit/chart` re-exports `@metrickit/ui` plus Dashboard, RunDashboard, RunDetail, labels.
+- `@benchkit/format` re-exports `@otlpkit/core` plus benchmark parsers, conventions, compare.
+- `@benchkit/chart` re-exports `@otlpkit/ui` plus Dashboard, RunDashboard, RunDetail, labels.
 
 This means `import { MetricsBatch } from "@benchkit/format"` continues to work.
 
 ### Action re-export
 
 `actions/monitor` and `actions/emit-metric` stay in the benchkit repo for now.
-If a `metrickit` repo is created later, these actions can be published there and
+If a `otlpkit` repo is created later, these actions can be published there and
 the benchkit versions become thin wrappers or aliases.
 
 ---
@@ -136,7 +136,7 @@ the benchkit versions become thin wrappers or aliases.
 
 Run files (`data/runs/{run-id}/benchmark.otlp.json`) contain OTLP with `benchkit.*` attributes. These
 attributes are part of the published data contract and will not be renamed.
-Metrickit will read OTLP generically (ignoring attribute names it doesn't
+OtlpKit will read OTLP generically (ignoring attribute names it doesn't
 know) while benchkit will continue to interpret `benchkit.*` attributes.
 
 ### Schema evolution
@@ -149,25 +149,25 @@ treated as version 1 and remain backward-compatible.
 ## Extraction sequence
 
 ```
-Phase 2 (#179): Extract @metrickit/core from @benchkit/format
-  ├── OTLP types → @metrickit/core
-  ├── MetricsBatch (generic) → @metrickit/core
-  ├── OTLP parsing → @metrickit/core
-  └── @benchkit/format re-exports @metrickit/core
+Phase 2 (#179): Extract @otlpkit/core from @benchkit/format
+  ├── OTLP types → @otlpkit/core
+  ├── MetricsBatch (generic) → @otlpkit/core
+  ├── OTLP parsing → @otlpkit/core
+  └── @benchkit/format re-exports @otlpkit/core
 
-Phase 3 (#180): Extract @metrickit/ui from @benchkit/chart
-  ├── Chart primitives → @metrickit/ui
-  ├── Fetch helpers → @metrickit/ui
-  ├── Filters → @metrickit/ui
-  └── @benchkit/chart re-exports @metrickit/ui
+Phase 3 (#180): Extract @otlpkit/ui from @benchkit/chart
+  ├── Chart primitives → @otlpkit/ui
+  ├── Fetch helpers → @otlpkit/ui
+  ├── Filters → @otlpkit/ui
+  └── @benchkit/chart re-exports @otlpkit/ui
 
 Phase 4 (#181): Decouple aggregation
-  ├── Generic aggregation → @metrickit/core
+  ├── Generic aggregation → @otlpkit/core
   ├── Benchmark aggregation defaults → @benchkit/format
   └── actions/aggregate uses composition
 
 Phase 5 (#182): Release and migration
-  ├── Publish @metrickit/* packages
+  ├── Publish @otlpkit/* packages
   ├── Update docs and demo repo
   └── Announce migration path
 ```
@@ -180,6 +180,6 @@ Phase 5 (#182): Release and migration
 |---|---|
 | Re-export shim, not rename | Zero breaking changes for existing consumers. |
 | `benchkit.*` attributes stay forever | Existing data files depend on them. |
-| Label defaults become injectable | Allows metrickit UI to be domain-agnostic. |
+| Label defaults become injectable | Allows otlpkit UI to be domain-agnostic. |
 | `actions/monitor` stays in benchkit repo | Simpler than creating a new repo now. |
 | Aggregate gets composition, not fork | One codebase with pluggable keys, not two copies. |

--- a/octo11y/docs/vision-and-roadmap.md
+++ b/octo11y/docs/vision-and-roadmap.md
@@ -139,7 +139,7 @@ competitive-first experiences.
 |---|---|---|
 | #179 | Extract `@octo11y/core` package | Done (PR #264) |
 | #180 | Explicit core imports across actions + chart | Done (PR #265) |
-| #189–#193 | Metrickit boundary plan and compatibility shims | Done (PR #263) |
+| #189–#193 | OtlpKit boundary plan and compatibility shims | Done (PR #263) |
 | #182 | Release, docs, and demo migration | In progress |
 | #183 | Epic umbrella | Open (closes when #182 ships) |
 


### PR DESCRIPTION
## Summary

Post-merge cleanup pass after #61:

- renamed legacy doc `metrickit-boundary-plan.md` to `otlpkit-boundary-plan.md`
- updated docs index link to point at the new filename
- updated roadmap wording from "Metrickit" to "OtlpKit" for consistency

## Issue hygiene completed

- closed stale legacy issues: #13, #15, #35
- posted tracker update on #60

## Validation

- `npm run lint`
