### PR TITLE
chore(lint): align biome schema with installed cli

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "files": {
     "includes": [
       "**",


### PR DESCRIPTION
## Summary
- update  schema URL from 2.4.10 to 2.4.11 to match installed Biome CLI
- remove noisy schema-mismatch message from lint/check runs

## Validation
- npm run lint
- npm run check