### PR TITLE
feat(benchkit): shared metrics-dir flow + benchkit-emit CLI

### DIFF
--- a/octo11y/actions/monitor/README.md
+++ b/octo11y/actions/monitor/README.md
@@ -15,10 +15,14 @@ for JS actions, because `@main` does not include compiled action bundles.
   benchmark code can emit custom metrics to the same collector
 - waits for the OTLP HTTP receiver to answer before returning so the next step
   can emit metrics immediately
-- works with `actions/emit-metric` for simple one-off workflow metrics without a
-  full OTLP SDK
+- installs a `benchkit-emit` CLI for one-off workflow metrics without a full
+  OTLP SDK
+- creates a shared metrics directory and exports
+  `BENCHKIT_METRICS_DIR`, `BENCHKIT_RUN_ID`, and `BENCHKIT_EMIT_ENDPOINT`
 - writes a raw OTLP JSONL sidecar (gzipped) to the data branch at
   `data/runs/{run-id}/telemetry.otlp.jsonl.gz`
+- writes a consolidated OTLP JSON document to
+  `${BENCHKIT_METRICS_DIR}/monitor.otlp.json` in the post step
 - filters process metrics to runner-descendant processes before pushing, so the
   stored telemetry stays focused on the benchmark job instead of the whole host
 
@@ -60,20 +64,14 @@ OTLP sidecar to the data branch.
 
 ## Emitting a one-off custom metric
 
-If your workflow only needs to record a single custom score or count, use the
-emit action against the collector endpoint from the monitor step:
+If your workflow only needs to record a custom score or count, use the
+`benchkit-emit` CLI installed by monitor:
 
 ```yaml
 - name: Emit score metric
-  uses: strawgate/octo11y/actions/emit-metric@main-dist
-  with:
-    otlp-http-endpoint: ${{ steps.monitor.outputs.otlp-http-endpoint }}
-    name: test_score
-    value: 74
-    unit: points
-    scenario: search-relevance
-    series: baseline
-    direction: bigger_is_better
+  run: |
+    benchkit-emit --name test_score --value 74 --unit points \
+      --scenario search-relevance --series baseline --direction up
 ```
 
 ## Inputs
@@ -96,6 +94,7 @@ emit action against the collector endpoint from the monitor step:
 |--------|-------------|
 | `otlp-grpc-endpoint` | OTLP gRPC endpoint, e.g. `grpc://localhost:4317` |
 | `otlp-http-endpoint` | OTLP HTTP endpoint, e.g. `http://localhost:4318` |
+| `metrics-dir` | Shared metrics directory, e.g. `${RUNNER_TEMP}/benchkit-metrics` |
 
 ## Stored output
 
@@ -115,6 +114,10 @@ fails instead of overwriting it.
 Benchkit also stamps resource attributes such as `benchkit.run_id`,
 `benchkit.kind=hybrid`, `benchkit.source_format=otlp`, and, when available,
 `benchkit.ref` and `benchkit.commit`.
+
+In addition, monitor writes a consolidated OTLP JSON file to
+`${BENCHKIT_METRICS_DIR}/monitor.otlp.json` so `actions/stash` can merge monitor
+and custom CLI metrics without JSONL conversion glue.
 
 ## How it works
 

--- a/octo11y/actions/monitor/action.yml
+++ b/octo11y/actions/monitor/action.yml
@@ -45,6 +45,8 @@ outputs:
     description: 'OTLP gRPC endpoint (e.g. localhost:4317).'
   otlp-http-endpoint:
     description: 'OTLP HTTP endpoint (e.g. http://localhost:4318).'
+  metrics-dir:
+    description: 'Shared metrics directory for monitor and benchkit-emit outputs.'
 
 runs:
   using: 'node24'

--- a/octo11y/actions/monitor/package.json
+++ b/octo11y/actions/monitor/package.json
@@ -4,13 +4,15 @@
   "private": true,
   "description": "GitHub Action: background system and custom metrics collection via OpenTelemetry Collector.",
   "scripts": {
-    "build": "tsc && ncc build lib/main.js -o dist/main -s && ncc build lib/post.js -o dist/post -s",
-    "test": "tsc && node --test lib/otel-config.test.js lib/otel-start.test.js lib/otel-stop.test.js",
+    "build": "tsc && ncc build lib/main.js -o dist/main -s && ncc build lib/post.js -o dist/post -s && ncc build lib/cli.js -o dist/cli -s",
+    "test": "tsc && node --test lib/cli.test.js lib/otel-config.test.js lib/otel-start.test.js lib/otel-stop.test.js",
     "lint": "tsc --noEmit"
   },
   "dependencies": {
     "@actions/core": "^1.11.0",
+    "@actions/exec": "^1.1.1",
     "@actions/tool-cache": "^2.0.1",
+    "@benchkit/actions-common": "*",
     "@benchkit/format": "*"
   }
 }

--- a/octo11y/actions/monitor/src/cli.test.ts
+++ b/octo11y/actions/monitor/src/cli.test.ts
@@ -1,0 +1,113 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { __test, runCli } from "./cli.js";
+
+function withEnv(name: string, value: string | undefined, fn: () => void): void {
+  const prev = process.env[name];
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = prev;
+    }
+  }
+}
+
+describe("benchkit-emit cli parse", () => {
+  it("parses required args and infers defaults", () => {
+    withEnv("GITHUB_JOB", "bench", () => {
+      const parsed = __test.parseArgs([
+        "--name", "latency_ms",
+        "--value", "42",
+        "--output", "/tmp/out",
+      ]);
+      assert.equal(parsed.name, "latency_ms");
+      assert.equal(parsed.value, 42);
+      assert.equal(parsed.scenario, "latency_ms");
+      assert.equal(parsed.series, "bench");
+      assert.equal(parsed.direction, "smaller_is_better");
+      assert.equal(parsed.outputDir, "/tmp/out");
+    });
+  });
+
+  it("accepts direction aliases", () => {
+    assert.equal(__test.parseDirection("up", "ms"), "bigger_is_better");
+    assert.equal(__test.parseDirection("down", "ops/s"), "smaller_is_better");
+  });
+
+  it("normalizes endpoint suffix", () => {
+    assert.equal(
+      __test.normalizeEndpoint("http://localhost:4318"),
+      "http://localhost:4318/v1/metrics",
+    );
+    assert.equal(
+      __test.normalizeEndpoint("http://localhost:4318/v1/metrics"),
+      "http://localhost:4318/v1/metrics",
+    );
+  });
+});
+
+describe("benchkit-emit cli payload", () => {
+  it("builds payload with benchkit semantic attrs", () => {
+    const parsed = __test.parseArgs([
+      "--name", "bundle_size_bytes",
+      "--value", "1024",
+      "--unit", "bytes",
+      "--direction", "down",
+      "--output", "/tmp/out",
+      "--attribute", "dataset=wiki",
+      "--resource-attribute", "team=platform",
+    ]);
+    const payload = __test.buildPayload(parsed, new Date("2026-04-12T00:00:00.000Z")) as {
+      resourceMetrics: Array<{
+        resource: { attributes: Array<{ key: string; value: Record<string, unknown> }> };
+        scopeMetrics: Array<{ metrics: Array<{ name: string }> }>;
+      }>;
+    };
+
+    const attrs = payload.resourceMetrics[0].resource.attributes;
+    assert.ok(attrs.some((a) => a.key === "benchkit.run_id"));
+    assert.ok(attrs.some((a) => a.key === "benchkit.kind"));
+    assert.ok(attrs.some((a) => a.key === "benchkit.source_format"));
+    assert.ok(attrs.some((a) => a.key === "team"));
+
+    const metric = payload.resourceMetrics[0].scopeMetrics[0].metrics[0];
+    assert.equal(metric.name, "bundle_size_bytes");
+  });
+});
+
+describe("benchkit-emit cli runtime", () => {
+  it("writes OTLP fallback file when output is configured", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "benchkit-emit-test-"));
+    try {
+      await runCli([
+        "--name", "latency_ms",
+        "--value", "17.5",
+        "--output", tmpDir,
+      ]);
+
+      const files = fs
+        .readdirSync(tmpDir)
+        .filter((name) => name.endsWith(".otlp.json"));
+      assert.equal(files.length, 1);
+
+      const doc = JSON.parse(
+        fs.readFileSync(path.join(tmpDir, files[0]), "utf-8"),
+      ) as { resourceMetrics?: unknown[] };
+      assert.ok(Array.isArray(doc.resourceMetrics));
+      assert.ok(doc.resourceMetrics.length > 0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/octo11y/actions/monitor/src/cli.ts
+++ b/octo11y/actions/monitor/src/cli.ts
@@ -1,0 +1,376 @@
+import { inferDirection } from "@benchkit/format";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+type BenchkitDirection = "bigger_is_better" | "smaller_is_better";
+type BenchkitKind = "code" | "workflow" | "hybrid";
+type BenchkitRole = "outcome" | "diagnostic";
+type AttributeValue = string | number | boolean;
+
+type ParsedArgs = {
+  name: string;
+  value: number;
+  unit?: string;
+  scenario: string;
+  series: string;
+  direction: BenchkitDirection;
+  role: BenchkitRole;
+  kind: BenchkitKind;
+  runId: string;
+  endpoint?: string;
+  outputDir?: string;
+  timeoutMs: number;
+  attributes: Record<string, AttributeValue>;
+  resourceAttributes: Record<string, AttributeValue>;
+};
+
+type OtlpAttribute = {
+  key: string;
+  value: {
+    stringValue?: string;
+    intValue?: string;
+    doubleValue?: number;
+    boolValue?: boolean;
+  };
+};
+
+const RESERVED_POINT_ATTRIBUTES = new Set([
+  "benchkit.scenario",
+  "benchkit.series",
+  "benchkit.metric.direction",
+  "benchkit.metric.role",
+]);
+
+function printHelp(): void {
+  console.log(`benchkit-emit — emit a custom OTLP metric via benchkit monitor\n\nUsage:\n  benchkit-emit --name <metric> --value <number> [options]\n\nOptions:\n  --name <name>                    Metric name (required)\n  --value <number>                 Metric value (required)\n  --unit <unit>                    Metric unit (ms, bytes, %, etc.)\n  --scenario <scenario>            Scenario label (default: metric name)\n  --series <series>                Series label (default: GITHUB_JOB or 'default')\n  --direction <dir>                bigger_is_better|smaller_is_better|up|down\n  --role <role>                    outcome|diagnostic (default: outcome)\n  --kind <kind>                    code|workflow|hybrid (default: hybrid)\n  --run-id <id>                    Override run id (default: BENCHKIT_RUN_ID or GITHUB_RUN_ID-attempt)\n  --endpoint <url>                 OTLP HTTP endpoint (default: BENCHKIT_EMIT_ENDPOINT)\n  --output <dir>                   Output directory for *.otlp.json fallback (default: BENCHKIT_METRICS_DIR)\n  --timeout-ms <ms>                HTTP timeout in milliseconds (default: 10000)\n  --attribute <k=v>                Repeatable datapoint attribute\n  --resource-attribute <k=v>       Repeatable resource attribute\n  --help                           Show this help\n\nBehavior:\n  If --endpoint (or BENCHKIT_EMIT_ENDPOINT) is set, emits over HTTP.\n  If no endpoint is set, or emission fails and --output is available, writes an OTLP JSON file.`);
+}
+
+function defaultRunId(): string {
+  const explicit = process.env.BENCHKIT_RUN_ID;
+  if (explicit) return explicit;
+  const runId = process.env.GITHUB_RUN_ID;
+  const attempt = process.env.GITHUB_RUN_ATTEMPT || "1";
+  if (runId) return `${runId}-${attempt}`;
+  return `local-${Date.now()}`;
+}
+
+function parseDirection(raw: string | undefined, fallbackHint: string): BenchkitDirection {
+  if (!raw) return inferDirection(fallbackHint);
+  const normalized = raw.trim().toLowerCase();
+  if (
+    normalized === "bigger_is_better"
+    || normalized === "bigger"
+    || normalized === "up"
+    || normalized === "higher"
+  ) {
+    return "bigger_is_better";
+  }
+  if (
+    normalized === "smaller_is_better"
+    || normalized === "smaller"
+    || normalized === "down"
+    || normalized === "lower"
+  ) {
+    return "smaller_is_better";
+  }
+  throw new Error(
+    `Unsupported direction '${raw}'. Expected bigger_is_better|smaller_is_better|up|down.`,
+  );
+}
+
+function normalizeEndpoint(endpoint: string): string {
+  const trimmed = endpoint.trim().replace(/\/+$/, "");
+  if (!trimmed) {
+    throw new Error("OTLP HTTP endpoint must not be empty.");
+  }
+  return trimmed.endsWith("/v1/metrics") ? trimmed : `${trimmed}/v1/metrics`;
+}
+
+function parseFiniteNumber(name: string, value: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`'${name}' must be a finite number. Received '${value}'.`);
+  }
+  return parsed;
+}
+
+function parsePositiveInteger(name: string, value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`'${name}' must be a positive integer. Received '${value}'.`);
+  }
+  return parsed;
+}
+
+function parseScalar(value: string): AttributeValue {
+  const lowered = value.toLowerCase();
+  if (lowered === "true") return true;
+  if (lowered === "false") return false;
+  const asNumber = Number(value);
+  if (Number.isFinite(asNumber) && value.trim() !== "") {
+    return asNumber;
+  }
+  return value;
+}
+
+function parseKeyValueEntry(entry: string): [string, AttributeValue] {
+  const separator = entry.indexOf("=");
+  if (separator <= 0) {
+    throw new Error(`Attribute '${entry}' must use key=value format.`);
+  }
+  const key = entry.slice(0, separator).trim();
+  const value = entry.slice(separator + 1).trim();
+  if (!key) {
+    throw new Error("Attribute key must not be empty.");
+  }
+  return [key, parseScalar(value)];
+}
+
+function sanitizeFileName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "metric";
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const flags = new Map<string, string[]>();
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--help") {
+      printHelp();
+      process.exit(0);
+    }
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected argument '${token}'. Use --help for usage.`);
+    }
+    const key = token.slice(2);
+    const value = argv[i + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for '--${key}'.`);
+    }
+    i += 1;
+    const existing = flags.get(key) ?? [];
+    existing.push(value);
+    flags.set(key, existing);
+  }
+
+  const requiredSingle = (name: string): string => {
+    const values = flags.get(name) ?? [];
+    if (values.length === 0) {
+      throw new Error(`Missing required argument '--${name}'.`);
+    }
+    return values[values.length - 1].trim();
+  };
+  const optionalSingle = (name: string): string | undefined => {
+    const values = flags.get(name) ?? [];
+    if (values.length === 0) return undefined;
+    return values[values.length - 1].trim();
+  };
+
+  const attributes: Record<string, AttributeValue> = {};
+  for (const raw of flags.get("attribute") ?? []) {
+    const [key, value] = parseKeyValueEntry(raw);
+    attributes[key] = value;
+  }
+
+  const resourceAttributes: Record<string, AttributeValue> = {};
+  for (const raw of flags.get("resource-attribute") ?? []) {
+    const [key, value] = parseKeyValueEntry(raw);
+    resourceAttributes[key] = value;
+  }
+
+  const name = requiredSingle("name");
+  if (!name) {
+    throw new Error("'--name' must not be blank.");
+  }
+  const unit = optionalSingle("unit");
+  const scenario = optionalSingle("scenario") || name;
+  const series = optionalSingle("series") || process.env.GITHUB_JOB || "default";
+  const direction = parseDirection(optionalSingle("direction"), unit || name);
+  const roleInput = optionalSingle("role") || "outcome";
+  if (roleInput !== "outcome" && roleInput !== "diagnostic") {
+    throw new Error(`Unsupported role '${roleInput}'. Expected outcome|diagnostic.`);
+  }
+  const kindInput = optionalSingle("kind") || "hybrid";
+  if (kindInput !== "code" && kindInput !== "workflow" && kindInput !== "hybrid") {
+    throw new Error(`Unsupported kind '${kindInput}'. Expected code|workflow|hybrid.`);
+  }
+
+  return {
+    name,
+    value: parseFiniteNumber("value", requiredSingle("value")),
+    unit,
+    scenario,
+    series,
+    direction,
+    role: roleInput,
+    kind: kindInput,
+    runId: optionalSingle("run-id") || defaultRunId(),
+    endpoint: optionalSingle("endpoint") || process.env.BENCHKIT_EMIT_ENDPOINT,
+    outputDir: optionalSingle("output") || process.env.BENCHKIT_METRICS_DIR,
+    timeoutMs: parsePositiveInteger("timeout-ms", optionalSingle("timeout-ms") || "10000"),
+    attributes,
+    resourceAttributes,
+  };
+}
+
+function toOtlpAttributeValue(value: AttributeValue): OtlpAttribute["value"] {
+  if (typeof value === "boolean") {
+    return { boolValue: value };
+  }
+  if (typeof value === "number") {
+    if (Number.isSafeInteger(value)) {
+      return { intValue: String(value) };
+    }
+    return { doubleValue: value };
+  }
+  return { stringValue: value };
+}
+
+function buildAttribute(key: string, value: AttributeValue): OtlpAttribute {
+  return {
+    key,
+    value: toOtlpAttributeValue(value),
+  };
+}
+
+function validatePointAttributes(attributes: Record<string, AttributeValue>): void {
+  for (const key of Object.keys(attributes)) {
+    if (RESERVED_POINT_ATTRIBUTES.has(key)) {
+      throw new Error(`Attribute '${key}' is reserved. Use a dedicated option instead.`);
+    }
+    if (key.startsWith("benchkit.")) {
+      throw new Error(`Custom attributes must not use the 'benchkit.' prefix. Got '${key}'.`);
+    }
+  }
+}
+
+function validateResourceAttributes(attributes: Record<string, AttributeValue>): void {
+  for (const key of Object.keys(attributes)) {
+    if (key.startsWith("benchkit.")) {
+      throw new Error(`Resource attributes must not use the 'benchkit.' prefix. Got '${key}'.`);
+    }
+  }
+}
+
+function buildPayload(options: ParsedArgs, now: Date = new Date()): Record<string, unknown> {
+  validatePointAttributes(options.attributes);
+  validateResourceAttributes(options.resourceAttributes);
+
+  const timestampNanos = String(BigInt(now.getTime()) * 1_000_000n);
+  const point = {
+    timeUnixNano: timestampNanos,
+    attributes: [
+      buildAttribute("benchkit.scenario", options.scenario),
+      buildAttribute("benchkit.series", options.series),
+      buildAttribute("benchkit.metric.direction", options.direction),
+      buildAttribute("benchkit.metric.role", options.role),
+      ...Object.entries(options.attributes).map(([key, value]) => buildAttribute(key, value)),
+    ],
+    ...(Number.isSafeInteger(options.value)
+      ? { asInt: String(options.value) }
+      : { asDouble: options.value }),
+  };
+
+  return {
+    resourceMetrics: [{
+      resource: {
+        attributes: [
+          buildAttribute("benchkit.run_id", options.runId),
+          buildAttribute("benchkit.kind", options.kind),
+          buildAttribute("benchkit.source_format", "otlp"),
+          ...(process.env.GITHUB_REF ? [buildAttribute("benchkit.ref", process.env.GITHUB_REF)] : []),
+          ...(process.env.GITHUB_SHA ? [buildAttribute("benchkit.commit", process.env.GITHUB_SHA)] : []),
+          ...(process.env.GITHUB_WORKFLOW ? [buildAttribute("benchkit.workflow", process.env.GITHUB_WORKFLOW)] : []),
+          ...(process.env.GITHUB_JOB ? [buildAttribute("benchkit.job", process.env.GITHUB_JOB)] : []),
+          ...(process.env.GITHUB_RUN_ATTEMPT ? [buildAttribute("benchkit.run_attempt", process.env.GITHUB_RUN_ATTEMPT)] : []),
+          ...(process.env.GITHUB_REPOSITORY ? [buildAttribute("service.name", process.env.GITHUB_REPOSITORY)] : []),
+          ...Object.entries(options.resourceAttributes).map(([key, value]) => buildAttribute(key, value)),
+        ],
+      },
+      scopeMetrics: [{
+        scope: { name: "benchkit.emit.cli" },
+        metrics: [{
+          name: options.name,
+          unit: options.unit || undefined,
+          gauge: { dataPoints: [point] },
+        }],
+      }],
+    }],
+  };
+}
+
+async function emitToCollector(endpoint: string, payload: Record<string, unknown>, timeoutMs: number): Promise<void> {
+  const url = normalizeEndpoint(endpoint);
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  if (response.ok) {
+    console.log(`benchkit-emit: emitted metric to ${url}`);
+    return;
+  }
+
+  const body = (await response.text()).trim();
+  throw new Error(
+    `Collector rejected metric emission (${response.status} ${response.statusText})${body ? `: ${body}` : "."}`,
+  );
+}
+
+function writePayloadFile(outputDir: string, metricName: string, payload: Record<string, unknown>): string {
+  const fileName = `emit-${sanitizeFileName(metricName)}-${Date.now()}.otlp.json`;
+  const outputPath = path.join(outputDir, fileName);
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(payload, null, 2)}\n`, "utf-8");
+  return outputPath;
+}
+
+export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
+  const args = parseArgs(argv);
+  const payload = buildPayload(args);
+
+  if (!args.endpoint && !args.outputDir) {
+    throw new Error(
+      "No endpoint or output directory available. Set --endpoint/--output or BENCHKIT_EMIT_ENDPOINT/BENCHKIT_METRICS_DIR.",
+    );
+  }
+
+  if (args.endpoint) {
+    try {
+      await emitToCollector(args.endpoint, payload, args.timeoutMs);
+      return;
+    } catch (err) {
+      if (!args.outputDir) {
+        throw err;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`benchkit-emit: HTTP emit failed (${message}); writing OTLP file fallback.`);
+    }
+  }
+
+  if (!args.outputDir) {
+    throw new Error("No output directory available for OTLP fallback file.");
+  }
+  const outputPath = writePayloadFile(args.outputDir, args.name, payload);
+  console.log(`benchkit-emit: wrote ${outputPath}`);
+}
+
+if (require.main === module) {
+  runCli().catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`benchkit-emit: ${message}`);
+    process.exitCode = 1;
+  });
+}
+
+export const __test = {
+  buildPayload,
+  parseArgs,
+  parseDirection,
+  normalizeEndpoint,
+};

--- a/octo11y/actions/monitor/src/cli.ts
+++ b/octo11y/actions/monitor/src/cli.ts
@@ -323,7 +323,8 @@ async function emitToCollector(endpoint: string, payload: Record<string, unknown
 }
 
 function writePayloadFile(outputDir: string, metricName: string, payload: Record<string, unknown>): string {
-  const fileName = `emit-${sanitizeFileName(metricName)}-${Date.now()}.otlp.json`;
+  const nonce = Math.random().toString(36).slice(2, 8);
+  const fileName = `emit-${sanitizeFileName(metricName)}-${Date.now()}-${nonce}.otlp.json`;
   const outputPath = path.join(outputDir, fileName);
   fs.mkdirSync(outputDir, { recursive: true });
   fs.writeFileSync(outputPath, `${JSON.stringify(payload, null, 2)}\n`, "utf-8");

--- a/octo11y/actions/monitor/src/otel-start.test.ts
+++ b/octo11y/actions/monitor/src/otel-start.test.ts
@@ -1,10 +1,15 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import * as http from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
   downloadUrl,
+  installBenchkitEmitCli,
   platformArch,
   resolveMetricSetsInput,
+  resolveMetricsDir,
   resolveProfile,
   resolveRunId,
   validatePort,
@@ -179,6 +184,38 @@ describe("resolveRunId", () => {
     } finally {
       if (savedId !== undefined) process.env.GITHUB_RUN_ID = savedId;
       else delete process.env.GITHUB_RUN_ID;
+    }
+  });
+});
+
+describe("resolveMetricsDir", () => {
+  it("uses RUNNER_TEMP when available", () => {
+    const prev = process.env.RUNNER_TEMP;
+    process.env.RUNNER_TEMP = "/tmp/benchkit-test";
+    try {
+      assert.equal(resolveMetricsDir(), "/tmp/benchkit-test/benchkit-metrics");
+    } finally {
+      if (prev === undefined) delete process.env.RUNNER_TEMP;
+      else process.env.RUNNER_TEMP = prev;
+    }
+  });
+});
+
+describe("installBenchkitEmitCli", () => {
+  it("creates a runnable wrapper command", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "benchkit-cli-bin-"));
+    try {
+      installBenchkitEmitCli("/tmp/fake-cli.js", tempDir);
+      if (process.platform === "win32") {
+        assert.ok(fs.existsSync(path.join(tempDir, "benchkit-emit.cmd")));
+      } else {
+        const wrapper = path.join(tempDir, "benchkit-emit");
+        assert.ok(fs.existsSync(wrapper));
+        const mode = fs.statSync(wrapper).mode & 0o777;
+        assert.equal(mode, 0o755);
+      }
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });
 });

--- a/octo11y/actions/monitor/src/otel-start.ts
+++ b/octo11y/actions/monitor/src/otel-start.ts
@@ -19,6 +19,7 @@ import {
 import type { MonitorProfile, OtelState } from "./types.js";
 
 const STATE_NAME = ".benchkit-otel.state.json";
+const BENCHKIT_METRICS_DIR_NAME = "benchkit-metrics";
 const DEFAULT_METRIC_SETS = ["cpu", "memory", "load", "process"];
 const CI_PROFILE_DEFAULT_METRIC_SETS = ["cpu", "memory", "load", "process"];
 
@@ -124,6 +125,41 @@ export function resolveRunId(): string {
   return `local-${Date.now()}`;
 }
 
+export function resolveMetricsDir(): string {
+  return path.join(runnerTemp(), BENCHKIT_METRICS_DIR_NAME);
+}
+
+function resolveEmitEndpoint(port: number): string {
+  return `http://localhost:${port}/v1/metrics`;
+}
+
+function resolveBenchkitEmitCliEntry(): string {
+  // ncc build layout
+  const distEntry = path.join(__dirname, "..", "cli", "index.js");
+  if (fs.existsSync(distEntry)) return distEntry;
+  // tsc test layout
+  const libEntry = path.join(__dirname, "cli.js");
+  if (fs.existsSync(libEntry)) return libEntry;
+  return distEntry;
+}
+
+export function installBenchkitEmitCli(
+  cliEntry: string,
+  binDir: string = path.join(runnerTemp(), "benchkit-bin"),
+): string {
+  fs.mkdirSync(binDir, { recursive: true });
+  if (process.platform === "win32") {
+    const cmdPath = path.join(binDir, "benchkit-emit.cmd");
+    fs.writeFileSync(cmdPath, `@echo off\r\nnode "${cliEntry}" %*\r\n`, { encoding: "utf-8" });
+  } else {
+    const shellPath = path.join(binDir, "benchkit-emit");
+    fs.writeFileSync(shellPath, `#!/usr/bin/env bash\nnode "${cliEntry}" "$@"\n`, { encoding: "utf-8" });
+    fs.chmodSync(shellPath, 0o755);
+  }
+  core.addPath(binDir);
+  return binDir;
+}
+
 export async function waitForOtlpHttpReady(
   port: number,
   timeoutMs: number,
@@ -158,8 +194,10 @@ export async function startOtelCollector(): Promise<void> {
   const otlpHttpPort = validatePort("otlp-http-port", core.getInput("otlp-http-port") || "4318");
   const dataBranch = core.getInput("data-branch") || DEFAULT_DATA_BRANCH;
   const runId = resolveRunId();
+  const metricsDir = resolveMetricsDir();
 
   const metricSets = validateMetricSets(metricSetsRaw);
+  fs.mkdirSync(metricsDir, { recursive: true });
 
   // Record the runner worker PID (our parent) so the post step can
   // filter process metrics to only runner descendants. This works
@@ -204,7 +242,7 @@ export async function startOtelCollector(): Promise<void> {
   }
 
   // Wait for the OTLP HTTP port to be ready before returning.
-  // The collector takes ~500ms-1s to bind on a cold start, so emit-metric
+  // The collector takes ~500ms-1s to bind on a cold start, so benchkit-emit
   // calls in the immediately following step would otherwise hit ECONNREFUSED.
   if (otlpHttpPort > 0) {
     const ready = await waitForOtlpHttpReady(otlpHttpPort, 15_000);
@@ -215,12 +253,18 @@ export async function startOtelCollector(): Promise<void> {
     }
   }
 
+  const emitEndpoint = resolveEmitEndpoint(otlpHttpPort);
+  const cliEntry = resolveBenchkitEmitCliEntry();
+  const binDir = installBenchkitEmitCli(cliEntry);
+  core.info(`benchkit-emit CLI installed to ${binDir}`);
+
   // Write state for the post step
   const state: OtelState = {
     pid: child.pid,
     configPath,
     outputPath,
     logPath,
+    metricsDir,
     startTime: Date.now(),
     runId,
     dataBranch,
@@ -240,6 +284,11 @@ export async function startOtelCollector(): Promise<void> {
   if (otlpHttpPort > 0) {
     core.setOutput("otlp-http-endpoint", `http://localhost:${otlpHttpPort}`);
   }
+  core.setOutput("metrics-dir", metricsDir);
+
+  core.exportVariable("BENCHKIT_METRICS_DIR", metricsDir);
+  core.exportVariable("BENCHKIT_RUN_ID", runId);
+  core.exportVariable("BENCHKIT_EMIT_ENDPOINT", emitEndpoint);
 
   core.info(
     `OTel Collector started (PID ${child.pid}, scrape interval ${scrapeInterval}, profile ${profile})`,
@@ -247,4 +296,5 @@ export async function startOtelCollector(): Promise<void> {
   core.info(`Enabled metric sets: ${metricSets.join(", ") || "(none)"}`);
   if (otlpGrpcPort > 0) core.info(`OTLP gRPC endpoint: grpc://localhost:${otlpGrpcPort}`);
   if (otlpHttpPort > 0) core.info(`OTLP HTTP endpoint: http://localhost:${otlpHttpPort}`);
+  core.info(`Shared metrics dir: ${metricsDir}`);
 }

--- a/octo11y/actions/monitor/src/otel-stop.test.ts
+++ b/octo11y/actions/monitor/src/otel-stop.test.ts
@@ -5,12 +5,14 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { spawn } from "node:child_process";
 import {
+  consolidateJsonl,
   filterToRunnerDescendants,
   findDescendantPids,
   isProcessRunning,
   safeUnlink,
   stopCollector,
   suppressExpectedCiNoise,
+  writeMonitorMetricsDoc,
 } from "./otel-stop.js";
 import type { OtelState } from "./types.js";
 
@@ -77,6 +79,43 @@ describe("suppressExpectedCiNoise", () => {
   });
 });
 
+describe("consolidateJsonl", () => {
+  it("merges resourceMetrics across JSONL lines", () => {
+    const content = [
+      JSON.stringify({ resourceMetrics: [{ resource: { attributes: [] }, scopeMetrics: [] }] }),
+      JSON.stringify({ resourceMetrics: [{ resource: { attributes: [] }, scopeMetrics: [] }] }),
+    ].join("\n");
+    const doc = consolidateJsonl(content);
+    assert.equal(doc.resourceMetrics.length, 2);
+  });
+
+  it("ignores malformed JSON lines", () => {
+    const content = [
+      "not-json",
+      JSON.stringify({ resourceMetrics: [{ resource: { attributes: [] }, scopeMetrics: [] }] }),
+    ].join("\n");
+    const doc = consolidateJsonl(content);
+    assert.equal(doc.resourceMetrics.length, 1);
+  });
+});
+
+describe("writeMonitorMetricsDoc", () => {
+  it("writes monitor.otlp.json in the metrics directory", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "otel-monitor-doc-"));
+    try {
+      const outputPath = writeMonitorMetricsDoc(
+        tmpDir,
+        JSON.stringify({ resourceMetrics: [{ resource: { attributes: [] }, scopeMetrics: [] }] }),
+      );
+      assert.equal(path.basename(outputPath), "monitor.otlp.json");
+      const parsed = JSON.parse(fs.readFileSync(outputPath, "utf-8")) as { resourceMetrics: unknown[] };
+      assert.equal(parsed.resourceMetrics.length, 1);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
 // ── stopCollector ───────────────────────────────────────────────────
 
 describe("stopCollector", () => {
@@ -86,6 +125,7 @@ describe("stopCollector", () => {
       configPath: "/tmp/fake-config.yaml",
       outputPath: "/tmp/fake-output.jsonl",
       logPath: "/tmp/fake-otelcol.log",
+      metricsDir: "/tmp/fake-metrics-dir",
       startTime: Date.now(),
       runId: "test-1",
       dataBranch: "bench-data",
@@ -107,6 +147,7 @@ describe("stopCollector", () => {
       configPath: "/tmp/fake-config.yaml",
       outputPath: "/tmp/fake-output.jsonl",
       logPath: "/tmp/fake-otelcol.log",
+      metricsDir: "/tmp/fake-metrics-dir",
       startTime: Date.now(),
       runId: "test-2",
       dataBranch: "bench-data",

--- a/octo11y/actions/monitor/src/otel-stop.ts
+++ b/octo11y/actions/monitor/src/otel-stop.ts
@@ -7,11 +7,17 @@
  */
 
 import * as core from "@actions/core";
+import * as exec from "@actions/exec";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { gzipSync } from "node:zlib";
-import { execFileSync } from "node:child_process";
+import {
+  checkoutDataBranch,
+  configureGit,
+  pushWithRetry,
+} from "@benchkit/actions-common";
+import { DEFAULT_PUSH_RETRY_COUNT, type OtlpMetricsDocument } from "@octo11y/core";
 import type { OtelState } from "./types.js";
 
 export function isProcessRunning(pid: number): boolean {
@@ -99,14 +105,6 @@ export async function stopCollector(state: OtelState): Promise<void> {
   } catch {
     // already gone
   }
-}
-
-function git(args: string[], cwd?: string, timeout = 30_000): string {
-  return execFileSync("git", args, {
-    cwd,
-    encoding: "utf-8",
-    timeout,
-  }).trim();
 }
 
 /**
@@ -230,7 +228,32 @@ export function filterToRunnerDescendants(
   return { filtered: outputLines.join("\n") + "\n", kept, removed };
 }
 
-function pushTelemetryToDataBranch(state: OtelState): void {
+export function consolidateJsonl(content: string): OtlpMetricsDocument {
+  const resourceMetrics: NonNullable<OtlpMetricsDocument["resourceMetrics"]> = [];
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+    let parsed: { resourceMetrics?: OtlpMetricsDocument["resourceMetrics"] };
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (Array.isArray(parsed.resourceMetrics)) {
+      resourceMetrics.push(...parsed.resourceMetrics);
+    }
+  }
+  return { resourceMetrics };
+}
+
+export function writeMonitorMetricsDoc(metricsDir: string, content: string): string {
+  const monitorDocPath = path.join(metricsDir, "monitor.otlp.json");
+  fs.mkdirSync(metricsDir, { recursive: true });
+  const doc = consolidateJsonl(content);
+  fs.writeFileSync(monitorDocPath, `${JSON.stringify(doc, null, 2)}\n`);
+  return monitorDocPath;
+}
+
+async function pushTelemetryToDataBranch(state: OtelState): Promise<void> {
   if (!fs.existsSync(state.outputPath)) {
     core.warning("No telemetry output file found — nothing to push.");
     return;
@@ -253,60 +276,10 @@ function pushTelemetryToDataBranch(state: OtelState): void {
   }
   core.setSecret(token);
 
-  const workspace = process.env.GITHUB_WORKSPACE;
-  if (!workspace) {
-    core.warning("GITHUB_WORKSPACE not set — skipping data branch push.");
-    return;
-  }
-
-  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
-
-  // Use a temporary worktree to commit to the data branch without
-  // disturbing the main checkout.
-  const worktreePath = path.join(
-    process.env.RUNNER_TEMP || os.tmpdir(),
-    "benchkit-data-worktree",
-  );
-
-  // Clean up any leftover worktree from a previous run
-  if (fs.existsSync(worktreePath)) {
-    try {
-      git(["worktree", "remove", "--force", worktreePath], workspace);
-    } catch {
-      fs.rmSync(worktreePath, { recursive: true, force: true });
-    }
-  }
+  await configureGit(token);
+  const worktreePath = await checkoutDataBranch(state.dataBranch, "benchkit-monitor");
 
   try {
-    // Configure git auth
-    git(
-      ["config", "--local", `http.${serverUrl}/.extraheader`,
-       `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString("base64")}`],
-      workspace,
-    );
-
-    // Fetch the data branch (or create it as an orphan)
-    let branchExists = false;
-    try {
-      git(["fetch", "origin", state.dataBranch, "--depth=1"], workspace);
-      branchExists = true;
-    } catch {
-      // branch does not exist yet
-    }
-
-    if (branchExists) {
-      git(
-        ["worktree", "add", worktreePath, `origin/${state.dataBranch}`],
-        workspace,
-      );
-      // Detach from remote tracking and create local branch
-      git(["checkout", "-B", state.dataBranch], worktreePath);
-    } else {
-      git(["worktree", "add", "--detach", worktreePath], workspace);
-      git(["checkout", "--orphan", state.dataBranch], worktreePath);
-      git(["rm", "-rf", "."], worktreePath);
-    }
-
     // Write telemetry file (gzipped)
     const telemetryDir = path.join(worktreePath, "data", "runs", state.runId);
     fs.mkdirSync(telemetryDir, { recursive: true });
@@ -321,76 +294,14 @@ function pushTelemetryToDataBranch(state: OtelState): void {
     const compressed = gzipSync(raw);
     fs.writeFileSync(targetPath, compressed);
 
-    // Commit and push
-    git(["add", targetPath], worktreePath);
-
-    // Check if there are changes to commit
-    try {
-      git(["diff", "--cached", "--quiet"], worktreePath);
-      core.info("No changes to commit.");
-      return;
-    } catch {
-      // diff --quiet exits non-zero if there are staged changes — good
-    }
-
-    git(
-      [
-        "-c", "user.name=benchkit[bot]",
-        "-c", "user.email=benchkit[bot]@users.noreply.github.com",
-        "commit", "-m", `telemetry: store run ${state.runId}`,
-      ],
-      worktreePath,
-    );
-
-    // Retry push up to 3 times with rebase to handle concurrent pushes
-    let pushed = false;
-    for (let attempt = 1; attempt <= 3; attempt++) {
-      try {
-        git(["push", "origin", state.dataBranch], worktreePath, 120_000);
-        core.info(`Telemetry pushed to ${state.dataBranch} for run ${state.runId}`);
-        pushed = true;
-        break;
-      } catch (err) {
-        if (attempt === 3) {
-          throw err; // Fail after 3 attempts
-        }
-        core.info(`Push attempt ${attempt} failed, rebasing and retrying...`);
-        try {
-          // Fetch latest and rebase
-          git(["fetch", "origin", state.dataBranch, "--depth=1"], workspace);
-          git(["rebase", `origin/${state.dataBranch}`], worktreePath);
-          // Re-stage and re-commit after rebase
-          git(["add", targetPath], worktreePath);
-          git(
-            [
-              "-c", "user.name=benchkit[bot]",
-              "-c", "user.email=benchkit[bot]@users.noreply.github.com",
-              "commit", "--allow-empty", "-m", `telemetry: store run ${state.runId}`,
-            ],
-            worktreePath,
-          );
-        } catch (rebaseErr) {
-          core.warning(`Rebase failed: ${rebaseErr instanceof Error ? rebaseErr.message : String(rebaseErr)}`);
-          throw err; // Throw original push error if rebase fails
-        }
-      }
-    }
-    if (!pushed) {
-      throw new Error("Failed to push telemetry after retries");
-    }
+    await exec.exec("git", ["-C", worktreePath, "add", targetPath]);
+    await exec.exec("git", ["-C", worktreePath, "commit", "-m", `telemetry: store run ${state.runId}`]);
+    await pushWithRetry(worktreePath, state.dataBranch, DEFAULT_PUSH_RETRY_COUNT);
+    core.info(`Telemetry pushed to ${state.dataBranch} for run ${state.runId}`);
   } finally {
-    // Clean up git auth header
-    try {
-      git(["config", "--local", "--unset", `http.${serverUrl}/.extraheader`], workspace);
-    } catch {
-      // best effort
-    }
-    // Clean up worktree
-    try {
-      git(["worktree", "remove", "--force", worktreePath], workspace);
-    } catch {
-      // best effort
-    }
+    await exec.exec("git", ["worktree", "remove", worktreePath, "--force"], {
+      ignoreReturnCode: true,
+    });
   }
 }
 
@@ -418,6 +329,7 @@ export async function stopOtelCollector(): Promise<void> {
 
   const profile = state.profile ?? "default";
   let suppressedCollectorLogLines = 0;
+  const metricsDir = state.metricsDir || path.join(process.env.RUNNER_TEMP || os.tmpdir(), "benchkit-metrics");
 
   // Dump collector logs for diagnostics
   if (state.logPath && fs.existsSync(state.logPath)) {
@@ -440,18 +352,22 @@ export async function stopOtelCollector(): Promise<void> {
     }
   }
 
-  // Filter process metrics to only runner descendants
-  if (state.runnerPpid && fs.existsSync(state.outputPath)) {
-    const raw = fs.readFileSync(state.outputPath, "utf-8");
-    const { filtered, kept, removed } = filterToRunnerDescendants(raw, state.runnerPpid);
-    fs.writeFileSync(state.outputPath, filtered);
-    core.info(
-      `Filtered processes: ${kept} resources kept, ${removed} non-runner resources removed`,
-    );
+  if (fs.existsSync(state.outputPath)) {
+    let telemetryContent = fs.readFileSync(state.outputPath, "utf-8");
+    if (state.runnerPpid) {
+      const { filtered, kept, removed } = filterToRunnerDescendants(telemetryContent, state.runnerPpid);
+      telemetryContent = filtered;
+      fs.writeFileSync(state.outputPath, telemetryContent);
+      core.info(
+        `Filtered processes: ${kept} resources kept, ${removed} non-runner resources removed`,
+      );
+    }
+    const monitorDocPath = writeMonitorMetricsDoc(metricsDir, telemetryContent);
+    core.info(`Wrote consolidated monitor metrics: ${monitorDocPath}`);
   }
 
   try {
-    pushTelemetryToDataBranch(state);
+    await pushTelemetryToDataBranch(state);
   } catch (err) {
     core.warning(`Failed to push telemetry: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/octo11y/actions/monitor/src/types.ts
+++ b/octo11y/actions/monitor/src/types.ts
@@ -8,6 +8,7 @@ export interface OtelState {
   configPath: string;
   outputPath: string;
   logPath: string;
+  metricsDir: string;
   startTime: number;
   runId: string;
   dataBranch: string;

--- a/octo11y/actions/stash/README.md
+++ b/octo11y/actions/stash/README.md
@@ -11,6 +11,8 @@ that later aggregation and comparison steps have a stable history to work with.
   OTLP metrics document
 - optionally merges monitor context produced by `actions/monitor` into the
   stored result
+- optionally merges `*.otlp.json` files from a shared metrics directory
+  (defaults to `BENCHKIT_METRICS_DIR`)
 - writes the result to `data/runs/{run-id}/benchmark.otlp.json` on the data branch
 - retries the push with an automatic rebase so concurrent matrix jobs do not
   race each other
@@ -37,19 +39,20 @@ jobs:
         with:
           results: bench.txt
           format: go
-          monitor-results: monitor.json
+          metrics-dir: ${{ steps.monitor.outputs.metrics-dir }}
 ```
 
 ## Inputs
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `results` | **yes** | — | Path or glob pattern to benchmark result file(s). |
+| `results` | no | — | Path or glob pattern to benchmark result file(s). |
 | `format` | no | `auto` | Input format: `auto`, `go`, `rust`, `hyperfine`, `pytest-benchmark`, `benchmark-action`, or `otlp`. |
 | `data-branch` | no | `bench-data` | Branch used for benchmark data storage. |
 | `github-token` | no | `${{ github.token }}` | Token with push access to the repository. |
 | `run-id` | no | `{GITHUB_RUN_ID}-{GITHUB_RUN_ATTEMPT}--{GITHUB_JOB}` | Custom run identifier. Defaults to a value that is collision-proof across concurrent jobs. For matrix jobs, supply a value that includes the matrix key so each variant writes a distinct file. |
 | `monitor-results` | no | — | Path to `monitor.json` produced by `actions/monitor`. When provided, monitor benchmarks and context are merged into the stored result. |
+| `metrics-dir` | no | `BENCHKIT_METRICS_DIR` | Directory to scan for `*.otlp.json` files (for example monitor + `benchkit-emit` output files). |
 | `commit-results` | no | `true` | When `false`, parse and output the result JSON but do not commit it to the data branch. |
 | `summary` | no | `true` | When `true`, write a parsed benchmark summary to `GITHUB_STEP_SUMMARY`. |
 
@@ -80,8 +83,8 @@ attributes are merged in before writing.
 
 1. **Parse**: glob-expand `results`, parse every matched file using the
    requested (or auto-detected) format, and merge into a single result document
-2. **Merge** *(optional)*: if `monitor-results` is set, read the monitor output and
-   merge its benchmarks and context into the result
+2. **Merge** *(optional)*: merge `monitor-results` and all `*.otlp.json` files in
+   `metrics-dir` (or `BENCHKIT_METRICS_DIR`) into the result
 3. **Push**: checkout (or create) the data branch in a temporary git worktree,
    write the result file, commit, and push — retrying up to five times with a
    randomized backoff and automatic rebase on conflict

--- a/octo11y/actions/stash/action.yml
+++ b/octo11y/actions/stash/action.yml
@@ -3,7 +3,8 @@ description: 'Parse benchmark results and commit them to a data branch.'
 inputs:
   results:
     description: 'Path or glob pattern to benchmark result file(s).'
-    required: true
+    required: false
+    default: ''
   format:
     description: 'Input format: auto (default), go, rust, hyperfine, pytest-benchmark, benchmark-action, or otlp.'
     required: false
@@ -29,6 +30,10 @@ inputs:
   monitor-results:
     description: 'Path to monitor.json produced by the monitor action. When provided, monitor benchmarks and context are merged into the stored result.'
     required: false
+  metrics-dir:
+    description: 'Directory containing *.otlp.json files to merge (defaults to BENCHKIT_METRICS_DIR when empty).'
+    required: false
+    default: ''
   commit-results:
     description: 'When false, parse and output the result JSON but do not commit it to the data branch.'
     required: false

--- a/octo11y/actions/stash/src/main.ts
+++ b/octo11y/actions/stash/src/main.ts
@@ -10,6 +10,7 @@ import {
   formatResultSummaryMarkdown,
   getEmptyBenchmarksWarning,
   parseBenchmarkFiles,
+  readMetricsDir,
   readMonitorOutput,
   writeResultFile,
 } from "./stash.js";
@@ -26,12 +27,14 @@ import {
 import { DEFAULT_PUSH_RETRY_COUNT } from "@octo11y/core";
 
 async function run(): Promise<void> {
-  const resultsPattern = core.getInput("results", { required: true });
+  const resultsPattern = core.getInput("results").trim();
   const format = (core.getInput("format") || "auto") as Format;
   const dataBranch = core.getInput("data-branch") || DEFAULT_DATA_BRANCH;
   const token = core.getInput("github-token", { required: true });
 
   const monitorPath = core.getInput("monitor-results") || "";
+  const metricsDirInput = core.getInput("metrics-dir").trim();
+  const metricsDir = metricsDirInput || process.env.BENCHKIT_METRICS_DIR || "";
 
   const commitResultsInputRaw = core.getInput("commit-results");
   let saveDataFile = true;
@@ -49,25 +52,37 @@ async function run(): Promise<void> {
     githubJob: process.env.GITHUB_JOB,
   });
 
-  // Parse benchmark files
-  const globber = await glob.create(resultsPattern);
-  const files = await globber.glob();
-  if (files.length === 0) {
-    throw new Error(`No files matched pattern: ${resultsPattern}`);
-  }
-  core.info(`Found ${files.length} result file(s)`);
-  const benchmarkDoc = parseBenchmarkFiles(files, format);
-  const emptyBenchmarksWarning = getEmptyBenchmarksWarning(benchmarkDoc);
-  if (emptyBenchmarksWarning) {
-    core.warning(emptyBenchmarksWarning);
+  let benchmarkDoc: ReturnType<typeof parseBenchmarkFiles> | undefined;
+  if (resultsPattern) {
+    const globber = await glob.create(resultsPattern);
+    const files = await globber.glob();
+    if (files.length === 0) {
+      throw new Error(`No files matched pattern: ${resultsPattern}`);
+    }
+    core.info(`Found ${files.length} result file(s)`);
+    benchmarkDoc = parseBenchmarkFiles(files, format);
+    const emptyBenchmarksWarning = getEmptyBenchmarksWarning(benchmarkDoc);
+    if (emptyBenchmarksWarning) {
+      core.warning(emptyBenchmarksWarning);
+    }
+  } else {
+    core.info("No benchmark results pattern provided; relying on monitor/metrics-dir inputs.");
   }
 
   // Merge monitor output if provided
   const monitorDoc = monitorPath ? readMonitorOutput(monitorPath) : undefined;
+  const metricsDirDoc = metricsDir ? readMetricsDir(metricsDir) : undefined;
+
+  if (!benchmarkDoc && !monitorDoc && !metricsDirDoc) {
+    throw new Error(
+      "No data sources provided. Set 'results' or provide 'monitor-results' / 'metrics-dir' inputs.",
+    );
+  }
 
   const result = buildResult({
     benchmarkDoc,
     monitorDoc,
+    metricsDirDoc,
     context: {
       commit: process.env.GITHUB_SHA,
       ref: process.env.GITHUB_REF,
@@ -79,10 +94,13 @@ async function run(): Promise<void> {
   });
 
   const batch = MetricsBatch.fromOtlp(result);
-  const monitorCount = monitorDoc
-    ? MetricsBatch.fromOtlp(monitorDoc).size
-    : 0;
-  core.info(`Parsed ${batch.withoutMonitor().size} benchmark metric(s)${monitorCount ? ` + ${monitorCount} monitor metric(s)` : ""}`);
+  const monitorCount = monitorDoc ? MetricsBatch.fromOtlp(monitorDoc).size : 0;
+  const metricsDirCount = metricsDirDoc ? MetricsBatch.fromOtlp(metricsDirDoc).size : 0;
+  core.info(
+    `Parsed ${batch.withoutMonitor().size} benchmark metric(s)`
+    + `${monitorCount ? ` + ${monitorCount} monitor metric(s)` : ""}`
+    + `${metricsDirCount ? ` + ${metricsDirCount} metrics-dir metric(s)` : ""}`,
+  );
 
   const tempResultPath = createTempResultPath(runId);
   writeResultFile(result, runId, tempResultPath);

--- a/octo11y/actions/stash/src/stash.test.ts
+++ b/octo11y/actions/stash/src/stash.test.ts
@@ -11,6 +11,7 @@ import {
   getEmptyBenchmarksWarning,
   parseBenchmarkFiles,
   parseBenchmarks,
+  readMetricsDir,
   readMonitorOutput,
   writeResultFile,
 } from "./stash.js";
@@ -139,6 +140,21 @@ describe("buildResult", () => {
     assert.ok(scenarios.includes("_monitor/system"));
   });
 
+  it("merges metrics-dir document", () => {
+    const metricsDirDoc = buildOtlpResult({
+      benchmarks: [{ name: "workflow", metrics: { bundle_size_bytes: { value: 1024 } } }],
+      context: { sourceFormat: "otlp" },
+    });
+    const result = buildResult({
+      benchmarkDoc: baseBenchmarkDoc,
+      metricsDirDoc,
+      context: baseContext,
+    });
+    const batch = MetricsBatch.fromOtlp(result);
+    assert.equal(batch.size, 2);
+    assert.ok(batch.metricNames.includes("bundle_size_bytes"));
+  });
+
   it("does not mutate input document", () => {
     const inputDoc = buildOtlpResult({
       benchmarks: [{ name: "BenchA", metrics: { m: { value: 1 } } }],
@@ -164,6 +180,13 @@ describe("buildResult", () => {
     });
     const batch = MetricsBatch.fromOtlp(result);
     assert.equal(batch.context.runner, undefined);
+  });
+
+  it("throws when no data sources are provided", () => {
+    assert.throws(
+      () => buildResult({ context: baseContext }),
+      /No benchmark or monitor metrics were provided/,
+    );
   });
 });
 
@@ -370,6 +393,50 @@ describe("readMonitorOutput", () => {
     } finally {
       fs.rmSync(tmpDir, { recursive: true });
     }
+  });
+});
+
+describe("readMetricsDir", () => {
+  it("merges *.otlp.json files in the directory", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stash-metrics-dir-"));
+    const docA = buildOtlpResult({
+      benchmarks: [{ name: "bench-a", metrics: { ns_per_op: { value: 120 } } }],
+      context: { sourceFormat: "otlp" },
+    });
+    const docB = buildOtlpResult({
+      benchmarks: [{ name: "bench-b", metrics: { ns_per_op: { value: 220 } } }],
+      context: { sourceFormat: "otlp" },
+    });
+    fs.writeFileSync(path.join(tmpDir, "a.otlp.json"), JSON.stringify(docA));
+    fs.writeFileSync(path.join(tmpDir, "b.otlp.json"), JSON.stringify(docB));
+
+    try {
+      const merged = readMetricsDir(tmpDir);
+      assert.ok(merged);
+      const batch = MetricsBatch.fromOtlp(merged!);
+      assert.equal(batch.size, 2);
+      assert.ok(batch.scenarios.includes("bench-a"));
+      assert.ok(batch.scenarios.includes("bench-b"));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns undefined when no *.otlp.json files exist", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "stash-metrics-dir-empty-"));
+    try {
+      assert.equal(readMetricsDir(tmpDir), undefined);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when metrics-dir path is missing", () => {
+    const missing = path.join(os.tmpdir(), `stash-metrics-missing-${Date.now()}`);
+    assert.throws(
+      () => readMetricsDir(missing),
+      /Metrics directory not found/,
+    );
   });
 });
 

--- a/octo11y/actions/stash/src/stash.ts
+++ b/octo11y/actions/stash/src/stash.ts
@@ -16,8 +16,9 @@ export interface StashContext {
 }
 
 export interface BuildResultOptions {
-  benchmarkDoc: OtlpMetricsDocument;
+  benchmarkDoc?: OtlpMetricsDocument;
   monitorDoc?: OtlpMetricsDocument;
+  metricsDirDoc?: OtlpMetricsDocument;
   context: StashContext;
 }
 
@@ -27,10 +28,21 @@ export interface SummaryOptions {
 
 /** Assemble an OtlpMetricsDocument from parsed benchmarks, optional monitor data, and CI context. */
 export function buildResult(opts: BuildResultOptions): OtlpMetricsDocument {
-  let batch = MetricsBatch.fromOtlp(opts.benchmarkDoc);
-  if (opts.monitorDoc) {
-    batch = MetricsBatch.merge(batch, MetricsBatch.fromOtlp(opts.monitorDoc));
+  const batches: MetricsBatch[] = [];
+  if (opts.benchmarkDoc) {
+    batches.push(MetricsBatch.fromOtlp(opts.benchmarkDoc));
   }
+  if (opts.monitorDoc) {
+    batches.push(MetricsBatch.fromOtlp(opts.monitorDoc));
+  }
+  if (opts.metricsDirDoc) {
+    batches.push(MetricsBatch.fromOtlp(opts.metricsDirDoc));
+  }
+  if (batches.length === 0) {
+    throw new Error("No benchmark or monitor metrics were provided to stash.");
+  }
+
+  const batch = MetricsBatch.merge(...batches);
 
   // Override resource context with stash-provided CI context
   const ctx = {
@@ -101,6 +113,40 @@ export function readMonitorOutput(monitorPath: string): OtlpMetricsDocument {
   }
 
   return parsed as OtlpMetricsDocument;
+}
+
+/**
+ * Read all *.otlp.json files in a metrics directory and merge them.
+ */
+export function readMetricsDir(metricsDir: string): OtlpMetricsDocument | undefined {
+  if (!fs.existsSync(metricsDir)) {
+    throw new Error(`Metrics directory not found: ${metricsDir}`);
+  }
+  const stat = fs.statSync(metricsDir);
+  if (!stat.isDirectory()) {
+    throw new Error(`Metrics path is not a directory: ${metricsDir}`);
+  }
+
+  const files = fs
+    .readdirSync(metricsDir)
+    .filter((name) => name.endsWith(".otlp.json"))
+    .sort()
+    .map((name) => path.join(metricsDir, name));
+
+  if (files.length === 0) {
+    return undefined;
+  }
+
+  const docs: OtlpMetricsDocument[] = [];
+  for (const file of files) {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf-8")) as OtlpMetricsDocument;
+    if (!Array.isArray(parsed.resourceMetrics)) {
+      throw new Error(`Metrics file is not valid OTLP JSON: ${file}`);
+    }
+    docs.push(parsed);
+  }
+
+  return MetricsBatch.merge(...docs.map((doc) => MetricsBatch.fromOtlp(doc))).toOtlp();
 }
 
 /**

--- a/octo11y/docs/getting-started.md
+++ b/octo11y/docs/getting-started.md
@@ -135,7 +135,7 @@ describe additional features you can layer on.
           comment-on-pr: true      # post/update a PR comment
 ```
 
-### Telemetry with monitor and emit-metric
+### Telemetry with monitor and benchkit-emit
 
 If you want host metrics or custom OTLP metrics, start the monitor once near the top of the job:
 
@@ -161,38 +161,36 @@ To record a one-off workflow metric without wiring up a full OTLP SDK:
 
 ```yaml
       - name: Emit score metric
-        uses: strawgate/octo11y/actions/emit-metric@main-dist
-        with:
-          otlp-http-endpoint: ${{ steps.monitor.outputs.otlp-http-endpoint }}
-          name: test_score
-          value: 74
-          unit: points
-          scenario: search-relevance
-          series: baseline
-          direction: bigger_is_better
-          attributes: |
-            dataset=wiki
-            variant=bm25
+        run: |
+          benchkit-emit --name test_score --value 74 --unit points \
+            --scenario search-relevance --series baseline \
+            --direction up --attribute dataset=wiki --attribute variant=bm25
 ```
 
-The monitor action stores raw OTLP telemetry at `data/runs/{run-id}/telemetry.otlp.jsonl.gz`.
+Then stash benchmarks and monitor/custom metrics together:
+
+```yaml
+      - uses: strawgate/octo11y/actions/stash@main-dist
+        with:
+          results: bench.txt
+          metrics-dir: ${{ steps.monitor.outputs.metrics-dir }}
+```
+
+The monitor action stores raw telemetry at `data/runs/{run-id}/telemetry.otlp.jsonl.gz`
+and writes a merged OTLP snapshot to `${BENCHKIT_METRICS_DIR}/monitor.otlp.json`.
 
 ### Custom workflow metrics (non-benchmark)
 
 You do not need a benchmark tool to use Octo11y. Any numeric value you can
-compute in a workflow step can become a tracked metric with `emit-metric`:
+compute in a workflow step can become a tracked metric with `benchkit-emit`:
 
 ```yaml
       - name: Track bundle size
         run: echo "BUNDLE_SIZE=$(du -sb dist/ | cut -f1)" >> "$GITHUB_ENV"
 
-      - uses: strawgate/octo11y/actions/emit-metric@main-dist
-        with:
-          otlp-http-endpoint: ${{ steps.monitor.outputs.otlp-http-endpoint }}
-          name: bundle_size_bytes
-          value: ${{ env.BUNDLE_SIZE }}
-          unit: bytes
-          direction: smaller_is_better
+      - run: |
+          benchkit-emit --name bundle_size_bytes --value "${{ env.BUNDLE_SIZE }}" \
+            --unit bytes --direction down
 ```
 
 Other ideas: Docker image size, test count, build duration, dependency count,

--- a/octo11y/docs/recipes.md
+++ b/octo11y/docs/recipes.md
@@ -112,7 +112,7 @@ jobs:
 
 ## Workflow metrics (non-benchmark)
 
-These recipes use `emit-metric` to track any numeric value over time.
+These recipes use `benchkit-emit` to track any numeric value over time.
 They require `actions/monitor` to provide an OTLP collector endpoint.
 
 ### Scheduled ingest from existing CI runs
@@ -203,26 +203,16 @@ jobs:
           echo "JS=$JS" >> "$GITHUB_ENV"
           echo "CSS=$CSS" >> "$GITHUB_ENV"
 
-      - uses: strawgate/octo11y/actions/emit-metric@main-dist
-        with:
-          otlp-http-endpoint: ${{ steps.monitor.outputs.otlp-http-endpoint }}
-          name: bundle_total_bytes
-          value: ${{ env.TOTAL }}
-          unit: bytes
-          direction: smaller_is_better
-          scenario: bundle
+      - run: |
+          benchkit-emit --name bundle_total_bytes --value "${{ env.TOTAL }}" \
+            --unit bytes --direction down --scenario bundle
 
-      - uses: strawgate/octo11y/actions/emit-metric@main-dist
-        with:
-          otlp-http-endpoint: ${{ steps.monitor.outputs.otlp-http-endpoint }}
-          name: bundle_js_bytes
-          value: ${{ env.JS }}
-          unit: bytes
-          direction: smaller_is_better
-          scenario: bundle
+      - run: |
+          benchkit-emit --name bundle_js_bytes --value "${{ env.JS }}" \
+            --unit bytes --direction down --scenario bundle
 
       - uses: strawgate/octo11y/actions/stash@main-dist
-        with: { results: ${{ steps.monitor.outputs.monitor-results }}, format: otlp }
+        with: { metrics-dir: ${{ steps.monitor.outputs.metrics-dir }} }
       - uses: strawgate/octo11y/actions/aggregate@main-dist
         if: github.ref == 'refs/heads/main'
 ```
@@ -249,17 +239,12 @@ jobs:
           SIZE=$(docker inspect myapp:latest --format '{{.Size}}')
           echo "IMAGE_SIZE=$SIZE" >> "$GITHUB_ENV"
 
-      - uses: strawgate/octo11y/actions/emit-metric@main-dist
-        with:
-          otlp-http-endpoint: ${{ steps.monitor.outputs.otlp-http-endpoint }}
-          name: image_size_bytes
-          value: ${{ env.IMAGE_SIZE }}
-          unit: bytes
-          direction: smaller_is_better
-          scenario: docker
+      - run: |
+          benchkit-emit --name image_size_bytes --value "${{ env.IMAGE_SIZE }}" \
+            --unit bytes --direction down --scenario docker
 
       - uses: strawgate/octo11y/actions/stash@main-dist
-        with: { results: ${{ steps.monitor.outputs.monitor-results }}, format: otlp }
+        with: { metrics-dir: ${{ steps.monitor.outputs.metrics-dir }} }
       - uses: strawgate/octo11y/actions/aggregate@main-dist
 ```
 
@@ -302,35 +287,20 @@ jobs:
           END=$(date +%s%N)
           echo "TEST_MS=$(( (END - START) / 1000000 ))" >> "$GITHUB_ENV"
 
-      - uses: strawgate/octo11y/actions/emit-metric@main-dist
-        with:
-          otlp-http-endpoint: ${{ steps.monitor.outputs.otlp-http-endpoint }}
-          name: install_duration_ms
-          value: ${{ env.INSTALL_MS }}
-          unit: ms
-          direction: smaller_is_better
-          scenario: ci-timing
+      - run: |
+          benchkit-emit --name install_duration_ms --value "${{ env.INSTALL_MS }}" \
+            --unit ms --direction down --scenario ci-timing
 
-      - uses: strawgate/octo11y/actions/emit-metric@main-dist
-        with:
-          otlp-http-endpoint: ${{ steps.monitor.outputs.otlp-http-endpoint }}
-          name: build_duration_ms
-          value: ${{ env.BUILD_MS }}
-          unit: ms
-          direction: smaller_is_better
-          scenario: ci-timing
+      - run: |
+          benchkit-emit --name build_duration_ms --value "${{ env.BUILD_MS }}" \
+            --unit ms --direction down --scenario ci-timing
 
-      - uses: strawgate/octo11y/actions/emit-metric@main-dist
-        with:
-          otlp-http-endpoint: ${{ steps.monitor.outputs.otlp-http-endpoint }}
-          name: test_duration_ms
-          value: ${{ env.TEST_MS }}
-          unit: ms
-          direction: smaller_is_better
-          scenario: ci-timing
+      - run: |
+          benchkit-emit --name test_duration_ms --value "${{ env.TEST_MS }}" \
+            --unit ms --direction down --scenario ci-timing
 
       - uses: strawgate/octo11y/actions/stash@main-dist
-        with: { results: ${{ steps.monitor.outputs.monitor-results }}, format: otlp }
+        with: { metrics-dir: ${{ steps.monitor.outputs.metrics-dir }} }
       - uses: strawgate/octo11y/actions/aggregate@main-dist
 ```
 
@@ -360,26 +330,16 @@ jobs:
           echo "TEST_COUNT=$TOTAL" >> "$GITHUB_ENV"
           echo "COVERAGE=$COVER" >> "$GITHUB_ENV"
 
-      - uses: strawgate/octo11y/actions/emit-metric@main-dist
-        with:
-          otlp-http-endpoint: ${{ steps.monitor.outputs.otlp-http-endpoint }}
-          name: test_count
-          value: ${{ env.TEST_COUNT }}
-          unit: tests
-          direction: bigger_is_better
-          scenario: test-health
+      - run: |
+          benchkit-emit --name test_count --value "${{ env.TEST_COUNT }}" \
+            --unit tests --direction up --scenario test-health
 
-      - uses: strawgate/octo11y/actions/emit-metric@main-dist
-        with:
-          otlp-http-endpoint: ${{ steps.monitor.outputs.otlp-http-endpoint }}
-          name: coverage_pct
-          value: ${{ env.COVERAGE }}
-          unit: "%"
-          direction: bigger_is_better
-          scenario: test-health
+      - run: |
+          benchkit-emit --name coverage_pct --value "${{ env.COVERAGE }}" \
+            --unit "%" --direction up --scenario test-health
 
       - uses: strawgate/octo11y/actions/stash@main-dist
-        with: { results: ${{ steps.monitor.outputs.monitor-results }}, format: otlp }
+        with: { metrics-dir: ${{ steps.monitor.outputs.metrics-dir }} }
       - uses: strawgate/octo11y/actions/aggregate@main-dist
 ```
 
@@ -407,17 +367,12 @@ jobs:
           HEALTH_MS=$(echo "$HEALTH * 1000" | bc | cut -d. -f1)
           echo "HEALTH_MS=$HEALTH_MS" >> "$GITHUB_ENV"
 
-      - uses: strawgate/octo11y/actions/emit-metric@main-dist
-        with:
-          otlp-http-endpoint: ${{ steps.monitor.outputs.otlp-http-endpoint }}
-          name: health_latency_ms
-          value: ${{ env.HEALTH_MS }}
-          unit: ms
-          direction: smaller_is_better
-          scenario: api-latency
+      - run: |
+          benchkit-emit --name health_latency_ms --value "${{ env.HEALTH_MS }}" \
+            --unit ms --direction down --scenario api-latency
 
       - uses: strawgate/octo11y/actions/stash@main-dist
-        with: { results: ${{ steps.monitor.outputs.monitor-results }}, format: otlp }
+        with: { metrics-dir: ${{ steps.monitor.outputs.metrics-dir }} }
       - uses: strawgate/octo11y/actions/aggregate@main-dist
 ```
 
@@ -477,7 +432,7 @@ metrics alongside your benchmark results:
       - uses: strawgate/octo11y/actions/stash@main-dist
         with:
           results: bench.txt
-          monitor-results: ${{ steps.monitor.outputs.monitor-results }}
+          metrics-dir: ${{ steps.monitor.outputs.metrics-dir }}
 ```
 
 The monitor data appears in the run detail view alongside your benchmark

--- a/octo11y/docs/reference/actions.md
+++ b/octo11y/docs/reference/actions.md
@@ -10,7 +10,7 @@ A common end-to-end setup looks like this:
 2. Use `actions/parse-results` to parse and stash results from logs or files.
 3. Use `actions/aggregate` to rebuild indexes and views.
 4. Use `actions/compare` on pull requests.
-5. Optionally use `actions/monitor` and `actions/emit-metric` for OTLP telemetry.
+5. Optionally use `actions/monitor` and its `benchkit-emit` CLI for OTLP telemetry.
 
 ## Actions at a glance
 
@@ -22,7 +22,6 @@ A common end-to-end setup looks like this:
 | `actions/aggregate` | Rebuild derived indexes, series, run views, and badges | `data/index.json`, `data/series/*`, `data/index/*`, `data/views/runs/*`, `data/badges/*` | [`../../actions/aggregate/README.md`](../../actions/aggregate/README.md) |
 | `actions/compare` | Compare current results to recent baselines | PR comment, step summary, regression status | [`../../actions/compare/README.md`](../../actions/compare/README.md) |
 | `actions/monitor` | Collect host and custom OTLP telemetry | `data/runs/{run-id}/telemetry.otlp.jsonl.gz` | [`../../actions/monitor/README.md`](../../actions/monitor/README.md) |
-| `actions/emit-metric` | Emit one-off OTLP metrics during a job | OTLP metric into the running collector | [`../../actions/emit-metric/README.md`](../../actions/emit-metric/README.md) |
 | `actions/repo-stats` | Collect GitHub repo statistics as metrics | `repo-stats.json` (OTLP) | [`../../actions/repo-stats/README.md`](../../actions/repo-stats/README.md) |
 
 ## Which action should I start with?
@@ -88,16 +87,6 @@ Best for:
 - CPU, memory, load, and process metrics
 - hybrid benchmark runs
 - storing raw OTLP sidecars for later aggregation
-
-### Emit Metric
-
-Use this with `actions/monitor` when you need to send one custom metric from a shell step.
-
-Best for:
-
-- simple scores or counters
-- workflow metrics without a full OTLP SDK
-- glue code in GitHub Actions jobs
 
 ### Repo Stats
 


### PR DESCRIPTION
## Summary
- implement issue #38 with a shared `metrics-dir` flow between monitor and stash
- add a new `benchkit-emit` CLI bundled with monitor for one-off workflow metrics
- make stash `results` optional when monitor/metrics-dir sources provide OTLP documents
- update monitor to export `BENCHKIT_METRICS_DIR`, `BENCHKIT_RUN_ID`, and `BENCHKIT_EMIT_ENDPOINT`, and output `metrics-dir`
- write consolidated `monitor.otlp.json` in monitor post-step and refactor monitor branch push to shared `pushWithRetry`
- update getting-started + recipes + action reference docs to use `benchkit-emit` and `metrics-dir`

## Validation
- `npm run test -w actions/monitor`
- `npm run test -w actions/stash`
- `npm run octo11y:test`
- `npm run octo11y:lint`

Closes #38
