### PR TITLE
feat(actions): add resource-attributes to emit-metric and repo-stats

### DIFF
--- a/octo11y/actions/emit-metric/README.md
+++ b/octo11y/actions/emit-metric/README.md
@@ -25,6 +25,9 @@ SDK inside benchmark code.
     attributes: |
       dataset=wiki
       variant=bm25
+    resource-attributes: |
+      team=platform
+      env=production
 ```
 
 The action sends OTLP/HTTP to the collector's `/v1/metrics` endpoint. Benchkit
@@ -43,6 +46,7 @@ inputs are:
 - `series`
 - `direction`
 - `attributes`
+- `resource-attributes`
 - `otlp-http-endpoint`
 
 `scenario` defaults to the metric name, `series` defaults to `GITHUB_JOB` (or

--- a/octo11y/actions/emit-metric/action.yml
+++ b/octo11y/actions/emit-metric/action.yml
@@ -52,6 +52,10 @@ inputs:
     description: "Additional datapoint attributes as JSON object or key=value lines."
     required: false
     default: ""
+  resource-attributes:
+    description: "Additional resource-level attributes as JSON object or key=value lines."
+    required: false
+    default: ""
   run-id:
     description: "Run identifier to stamp on OTLP resource attributes. Defaults to GITHUB_RUN_ID-GITHUB_RUN_ATTEMPT."
     required: false

--- a/octo11y/actions/emit-metric/src/emit-metric.test.ts
+++ b/octo11y/actions/emit-metric/src/emit-metric.test.ts
@@ -86,6 +86,7 @@ describe("buildOtlpMetricPayload", () => {
       direction: "bigger_is_better",
       role: "outcome",
       attributes: { dataset: "wiki" },
+      resourceAttributes: { team: "platform", batch_size: 2000, warm: true },
       runId: "123-1",
       benchkitKind: "hybrid",
       serviceName: "benchkit-selftest",
@@ -110,6 +111,9 @@ describe("buildOtlpMetricPayload", () => {
     assert.ok(resourceAttributes.some((attr) => attr.key === "benchkit.run_id"));
     assert.ok(resourceAttributes.some((attr) => attr.key === "benchkit.kind"));
     assert.ok(resourceAttributes.some((attr) => attr.key === "service.name"));
+    assert.ok(resourceAttributes.some((attr) => attr.key === "team"));
+    assert.ok(resourceAttributes.some((attr) => attr.key === "batch_size"));
+    assert.ok(resourceAttributes.some((attr) => attr.key === "warm"));
 
     const gauge = metrics[0].gauge as { dataPoints: Array<Record<string, unknown>> };
     const dataPoint = gauge.dataPoints[0];
@@ -135,6 +139,7 @@ describe("buildOtlpMetricPayload", () => {
       direction: "bigger_is_better",
       role: "outcome",
       attributes: {},
+      resourceAttributes: {},
       runId: "123-1",
       benchkitKind: "workflow",
     }, new Date("2026-04-02T03:00:00.000Z"));
@@ -161,6 +166,7 @@ describe("buildOtlpMetricPayload", () => {
         direction: "bigger_is_better",
         role: "outcome",
         attributes: { "benchkit.scenario": "oops" },
+        resourceAttributes: {},
         runId: "123-1",
         benchkitKind: "hybrid",
       }),
@@ -182,10 +188,33 @@ describe("buildOtlpMetricPayload", () => {
         direction: "bigger_is_better",
         role: "outcome",
         attributes: { "benchkit.custom.foo": "bar" },
+        resourceAttributes: {},
         runId: "123-1",
         benchkitKind: "hybrid",
       }),
       /Custom attributes must not use the 'benchkit\.' prefix/,
+    );
+  });
+
+  it("rejects resource attributes with benchkit. prefix", () => {
+    assert.throws(
+      () => buildOtlpMetricPayload({
+        endpoint: "http://localhost:4318/v1/metrics",
+        name: "test_score",
+        value: 74,
+        metricKind: "gauge",
+        aggregationTemporality: "cumulative",
+        monotonic: false,
+        scenario: "search",
+        series: "baseline",
+        direction: "bigger_is_better",
+        role: "outcome",
+        attributes: {},
+        resourceAttributes: { "benchkit.team": "platform" },
+        runId: "123-1",
+        benchkitKind: "hybrid",
+      }),
+      /Resource attributes must not use the 'benchkit\.' prefix/,
     );
   });
 });

--- a/octo11y/actions/emit-metric/src/emit-metric.ts
+++ b/octo11y/actions/emit-metric/src/emit-metric.ts
@@ -42,6 +42,7 @@ export interface EmitMetricOptions {
   runId: string;
   benchkitKind: BenchkitKind;
   serviceName?: string;
+  resourceAttributes: Record<string, AttributeValue>;
   ref?: string;
   commit?: string;
   workflow?: string;
@@ -204,6 +205,16 @@ function buildResourceAttributes(options: EmitMetricOptions): OtlpAttribute[] {
   if (options.job) attributes.push(buildAttribute("benchkit.job", options.job));
   if (options.runAttempt) attributes.push(buildAttribute("benchkit.run_attempt", options.runAttempt));
   if (options.serviceName) attributes.push(buildAttribute("service.name", options.serviceName));
+  for (const key of Object.keys(options.resourceAttributes)) {
+    if (key.startsWith("benchkit.")) {
+      throw new Error(
+        `Resource attributes must not use the 'benchkit.' prefix. Got '${key}'.`,
+      );
+    }
+  }
+  for (const [key, value] of Object.entries(options.resourceAttributes)) {
+    attributes.push(buildAttribute(key, value));
+  }
 
   return attributes;
 }
@@ -348,6 +359,7 @@ export async function runEmitMetricAction(): Promise<void> {
   );
   const role = parseBenchkitRole(core.getInput("role") || "outcome");
   const attributes = parseAttributes(core.getInput("attributes") || "");
+  const resourceAttributes = parseAttributes(core.getInput("resource-attributes") || "");
   const runId = core.getInput("run-id").trim() || defaultRunId();
   const benchkitKind = parseBenchkitKind(core.getInput("benchkit-kind") || "hybrid");
   const serviceName = core.getInput("service-name").trim() || process.env.GITHUB_REPOSITORY;
@@ -375,6 +387,7 @@ export async function runEmitMetricAction(): Promise<void> {
     direction,
     role,
     attributes,
+    resourceAttributes,
     runId,
     benchkitKind,
     serviceName,

--- a/octo11y/actions/repo-stats/README.md
+++ b/octo11y/actions/repo-stats/README.md
@@ -21,6 +21,7 @@ drop in one step:
 | `scenario` | no | repo name | Benchkit scenario name for the metrics |
 | `metrics` | no | `all` | Comma-separated list of metrics to collect (see below) |
 | `output-file` | no | `repo-stats.json` | Path to write the OTLP JSON file |
+| `resource-attributes` | no | `""` | Additional OTLP resource attributes as JSON object or key=value lines |
 | `workflow-run-count` | no | `30` | Recent runs to sample for `workflow-success-pct` |
 
 ## Outputs
@@ -127,6 +128,9 @@ jobs:
 - uses: strawgate/octo11y/actions/repo-stats@main-dist
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
+    resource-attributes: |
+      team=platform
+      env=prod
     metrics: stars, forks, contributors, watchers
 ```
 

--- a/octo11y/actions/repo-stats/action.yml
+++ b/octo11y/actions/repo-stats/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: "Path to write the generated OTLP JSON file."
     required: false
     default: "repo-stats.json"
+  resource-attributes:
+    description: "Additional resource-level attributes as JSON object or key=value lines."
+    required: false
+    default: ""
   workflow-run-count:
     description: >-
       Number of recent workflow runs to examine when computing the

--- a/octo11y/actions/repo-stats/src/repo-stats.test.ts
+++ b/octo11y/actions/repo-stats/src/repo-stats.test.ts
@@ -1,6 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseMetricNames, ALL_METRICS, writeOtlpFile, median } from "./repo-stats.js";
+import {
+  parseMetricNames,
+  ALL_METRICS,
+  writeOtlpFile,
+  median,
+  parseResourceAttributes,
+} from "./repo-stats.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -88,6 +94,45 @@ describe("parseMetricNames", () => {
   it("accepts languages", () => {
     const result = parseMetricNames("languages");
     assert.deepStrictEqual(result, ["languages"]);
+  });
+});
+
+// ---- parseResourceAttributes ----------------------------------------------
+
+describe("parseResourceAttributes", () => {
+  it("parses JSON resource attributes with typed values", () => {
+    assert.deepStrictEqual(
+      parseResourceAttributes('{"team":"platform","batch_size":2000,"warm":true}'),
+      {
+        team: "platform",
+        batch_size: 2000,
+        warm: true,
+      },
+    );
+  });
+
+  it("parses key=value lines", () => {
+    assert.deepStrictEqual(
+      parseResourceAttributes("team=platform\nenv=prod"),
+      {
+        team: "platform",
+        env: "prod",
+      },
+    );
+  });
+
+  it("rejects benchkit-prefixed keys", () => {
+    assert.throws(
+      () => parseResourceAttributes("benchkit.team=platform"),
+      /must not use the 'benchkit\.' prefix/,
+    );
+  });
+
+  it("rejects non-object JSON", () => {
+    assert.throws(
+      () => parseResourceAttributes('[1,2,3]'),
+      /must use key=value format/,
+    );
   });
 });
 
@@ -186,6 +231,37 @@ describe("writeOtlpFile", () => {
       const metric = doc.resourceMetrics[0].scopeMetrics[0].metrics[0];
       assert.equal(metric.name, "workflow_success_pct");
       assert.equal(metric.gauge.dataPoints[0].asDouble, 93.3);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes custom resource attributes", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "repo-stats-test-"));
+    const outFile = path.join(tmpDir, "out.json");
+
+    try {
+      writeOtlpFile(
+        {
+          stars: { value: 42, unit: "count", direction: "bigger_is_better" },
+        },
+        "my-repo",
+        outFile,
+        {
+          team: "platform",
+          batch_size: 2000,
+          warm: true,
+        },
+      );
+
+      const doc = JSON.parse(fs.readFileSync(outFile, "utf-8"));
+      const resAttrs = doc.resourceMetrics[0].resource.attributes;
+      const teamAttr = resAttrs.find((a: { key: string }) => a.key === "team");
+      const batchSizeAttr = resAttrs.find((a: { key: string }) => a.key === "batch_size");
+      const warmAttr = resAttrs.find((a: { key: string }) => a.key === "warm");
+      assert.equal(teamAttr?.value?.stringValue, "platform");
+      assert.equal(batchSizeAttr?.value?.intValue, "2000");
+      assert.equal(warmAttr?.value?.boolValue, true);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/octo11y/actions/repo-stats/src/repo-stats.ts
+++ b/octo11y/actions/repo-stats/src/repo-stats.ts
@@ -4,6 +4,8 @@ import { buildOtlpResult } from "@benchkit/format";
 import type { OtlpResultBenchmark, OtlpResultMetric } from "@benchkit/format";
 import * as fs from "node:fs";
 
+type AttributeValue = string | number | boolean;
+
 // ---- Types ----------------------------------------------------------------
 
 export type MetricName =
@@ -105,6 +107,7 @@ export interface RepoStatsOptions {
   metrics: MetricName[];
   outputFile: string;
   workflowRunCount: number;
+  resourceAttributes: Record<string, AttributeValue>;
 }
 
 // ---- Input parsing --------------------------------------------------------
@@ -146,8 +149,19 @@ export function parseOptions(): RepoStatsOptions {
     core.getInput("workflow-run-count") || "30",
     "workflow-run-count",
   );
+  const resourceAttributes = parseResourceAttributes(
+    core.getInput("resource-attributes") || "",
+  );
 
-  return { token, repository, scenario, metrics, outputFile, workflowRunCount };
+  return {
+    token,
+    repository,
+    scenario,
+    metrics,
+    outputFile,
+    workflowRunCount,
+    resourceAttributes,
+  };
 }
 
 function parsePositiveInt(value: string, label: string): number {
@@ -156,6 +170,66 @@ function parsePositiveInt(value: string, label: string): number {
     throw new Error(`${label} must be a positive integer, got "${value}".`);
   }
   return n;
+}
+
+export function parseResourceAttributes(raw: string): Record<string, AttributeValue> {
+  const trimmed = raw.trim();
+  if (!trimmed) return {};
+
+  if (trimmed.startsWith("{")) {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+      throw new Error("resource-attributes JSON must be an object.");
+    }
+    const result: Record<string, AttributeValue> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (!key.trim()) {
+        throw new Error("resource-attributes keys must not be empty.");
+      }
+      if (
+        typeof value !== "string"
+        && typeof value !== "number"
+        && typeof value !== "boolean"
+      ) {
+        throw new Error(
+          `resource-attributes '${key}' must be a string, number, or boolean.`,
+        );
+      }
+      if (key.startsWith("benchkit.")) {
+        throw new Error(
+          `resource-attributes must not use the 'benchkit.' prefix. Got '${key}'.`,
+        );
+      }
+      result[key] = value;
+    }
+    return result;
+  }
+
+  const result: Record<string, AttributeValue> = {};
+  const entries = trimmed
+    .split(/\r?\n/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  for (const entry of entries) {
+    const separator = entry.indexOf("=");
+    if (separator <= 0) {
+      throw new Error(
+        `resource-attributes entry '${entry}' must use key=value format.`,
+      );
+    }
+    const key = entry.slice(0, separator).trim();
+    const value = entry.slice(separator + 1).trim();
+    if (!key) {
+      throw new Error("resource-attributes keys must not be empty.");
+    }
+    if (key.startsWith("benchkit.")) {
+      throw new Error(
+        `resource-attributes must not use the 'benchkit.' prefix. Got '${key}'.`,
+      );
+    }
+    result[key] = value;
+  }
+  return result;
 }
 
 // ---- Metric collectors ----------------------------------------------------
@@ -737,6 +811,7 @@ export function writeOtlpFile(
   metrics: Record<string, OtlpResultMetric>,
   scenario: string,
   outputFile: string,
+  resourceAttributes: Record<string, AttributeValue> = {},
 ): void {
   const benchmark: OtlpResultBenchmark = {
     name: scenario,
@@ -745,7 +820,10 @@ export function writeOtlpFile(
 
   const doc = buildOtlpResult({
     benchmarks: [benchmark],
-    context: { sourceFormat: "otlp" },
+    context: {
+      sourceFormat: "otlp",
+      resourceAttributes,
+    },
   });
 
   fs.writeFileSync(outputFile, JSON.stringify(doc, null, 2));
@@ -761,7 +839,12 @@ export async function runRepoStatsAction(): Promise<void> {
   );
 
   const metrics = await collectMetrics(options);
-  writeOtlpFile(metrics, options.scenario, options.outputFile);
+  writeOtlpFile(
+    metrics,
+    options.scenario,
+    options.outputFile,
+    options.resourceAttributes,
+  );
 
   core.info(`Wrote ${options.outputFile}`);
   core.setOutput("results-file", options.outputFile);

--- a/octo11y/packages/format/src/build-otlp-result.test.ts
+++ b/octo11y/packages/format/src/build-otlp-result.test.ts
@@ -153,6 +153,27 @@ describe("buildOtlpResult", () => {
     assert.equal(findAttr(attrs, ATTR_COMMIT)?.value?.stringValue, "abc123");
   });
 
+  it("merges custom resource attributes from context", () => {
+    const doc = buildOtlpResult({
+      benchmarks: [{ name: "test", metrics: { x: 1 } }],
+      context: {
+        sourceFormat: "go",
+        runId: "run-1",
+        resourceAttributes: {
+          team: "platform",
+          batch_size: 2000,
+          warm: true,
+        },
+      },
+    });
+
+    const attrs = doc.resourceMetrics[0].resource!.attributes!;
+    assert.equal(findAttr(attrs, ATTR_RUN_ID)?.value?.stringValue, "run-1");
+    assert.equal(findAttr(attrs, "team")?.value?.stringValue, "platform");
+    assert.equal(findAttr(attrs, "batch_size")?.value?.intValue, "2000");
+    assert.equal(findAttr(attrs, "warm")?.value?.boolValue, true);
+  });
+
   it("defaults to otlp source format when no context is provided", () => {
     const doc = buildOtlpResult({
       benchmarks: [{ name: "test", metrics: { x: 1 } }],

--- a/octo11y/packages/format/src/build-otlp-result.ts
+++ b/octo11y/packages/format/src/build-otlp-result.ts
@@ -53,6 +53,7 @@ export interface OtlpResultContext {
   runAttempt?: string;
   runner?: string;
   serviceName?: string;
+  resourceAttributes?: Record<string, string | number | boolean>;
 }
 
 export interface BuildOtlpResultOptions {
@@ -96,6 +97,11 @@ function buildResourceAttributes(ctx: OtlpResultContext): OtlpAttribute[] {
   if (ctx.runAttempt) attrs.push(attr(ATTR_RUN_ATTEMPT, ctx.runAttempt));
   if (ctx.runner) attrs.push(attr(ATTR_RUNNER, ctx.runner));
   if (ctx.serviceName) attrs.push(attr(ATTR_SERVICE_NAME, ctx.serviceName));
+  if (ctx.resourceAttributes) {
+    for (const [key, value] of Object.entries(ctx.resourceAttributes)) {
+      attrs.push(attr(key, value));
+    }
+  }
   return attrs;
 }
 


### PR DESCRIPTION
## Summary
- add `resource-attributes` inputs to `actions/emit-metric` and `actions/repo-stats`
- extend `@benchkit/format` `buildOtlpResult` context to merge custom resource attributes
- parse JSON or key=value resource attributes and reject reserved `benchkit.*` keys
- add tests and docs for both actions

Closes #39

## Validation
- npm run check
- npm run octo11y:test
- npm run octo11y:lint
