### PR TITLE
chore(release): bump lockstep packages to 0.2.3

### DIFF
--- a/octo11y/packages/adapters/package.json
+++ b/octo11y/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benchkit/adapters",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Data adapters for transforming benchkit metrics into charting library formats (Chart.js, ECharts, Recharts, D3, etc.).",
   "type": "module",
   "main": "dist/index.js",

--- a/octo11y/packages/chart/package.json
+++ b/octo11y/packages/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benchkit/chart",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Preact components for rendering benchkit benchmark dashboards.",
   "type": "module",
   "main": "dist/index.js",

--- a/octo11y/packages/core/package.json
+++ b/octo11y/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octo11y/core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Generic OTLP metric types, parsing, and data structures for metric storage and visualization.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/octo11y/packages/format/package.json
+++ b/octo11y/packages/format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benchkit/format",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Benchmark result types and format parsers (Go bench, Rust bench, Hyperfine, pytest-benchmark, benchmark-action, OTLP).",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otlpkit/adapters",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Charting-library adapters for otlpkit view frames.",
   "license": "UNLICENSED",
   "engines": {
@@ -57,7 +57,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@otlpkit/views": "^0.1.0"
+    "@otlpkit/views": "^0.2.3"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/otlpjson/package.json
+++ b/packages/otlpjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otlpkit/otlpjson",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "OTLP JSON parsing and iterators for metrics, traces, and logs.",
   "license": "UNLICENSED",
   "engines": {

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otlpkit/query",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Generic telemetry query helpers for otlpkit.",
   "license": "UNLICENSED",
   "engines": {
@@ -31,7 +31,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@otlpkit/otlpjson": "^0.1.0"
+    "@otlpkit/otlpjson": "^0.2.3"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otlpkit/views",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Reusable telemetry view frames for otlpkit.",
   "license": "UNLICENSED",
   "engines": {
@@ -31,8 +31,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@otlpkit/otlpjson": "^0.1.0",
-    "@otlpkit/query": "^0.1.0"
+    "@otlpkit/otlpjson": "^0.2.3",
+    "@otlpkit/query": "^0.2.3"
   },
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
## Summary
- bump lockstep package versions from 0.2.2 to 0.2.3
- update internal otlpkit dependency ranges to 0.2.3

## Validation
- npm run check:release
