### PR TITLE
Site/dashboard wiring: fix experience paths + reliable sample ingest

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -75,6 +75,6 @@ jobs:
           fetch-depth: 0
 
       - name: Aggregate bench-data branch
-        uses: ./octo11y/actions/aggregate
+        uses: strawgate/o11ykit/octo11y/actions/aggregate@main-dist
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -63,3 +63,18 @@ jobs:
           source-run-attempt: ${{ github.run_attempt }}
           source-job: benchmark
           run-id: ${{ github.run_id }}-${{ github.run_attempt }}--benchmark
+
+  aggregate-results:
+    needs:
+      - stash-results
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Aggregate bench-data branch
+        uses: ./octo11y/actions/aggregate
+        with:
+          github-token: ${{ github.token }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,13 +14,18 @@ permissions:
   contents: write
 
 jobs:
-  benchmark:
+  benchmark-and-stash:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Emit benchmark output
         shell: bash
         run: |
-          node <<'EOF'
+          node <<'EOF' | tee benchmark-results.txt
           function runBench(name, fn, iterations) {
             const start = process.hrtime.bigint();
             for (let i = 0; i < iterations; i += 1) fn(i);
@@ -43,30 +48,18 @@ jobs:
           }, 300000);
           EOF
 
-  stash-results:
-    needs:
-      - benchmark
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Parse and stash benchmark results
         uses: ./actions/parse-results
         with:
-          mode: auto
+          mode: file
+          results: benchmark-results.txt
           format: go
           github-token: ${{ github.token }}
-          source-run-id: ${{ github.run_id }}
-          source-run-attempt: ${{ github.run_attempt }}
-          source-job: benchmark
           run-id: ${{ github.run_id }}-${{ github.run_attempt }}--benchmark
 
   aggregate-results:
     needs:
-      - stash-results
+      - benchmark-and-stash
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,15 +40,24 @@ jobs:
       - name: Build package workspaces
         run: npm run build:packages
 
+      - name: Build octo11y package workspaces
+        run: npm run build:octo-packages
+
       - name: Build demo workspace
         run: npm run build --workspace @otlpkit/example-demo
+
+      - name: Build dashboard experiences
+        env:
+          BASE_PATH: /o11ykit/experiences/dashboard/
+        run: npm run build --workspace=@benchkit/dashboard
 
       - name: Assemble site artifact
         run: |
           rm -rf .site
-          mkdir -p .site/otlpkit
+          mkdir -p .site/otlpkit .site/experiences/dashboard
           cp -R site/* .site/
           cp -R examples/demo/dist/* .site/otlpkit/
+          cp -R octo11y/packages/dashboard/dist/* .site/experiences/dashboard/
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/octo11y/actions/aggregate/README.md
+++ b/octo11y/actions/aggregate/README.md
@@ -1,12 +1,16 @@
 # Benchkit Aggregate
 
-Rebuild `index.json` and series files from all benchmark run files on the data
-branch. Run this action after one or more `stash` calls to keep the query
-indexes that charts and dashboards rely on up to date.
+Rebuild `index.json` and series files from run artifacts on the data branch.
+Run this action after benchmark and/or monitor writes to keep the query indexes
+that charts and dashboards rely on up to date.
 
 ## What it does
 
-- reads every `data/runs/{run-id}/benchmark.otlp.json` file from the data branch
+- reads per-run OTLP artifacts under `data/runs/{run-id}/`, including:
+  - `*.otlp.json`
+  - `*.otlp.jsonl`
+  - `*.otlp.jsonl.gz`
+- still supports legacy flat files under `data/runs/*.json`
 - sorts runs chronologically and prunes the oldest ones when `max-runs` is set
 - builds `data/index.json` — a summary of all runs with their metrics
 - builds `data/series/{metric}.json` — time-series data for each metric
@@ -91,7 +95,7 @@ baseline.
 ## How it works
 
 1. **Fetch**: clone the data branch into a temporary git worktree
-2. **Read**: load all `data/runs/{run-id}/benchmark.otlp.json` files and sort them chronologically
+2. **Read**: load all OTLP run artifacts from `data/runs/` and sort them chronologically
 3. **Prune** *(optional)*: when `max-runs > 0`, delete the oldest run files
    that exceed the limit
 4. **Build**: compute the index, series, navigation indexes, and run detail
@@ -102,7 +106,8 @@ baseline.
 
 ## Relationship to stash and chart
 
-- `actions/stash` writes individual run files consumed by this action
+- `actions/stash` / `actions/parse-results` can write benchmark OTLP run files
+- `actions/monitor` can write telemetry sidecars consumed directly by this action
 - `actions/aggregate` rebuilds the derived indexes from those run files
 - chart and dashboard tooling reads `index.json` and the series files produced
   here

--- a/octo11y/actions/aggregate/src/aggregate.test.ts
+++ b/octo11y/actions/aggregate/src/aggregate.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { gzipSync } from "node:zlib";
 import Ajv from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
 import {
@@ -610,14 +611,119 @@ describe("readRuns", () => {
     }
   });
 
-  it("ignores run directories that only contain telemetry sidecars", () => {
+  it("reads telemetry sidecar-only runs from .otlp.jsonl.gz", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "benchkit-agg-test-"));
     try {
       const runDir = path.join(tmpDir, "run-001");
       fs.mkdirSync(runDir, { recursive: true });
-      fs.writeFileSync(path.join(runDir, "telemetry.otlp.jsonl.gz"), "not parsed by aggregate");
+
+      const telemetryLine = JSON.stringify({
+        resourceMetrics: [
+          {
+            resource: { attributes: [] },
+            scopeMetrics: [
+              {
+                metrics: [
+                  {
+                    name: "system.cpu.utilization",
+                    gauge: {
+                      dataPoints: [
+                        {
+                          attributes: [],
+                          asDouble: 0.42,
+                          timeUnixNano: "1711929600000000000",
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+      fs.writeFileSync(
+        path.join(runDir, "telemetry.otlp.jsonl.gz"),
+        gzipSync(`${telemetryLine}\n`),
+      );
+
       const runs = readRuns(tmpDir);
-      assert.equal(runs.length, 0);
+      assert.equal(runs.length, 1);
+      assert.equal(runs[0].id, "run-001");
+      assert.equal(runs[0].batch.points.length, 1);
+      assert.equal(runs[0].batch.points[0].scenario, "_monitor/system");
+      assert.equal(runs[0].batch.points[0].series, "system");
+      assert.equal(runs[0].batch.points[0].role, "diagnostic");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it("merges benchmark and telemetry files from the same run directory", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "benchkit-agg-test-"));
+    try {
+      const runDir = path.join(tmpDir, "run-001");
+      fs.mkdirSync(runDir, { recursive: true });
+
+      const benchmarkDoc = buildOtlpResult({
+        benchmarks: [{ name: "BenchA", metrics: { ns_per_op: { value: 100, unit: "ns/op" } } }],
+        context: { sourceFormat: "otlp", commit: "abc123" },
+      });
+      fs.writeFileSync(path.join(runDir, "benchmark.otlp.json"), JSON.stringify(benchmarkDoc));
+
+      const telemetryLine = JSON.stringify({
+        resourceMetrics: [
+          {
+            resource: { attributes: [] },
+            scopeMetrics: [
+              {
+                metrics: [
+                  {
+                    name: "process.cpu.time",
+                    gauge: {
+                      dataPoints: [
+                        {
+                          attributes: [],
+                          asDouble: 12.5,
+                          timeUnixNano: "1711929600000000000",
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+      fs.writeFileSync(path.join(runDir, "telemetry.otlp.jsonl"), `${telemetryLine}\n`);
+
+      const runs = readRuns(tmpDir);
+      assert.equal(runs.length, 1);
+      const points = runs[0].batch.points;
+      assert.ok(points.some((point) => point.scenario === "BenchA" && point.metric === "ns_per_op"));
+      assert.ok(points.some((point) => point.scenario === "_monitor/system" && point.metric === "process.cpu.time"));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it("ignores non-OTLP JSON files inside run directories", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "benchkit-agg-test-"));
+    try {
+      const runDir = path.join(tmpDir, "run-001");
+      fs.mkdirSync(runDir, { recursive: true });
+      fs.writeFileSync(path.join(runDir, "result.json"), JSON.stringify({ ok: true }));
+
+      const benchmarkDoc = buildOtlpResult({
+        benchmarks: [{ name: "BenchA", metrics: { ns_per_op: { value: 100, unit: "ns/op" } } }],
+        context: { sourceFormat: "otlp" },
+      });
+      fs.writeFileSync(path.join(runDir, "benchmark.otlp.json"), JSON.stringify(benchmarkDoc));
+
+      const runs = readRuns(tmpDir);
+      assert.equal(runs.length, 1);
+      assert.equal(runs[0].id, "run-001");
     } finally {
       fs.rmSync(tmpDir, { recursive: true });
     }

--- a/octo11y/actions/aggregate/src/aggregate.ts
+++ b/octo11y/actions/aggregate/src/aggregate.ts
@@ -1,7 +1,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { gunzipSync } from "node:zlib";
 import {
   MetricsBatch,
+  type MetricPoint,
+  type ResourceContext,
 } from "@benchkit/format";
 import type {
   MonitorContext,
@@ -20,13 +23,19 @@ export interface ParsedRun {
   monitor?: MonitorContext;
 }
 
-const RUN_BENCHMARK_FILE = "benchmark.otlp.json";
+const OTLP_JSON_SUFFIX = ".otlp.json";
+const OTLP_JSONL_SUFFIX = ".otlp.jsonl";
+const OTLP_JSONL_GZ_SUFFIX = ".otlp.jsonl.gz";
 
 /**
  * When a scenario name starts with `_monitor/`, prefix the metric name
  * so Dashboard can partition monitor metrics from user benchmarks.
  */
 export function resolveMetricName(scenario: string, metricName: string): string {
+  if (metricName.startsWith("_monitor/")) return metricName;
+  if (metricName.startsWith("_monitor.")) {
+    return `_monitor/${metricName.slice("_monitor.".length)}`;
+  }
   return scenario.startsWith("_monitor/") ? `_monitor/${metricName}` : metricName;
 }
 
@@ -183,53 +192,196 @@ export function buildSeries(runs: ParsedRun[]): Map<string, SeriesFile> {
 export function readRuns(runsDir: string): ParsedRun[] {
   if (!fs.existsSync(runsDir)) return [];
   const entries = fs.readdirSync(runsDir, { withFileTypes: true });
-  const runFiles = entries
-    .flatMap((entry): Array<{ id: string; fileName: string; filePath: string }> => {
-      if (entry.isDirectory()) {
-        const runId = entry.name;
-        const fileName = RUN_BENCHMARK_FILE;
-        const filePath = path.join(runsDir, runId, fileName);
-        if (!fs.existsSync(filePath)) {
-          return [];
-        }
-        return [{ id: runId, fileName: `${runId}/${fileName}`, filePath }];
-      }
-      if (entry.isFile() && entry.name.endsWith(".json")) {
-        const id = path.basename(entry.name, ".json");
-        const fileName = entry.name;
-        const filePath = path.join(runsDir, entry.name);
-        return [{ id, fileName, filePath }];
-      }
-      return [];
-    })
-    .sort((a, b) => a.id.localeCompare(b.id));
-  return runFiles.map(({ id, fileName, filePath }) => {
+  const runs: ParsedRun[] = [];
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      const parsed = parseRunDirectory(runsDir, entry.name);
+      if (parsed) runs.push(parsed);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".json")) {
+      const id = path.basename(entry.name, ".json");
+      const fileName = entry.name;
+      const filePath = path.join(runsDir, entry.name);
+      runs.push(parseRunFileFromJsonDocument(id, fileName, filePath));
+    }
+  }
+
+  runs.sort((a, b) => a.id.localeCompare(b.id));
+  return runs;
+}
+
+function parseRunDirectory(runsDir: string, runId: string): ParsedRun | undefined {
+  const runPath = path.join(runsDir, runId);
+  const entries = fs.readdirSync(runPath, { withFileTypes: true });
+  const files = entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) =>
+      name.endsWith(OTLP_JSON_SUFFIX)
+      || name.endsWith(OTLP_JSONL_SUFFIX)
+      || name.endsWith(OTLP_JSONL_GZ_SUFFIX))
+    .sort();
+
+  if (files.length === 0) {
+    return undefined;
+  }
+
+  const batches: MetricsBatch[] = files.map((fileName) => {
+    const filePath = path.join(runPath, fileName);
+    if (fileName.endsWith(OTLP_JSONL_GZ_SUFFIX)) {
+      const compressed = fs.readFileSync(filePath);
+      const content = gunzipSync(compressed).toString("utf-8");
+      return parseJsonlFile(runId, `${runId}/${fileName}`, content);
+    }
+    if (fileName.endsWith(OTLP_JSONL_SUFFIX)) {
+      const content = fs.readFileSync(filePath, "utf-8");
+      return parseJsonlFile(runId, `${runId}/${fileName}`, content);
+    }
+    return parseRunFileFromJsonDocument(runId, `${runId}/${fileName}`, filePath).batch;
+  });
+
+  const merged = mergeBatches(batches);
+  return buildParsedRun(runId, normalizeMonitorTelemetryPoints(merged));
+}
+
+function parseJsonlFile(runId: string, fileName: string, content: string): MetricsBatch {
+  const lines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return MetricsBatch.fromOtlp({ resourceMetrics: [] });
+  }
+
+  const batches: MetricsBatch[] = lines.map((line, index) => {
     let parsed: unknown;
     try {
-      parsed = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      parsed = JSON.parse(line);
     } catch (err) {
       throw new Error(
-        `Failed to parse run file '${fileName}': ${err instanceof Error ? err.message : String(err)}`,
+        `Failed to parse run file '${fileName}' line ${index + 1}: ${err instanceof Error ? err.message : String(err)}`,
         { cause: err },
       );
     }
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
       throw new Error(
-        `Run file '${fileName}' must contain a JSON object, got ${parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed}`,
+        `Run file '${fileName}' line ${index + 1} must contain a JSON object, got ${parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed}`,
       );
     }
-    return parseRunFile(id, parsed as Record<string, unknown>);
+    return parseRunObject(runId, parsed as Record<string, unknown>, fileName).batch;
   });
+  return mergeBatches(batches);
+}
+
+function mergeBatches(batches: readonly MetricsBatch[]): MetricsBatch {
+  if (batches.length === 0) {
+    return MetricsBatch.fromOtlp({ resourceMetrics: [] });
+  }
+  let runId: string | undefined;
+  let kind: string | undefined;
+  let sourceFormat: string | undefined;
+  let commit: string | undefined;
+  let ref: string | undefined;
+  let workflow: string | undefined;
+  let job: string | undefined;
+  let runAttempt: string | undefined;
+  let runner: string | undefined;
+  let serviceName: string | undefined;
+  const points: MetricPoint[] = [];
+  for (const batch of batches) {
+    points.push(...batch.points);
+    runId ??= batch.context.runId;
+    kind ??= batch.context.kind;
+    sourceFormat ??= batch.context.sourceFormat;
+    commit ??= batch.context.commit;
+    ref ??= batch.context.ref;
+    workflow ??= batch.context.workflow;
+    job ??= batch.context.job;
+    runAttempt ??= batch.context.runAttempt;
+    runner ??= batch.context.runner;
+    serviceName ??= batch.context.serviceName;
+  }
+  const context: ResourceContext = {
+    runId,
+    kind,
+    sourceFormat,
+    commit,
+    ref,
+    workflow,
+    job,
+    runAttempt,
+    runner,
+    serviceName,
+  };
+  return MetricsBatch.fromPoints(points, context);
+}
+
+function normalizeMonitorTelemetryPoints(batch: MetricsBatch): MetricsBatch {
+  const normalized = batch.points.map((point) => {
+    const scenario = point.scenario.trim();
+    const series = point.series.trim();
+
+    const isMonitorScenario = scenario.startsWith("_monitor/");
+    const isMonitorMetric = point.metric.startsWith("_monitor.") || point.metric.startsWith("_monitor/");
+    if (isMonitorScenario) {
+      const normalizedSeries = series || scenario.slice("_monitor/".length) || "system";
+      return {
+        ...point,
+        series: normalizedSeries,
+        role: point.role ?? "diagnostic",
+      };
+    }
+    if (scenario) {
+      return point;
+    }
+
+    if (!isMonitorMetric && series) {
+      return point;
+    }
+
+    const monitorSeries = series || "system";
+    return {
+      ...point,
+      scenario: `_monitor/${monitorSeries}`,
+      series: monitorSeries,
+      role: point.role ?? "diagnostic",
+    };
+  });
+  return MetricsBatch.fromPoints(normalized, batch.context);
+}
+
+function parseRunFileFromJsonDocument(id: string, fileName: string, filePath: string): ParsedRun {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  } catch (err) {
+    throw new Error(
+      `Failed to parse run file '${fileName}': ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      `Run file '${fileName}' must contain a JSON object, got ${parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed}`,
+    );
+  }
+  return parseRunObject(id, parsed as Record<string, unknown>, fileName);
 }
 
 /** Convert a parsed JSON object into a ParsedRun. Expects OTLP format. */
-function parseRunFile(id: string, data: Record<string, unknown>): ParsedRun {
+function parseRunObject(id: string, data: Record<string, unknown>, fileName: string): ParsedRun {
   if (!Array.isArray(data.resourceMetrics)) {
     throw new Error(
-      `Run file '${id}.json' is not valid OTLP JSON (missing resourceMetrics array).`,
+      `Run file '${fileName}' is not valid OTLP JSON (missing resourceMetrics array).`,
     );
   }
   const batch = MetricsBatch.fromOtlp(data as unknown as import("@benchkit/format").OtlpMetricsDocument);
+  return buildParsedRun(id, normalizeMonitorTelemetryPoints(batch));
+}
+
+function buildParsedRun(id: string, batch: MetricsBatch): ParsedRun {
   let timestamp = new Date().toISOString();
   if (batch.points.length > 0 && batch.points[0].timestamp) {
     const nanos = BigInt(batch.points[0].timestamp);

--- a/octo11y/actions/monitor/src/otel-config.test.ts
+++ b/octo11y/actions/monitor/src/otel-config.test.ts
@@ -2,6 +2,8 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   generateCollectorConfig,
+  mergeResourceAttributesInputs,
+  parseResourceAttributes,
   validateMetricSets,
   validateScrapeInterval,
   type CollectorConfigOptions,
@@ -54,6 +56,7 @@ describe("generateCollectorConfig", () => {
   it("generates config with hostmetrics and otlp receivers", () => {
     const yaml = generateCollectorConfig(baseOpts());
     assert.match(yaml, /hostmetrics:/);
+    assert.match(yaml, /initial_delay: 0s/);
     assert.match(yaml, /collection_interval: 1s/);
     assert.match(yaml, /cpu: \{\}/);
     assert.match(yaml, /memory: \{\}/);
@@ -179,6 +182,24 @@ describe("generateCollectorConfig", () => {
     assert.match(yaml, /processors: \[resource\]/);
   });
 
+  it("includes custom resource attributes", () => {
+    const yaml = generateCollectorConfig(
+      baseOpts({
+        resourceAttributes: {
+          "service.namespace": "bench",
+          "test.enabled": true,
+          "run.slot": 7,
+        },
+      }),
+    );
+    assert.match(yaml, /key: service\.namespace/);
+    assert.match(yaml, /value: "bench"/);
+    assert.match(yaml, /key: test\.enabled/);
+    assert.match(yaml, /value: "true"/);
+    assert.match(yaml, /key: run\.slot/);
+    assert.match(yaml, /value: "7"/);
+  });
+
   it("always includes benchkit.run_id, benchkit.kind, benchkit.source_format", () => {
     const yaml = generateCollectorConfig(baseOpts({ ref: undefined, commit: undefined }));
     assert.match(yaml, /benchkit\.run_id/);
@@ -206,6 +227,56 @@ describe("validateScrapeInterval", () => {
     assert.throws(() => validateScrapeInterval(""), /Invalid scrape interval/);
     assert.throws(() => validateScrapeInterval("1x"), /Invalid scrape interval/);
     assert.throws(() => validateScrapeInterval("1s\nmalicious: true"), /Invalid scrape interval/);
+  });
+});
+
+describe("resource attributes parsing", () => {
+  it("parses JSON attributes with typed values", () => {
+    assert.deepEqual(
+      parseResourceAttributes('{"service.namespace":"bench","slot":2,"enabled":true}'),
+      {
+        "service.namespace": "bench",
+        slot: 2,
+        enabled: true,
+      },
+    );
+  });
+
+  it("parses key=value line attributes", () => {
+    assert.deepEqual(
+      parseResourceAttributes("service.namespace=bench\nfeature.flag=on"),
+      {
+        "service.namespace": "bench",
+        "feature.flag": "on",
+      },
+    );
+  });
+
+  it("rejects benchkit-prefixed keys", () => {
+    assert.throws(
+      () => parseResourceAttributes("benchkit.kind=workflow"),
+      /must not use the 'benchkit\.' prefix/,
+    );
+  });
+
+  it("merges env and explicit attributes with explicit precedence", () => {
+    assert.deepEqual(
+      mergeResourceAttributesInputs(
+        "service.name=explicit\nservice.version=2",
+        "service.name=env\nservice.namespace=bench",
+      ),
+      {
+        "service.name": "explicit",
+        "service.namespace": "bench",
+        "service.version": "2",
+      },
+    );
+  });
+
+  it("uses env attributes when explicit input is empty", () => {
+    assert.deepEqual(mergeResourceAttributesInputs("", "service.name=env"), {
+      "service.name": "env",
+    });
   });
 });
 

--- a/octo11y/actions/monitor/src/otel-config.ts
+++ b/octo11y/actions/monitor/src/otel-config.ts
@@ -23,9 +23,13 @@ export interface CollectorConfigOptions {
   ref?: string;
   /** Commit SHA. */
   commit?: string;
+  /** Additional custom resource attributes (non-benchkit namespace). */
+  resourceAttributes?: Record<string, string | number | boolean>;
   /** When true, set process scraper to mute all process-level scraper errors. */
   muteProcessAllErrors?: boolean;
 }
+
+type ResourceAttributeValue = string | number | boolean;
 
 const VALID_METRIC_SETS = new Set([
   "cpu",
@@ -80,7 +84,84 @@ function resourceAttributes(opts: CollectorConfigOptions): Array<{
   if (opts.commit) {
     attrs.push({ key: "benchkit.commit", value: opts.commit, action: "upsert" });
   }
+  for (const [key, value] of Object.entries(opts.resourceAttributes ?? {})) {
+    attrs.push({ key, value: String(value), action: "upsert" });
+  }
   return attrs;
+}
+
+export function parseResourceAttributes(raw: string): Record<string, ResourceAttributeValue> {
+  const trimmed = raw.trim();
+  if (!trimmed) return {};
+
+  if (trimmed.startsWith("{")) {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+      throw new Error("resource-attributes JSON must be an object.");
+    }
+    const result: Record<string, ResourceAttributeValue> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (!key.trim()) {
+        throw new Error("resource-attributes keys must not be empty.");
+      }
+      if (
+        typeof value !== "string"
+        && typeof value !== "number"
+        && typeof value !== "boolean"
+      ) {
+        throw new Error(
+          `resource-attributes '${key}' must be a string, number, or boolean.`,
+        );
+      }
+      if (key.startsWith("benchkit.")) {
+        throw new Error(
+          `resource-attributes must not use the 'benchkit.' prefix. Got '${key}'.`,
+        );
+      }
+      result[key] = value;
+    }
+    return result;
+  }
+
+  const result: Record<string, ResourceAttributeValue> = {};
+  const entries = trimmed
+    .split(/\r?\n/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  for (const entry of entries) {
+    const separator = entry.indexOf("=");
+    if (separator <= 0) {
+      throw new Error(
+        `resource-attributes entry '${entry}' must use key=value format.`,
+      );
+    }
+    const key = entry.slice(0, separator).trim();
+    const value = entry.slice(separator + 1).trim();
+    if (!key) {
+      throw new Error("resource-attributes keys must not be empty.");
+    }
+    if (key.startsWith("benchkit.")) {
+      throw new Error(
+        `resource-attributes must not use the 'benchkit.' prefix. Got '${key}'.`,
+      );
+    }
+    result[key] = value;
+  }
+
+  return result;
+}
+
+export function mergeResourceAttributesInputs(
+  explicitInput: string,
+  envInput: string | undefined,
+): Record<string, ResourceAttributeValue> {
+  const envAttributes = parseResourceAttributes(envInput ?? "");
+  const explicitAttributes = parseResourceAttributes(explicitInput);
+  return {
+    ...envAttributes,
+    ...explicitAttributes,
+  };
 }
 
 /** Validate that a scrape interval looks like a valid Go duration. */
@@ -109,6 +190,7 @@ export function generateCollectorConfig(opts: CollectorConfigOptions): string {
   if (opts.metricSets.length > 0) {
     receiverNames.push("hostmetrics");
     lines.push("  hostmetrics:");
+    lines.push("    initial_delay: 0s");
     lines.push(`    collection_interval: ${interval}`);
     lines.push("    scrapers:");
     for (const set of opts.metricSets) {

--- a/octo11y/docs/README.md
+++ b/octo11y/docs/README.md
@@ -23,7 +23,7 @@
 ## Roadmap and planning
 
 - [`vision-and-roadmap.md`](vision-and-roadmap.md) — product direction and roadmap
-- [`metrickit-boundary-plan.md`](metrickit-boundary-plan.md) — metrickit/benchkit split boundary and compatibility plan
+- [`otlpkit-boundary-plan.md`](otlpkit-boundary-plan.md) — otlpkit/benchkit split boundary and compatibility plan
 - [`internal/agent-handoff.md`](internal/agent-handoff.md) — current execution queue for agents
 
 ## Package and action references

--- a/octo11y/docs/otlpkit-boundary-plan.md
+++ b/octo11y/docs/otlpkit-boundary-plan.md
@@ -1,14 +1,14 @@
-# Metrickit / Benchkit boundary plan
+# OTLPKit / Benchkit boundary plan
 
 This document defines the ownership boundary between the generic metric
-platform (**metrickit**) and the benchmark-specific product layer
+platform (**otlpkit**) and the benchmark-specific product layer
 (**benchkit**). It is the output of Phase 1 (#178) of the split epic (#183).
 
 ## Guiding principles
 
-1. **One-way dependency**: benchkit may depend on metrickit, never the reverse.
+1. **One-way dependency**: benchkit may depend on otlpkit, never the reverse.
 2. **No flag day**: existing `@benchkit/*` imports and `strawgate/octo11y/actions/*`
-   references continue to work. New `@metrickit/*` packages are additive.
+   references continue to work. New `@otlpkit/*` packages are additive.
 3. **Data contract stability**: existing `bench-data` branch files remain valid.
    Schema evolution is append-only or explicitly versioned.
 4. **Incremental extraction**: each phase produces a working, testable state.
@@ -21,9 +21,9 @@ platform (**metrickit**) and the benchmark-specific product layer
 
 | Surface | Owner | Rationale |
 |---|---|---|
-| OTLP types (`OtlpMetricsDocument`, etc.) | metrickit | Standard OpenTelemetry protocol encoding. |
-| OTLP parsing (`parseOtlp`, helpers) | metrickit | Pure OTLP deserialization, no benchmark logic. |
-| `MetricsBatch` (core: filter, groupBy, merge) | metrickit | Generic metric aggregation operations. |
+| OTLP types (`OtlpMetricsDocument`, etc.) | otlpkit | Standard OpenTelemetry protocol encoding. |
+| OTLP parsing (`parseOtlp`, helpers) | otlpkit | Pure OTLP deserialization, no benchmark logic. |
+| `MetricsBatch` (core: filter, groupBy, merge) | otlpkit | Generic metric aggregation operations. |
 | `buildOtlpResult()` | benchkit | Translates benchmark structures into OTLP with `benchkit.*` attributes. |
 | Benchmark parsers (Go, Rust, Hyperfine, pytest, benchmark-action) | benchkit | Format-specific parsing for benchmark tools. |
 | Semantic conventions (`ATTR_*`, `VALID_DIRECTIONS`, etc.) | benchkit | Benchmark-specific OTLP attribute vocabulary. |
@@ -35,10 +35,10 @@ platform (**metrickit**) and the benchmark-specific product layer
 
 | Surface | Owner | Rationale |
 |---|---|---|
-| `TrendChart`, `ComparisonChart`, `SampleChart`, `ComparisonBar` | metrickit | Generic time-series/comparison visualization. |
-| `TagFilter`, `DateRangeFilter` | metrickit | Generic series filtering. |
-| Fetch helpers (`fetchIndex`, `fetchSeries`, `fetchRun`, etc.) | metrickit | Generic HTTP data fetching. |
-| Data transforms (`dataPointsToComparisonData`, `samplesToDataPoints`) | metrickit | Generic data reshaping. |
+| `TrendChart`, `ComparisonChart`, `SampleChart`, `ComparisonBar` | otlpkit | Generic time-series/comparison visualization. |
+| `TagFilter`, `DateRangeFilter` | otlpkit | Generic series filtering. |
+| Fetch helpers (`fetchIndex`, `fetchSeries`, `fetchRun`, etc.) | otlpkit | Generic HTTP data fetching. |
+| Data transforms (`dataPointsToComparisonData`, `samplesToDataPoints`) | otlpkit | Generic data reshaping. |
 | `Dashboard` | benchkit | Benchmark-focused UI with monitor partitioning, regression detection. |
 | `RunDashboard`, `RunDetail` | benchkit | Benchmark run comparison and detail views. |
 | `RunTable`, `Leaderboard` | mixed | Core logic is generic; label defaults are benchmark-specific. |
@@ -48,8 +48,8 @@ platform (**metrickit**) and the benchmark-specific product layer
 
 | Surface | Owner | Rationale |
 |---|---|---|
-| `actions/monitor` | metrickit | Generic OTel Collector download, start/stop, host metrics. |
-| `actions/emit-metric` | metrickit | Generic OTLP HTTP metric emission. |
+| `actions/monitor` | otlpkit | Generic OTel Collector download, start/stop, host metrics. |
+| `actions/emit-metric` | otlpkit | Generic OTLP HTTP metric emission. |
 | `actions/stash` | benchkit | Benchmark file parsing, result assembly, data-branch push. |
 | `actions/aggregate` | mixed | Generic aggregation logic, but series key computation and `_monitor/` prefix are benchmark-specific. |
 | `actions/compare` | benchkit | Benchmark regression detection and PR commenting. |
@@ -58,11 +58,11 @@ platform (**metrickit**) and the benchmark-specific product layer
 
 | Schema | Owner | Rationale |
 |---|---|---|
-| `index.schema.json` | metrickit | Generic run index structure. |
-| `series.schema.json` | metrickit | Generic time-series structure. |
-| `index-refs.schema.json` | metrickit | Generic ref-based grouping. |
-| `index-prs.schema.json` | metrickit | Generic PR-based grouping. |
-| `index-metrics.schema.json` | metrickit | Generic metric navigation. |
+| `index.schema.json` | otlpkit | Generic run index structure. |
+| `series.schema.json` | otlpkit | Generic time-series structure. |
+| `index-refs.schema.json` | otlpkit | Generic ref-based grouping. |
+| `index-prs.schema.json` | otlpkit | Generic PR-based grouping. |
+| `index-metrics.schema.json` | otlpkit | Generic metric navigation. |
 | `comparison-result.schema.json` | benchkit | Benchmark comparison output. |
 | `view-run-detail.schema.json` | benchkit | Benchmark detail view with metric snapshots. |
 
@@ -81,13 +81,13 @@ These are the coupling points that must be cleanly split before extraction:
    the benchkit default.
 
 3. **`buildOtlpResult()`** — Benchmark-to-OTLP translator lives in `@benchkit/format`.
-   Should move to benchkit-only scope; metrickit should only consume and emit raw OTLP.
+   Should move to benchkit-only scope; otlpkit should only consume and emit raw OTLP.
 
 4. **Label defaults in chart** — `defaultMetricLabel` converts `ns_per_op` → "Throughput",
    assumes `_monitor/` partitioning. These should be injectable, not hardcoded.
 
 5. **Aggregate series key computation** — Currently reads `benchkit.scenario` + sorted
-   tags to build composite series keys. Metrickit should use a generic key strategy
+   tags to build composite series keys. OtlpKit should use a generic key strategy
    (e.g., resource attributes), with benchkit providing the scenario-aware override.
 
 ---
@@ -111,21 +111,21 @@ These are the coupling points that must be cleanly split before extraction:
 
 | New name | Contents |
 |---|---|
-| `@metrickit/core` | OTLP types, `MetricsBatch` (generic), OTLP parsing. |
-| `@metrickit/ui` | Chart primitives, fetch helpers, filters, data transforms. |
+| `@otlpkit/core` | OTLP types, `MetricsBatch` (generic), OTLP parsing. |
+| `@otlpkit/ui` | Chart primitives, fetch helpers, filters, data transforms. |
 
 ### Re-export strategy
 
 `@benchkit/format` and `@benchkit/chart` become thin re-export shims:
-- `@benchkit/format` re-exports `@metrickit/core` plus benchmark parsers, conventions, compare.
-- `@benchkit/chart` re-exports `@metrickit/ui` plus Dashboard, RunDashboard, RunDetail, labels.
+- `@benchkit/format` re-exports `@otlpkit/core` plus benchmark parsers, conventions, compare.
+- `@benchkit/chart` re-exports `@otlpkit/ui` plus Dashboard, RunDashboard, RunDetail, labels.
 
 This means `import { MetricsBatch } from "@benchkit/format"` continues to work.
 
 ### Action re-export
 
 `actions/monitor` and `actions/emit-metric` stay in the benchkit repo for now.
-If a `metrickit` repo is created later, these actions can be published there and
+If a `otlpkit` repo is created later, these actions can be published there and
 the benchkit versions become thin wrappers or aliases.
 
 ---
@@ -136,7 +136,7 @@ the benchkit versions become thin wrappers or aliases.
 
 Run files (`data/runs/{run-id}/benchmark.otlp.json`) contain OTLP with `benchkit.*` attributes. These
 attributes are part of the published data contract and will not be renamed.
-Metrickit will read OTLP generically (ignoring attribute names it doesn't
+OtlpKit will read OTLP generically (ignoring attribute names it doesn't
 know) while benchkit will continue to interpret `benchkit.*` attributes.
 
 ### Schema evolution
@@ -149,25 +149,25 @@ treated as version 1 and remain backward-compatible.
 ## Extraction sequence
 
 ```
-Phase 2 (#179): Extract @metrickit/core from @benchkit/format
-  ├── OTLP types → @metrickit/core
-  ├── MetricsBatch (generic) → @metrickit/core
-  ├── OTLP parsing → @metrickit/core
-  └── @benchkit/format re-exports @metrickit/core
+Phase 2 (#179): Extract @otlpkit/core from @benchkit/format
+  ├── OTLP types → @otlpkit/core
+  ├── MetricsBatch (generic) → @otlpkit/core
+  ├── OTLP parsing → @otlpkit/core
+  └── @benchkit/format re-exports @otlpkit/core
 
-Phase 3 (#180): Extract @metrickit/ui from @benchkit/chart
-  ├── Chart primitives → @metrickit/ui
-  ├── Fetch helpers → @metrickit/ui
-  ├── Filters → @metrickit/ui
-  └── @benchkit/chart re-exports @metrickit/ui
+Phase 3 (#180): Extract @otlpkit/ui from @benchkit/chart
+  ├── Chart primitives → @otlpkit/ui
+  ├── Fetch helpers → @otlpkit/ui
+  ├── Filters → @otlpkit/ui
+  └── @benchkit/chart re-exports @otlpkit/ui
 
 Phase 4 (#181): Decouple aggregation
-  ├── Generic aggregation → @metrickit/core
+  ├── Generic aggregation → @otlpkit/core
   ├── Benchmark aggregation defaults → @benchkit/format
   └── actions/aggregate uses composition
 
 Phase 5 (#182): Release and migration
-  ├── Publish @metrickit/* packages
+  ├── Publish @otlpkit/* packages
   ├── Update docs and demo repo
   └── Announce migration path
 ```
@@ -180,6 +180,6 @@ Phase 5 (#182): Release and migration
 |---|---|
 | Re-export shim, not rename | Zero breaking changes for existing consumers. |
 | `benchkit.*` attributes stay forever | Existing data files depend on them. |
-| Label defaults become injectable | Allows metrickit UI to be domain-agnostic. |
+| Label defaults become injectable | Allows otlpkit UI to be domain-agnostic. |
 | `actions/monitor` stays in benchkit repo | Simpler than creating a new repo now. |
 | Aggregate gets composition, not fork | One codebase with pluggable keys, not two copies. |

--- a/octo11y/docs/vision-and-roadmap.md
+++ b/octo11y/docs/vision-and-roadmap.md
@@ -139,7 +139,7 @@ competitive-first experiences.
 |---|---|---|
 | #179 | Extract `@octo11y/core` package | Done (PR #264) |
 | #180 | Explicit core imports across actions + chart | Done (PR #265) |
-| #189–#193 | Metrickit boundary plan and compatibility shims | Done (PR #263) |
+| #189–#193 | OtlpKit boundary plan and compatibility shims | Done (PR #263) |
 | #182 | Release, docs, and demo migration | In progress |
 | #183 | Epic umbrella | Open (closes when #182 ships) |
 

--- a/octo11y/packages/dashboard/README.md
+++ b/octo11y/packages/dashboard/README.md
@@ -54,13 +54,13 @@ The dev server starts at `http://localhost:5173/benchkit/` and fetches live data
 
 The home route emphasizes the generic Actions-to-metrics story. The Benchkit route preserves deep benchmark exploration.
 
-The Benchkit route renders a `<Dashboard>` component pointed at the configured data source repo (defaults to `strawgate/o11ykit-playground`):
+The Benchkit route renders a `<Dashboard>` component pointed at the configured data source repo (defaults to `strawgate/o11ykit`):
 
 ```tsx
 <Dashboard
-  source={{ owner: "strawgate", repo: "o11ykit-playground" }}
+  source={{ owner: "strawgate", repo: "o11ykit" }}
   seriesNameFormatter={(name) => name.replace(/^Benchmark/, "")}
-  commitHref={(sha) => `https://github.com/strawgate/o11ykit-playground/commit/${sha}`}
+  commitHref={(sha) => `https://github.com/strawgate/o11ykit/commit/${sha}`}
   regressionThreshold={10}
   regressionWindow={5}
 />

--- a/octo11y/packages/dashboard/README.md
+++ b/octo11y/packages/dashboard/README.md
@@ -1,6 +1,6 @@
 # @benchkit/dashboard
 
-Private Preact app that deploys the Octo11y site to GitHub Pages. This is **not** a library or template — it is the live deployment at [strawgate.github.io/octo11y](https://strawgate.github.io/octo11y/).
+Private Preact app used for the o11ykit "Experiences" pages on GitHub Pages. This is **not** a library or template.
 
 ## Role
 
@@ -54,13 +54,13 @@ The dev server starts at `http://localhost:5173/benchkit/` and fetches live data
 
 The home route emphasizes the generic Actions-to-metrics story. The Benchkit route preserves deep benchmark exploration.
 
-The Benchkit route renders a `<Dashboard>` component pointed at `strawgate/octo11y`:
+The Benchkit route renders a `<Dashboard>` component pointed at the configured data source repo (defaults to `strawgate/o11ykit-playground`):
 
 ```tsx
 <Dashboard
-  source={{ owner: "strawgate", repo: "octo11y" }}
+  source={{ owner: "strawgate", repo: "o11ykit-playground" }}
   seriesNameFormatter={(name) => name.replace(/^Benchmark/, "")}
-  commitHref={(sha) => `https://github.com/strawgate/octo11y/commit/${sha}`}
+  commitHref={(sha) => `https://github.com/strawgate/o11ykit-playground/commit/${sha}`}
   regressionThreshold={10}
   regressionWindow={5}
 />

--- a/octo11y/packages/dashboard/src/constants.ts
+++ b/octo11y/packages/dashboard/src/constants.ts
@@ -4,7 +4,7 @@ import type { SeriesEntry } from "@benchkit/format";
 export const PRODUCT_REPO_OWNER = "strawgate";
 export const PRODUCT_REPO_NAME = "o11ykit";
 
-const DEFAULT_DATA_REPO = "strawgate/o11ykit-playground";
+const DEFAULT_DATA_REPO = "strawgate/o11ykit";
 const DATA_REPO_QUERY_KEY = "dataRepo";
 const queryValue = (() => {
   try {
@@ -19,7 +19,7 @@ const DATA_REPO_SLUG =
   queryValue && queryValue.includes("/") ? queryValue : DEFAULT_DATA_REPO;
 const [parsedDataOwner, parsedDataRepo] = DATA_REPO_SLUG.split("/", 2);
 export const DATA_REPO_OWNER = parsedDataOwner || "strawgate";
-export const DATA_REPO_NAME = parsedDataRepo || "o11ykit-playground";
+export const DATA_REPO_NAME = parsedDataRepo || "o11ykit";
 export const DATA_SOURCE: DataSource = {
   owner: DATA_REPO_OWNER,
   repo: DATA_REPO_NAME,

--- a/octo11y/packages/dashboard/src/constants.ts
+++ b/octo11y/packages/dashboard/src/constants.ts
@@ -1,9 +1,29 @@
 import type { DataSource } from "@benchkit/chart";
 import type { SeriesEntry } from "@benchkit/format";
 
-export const REPO_OWNER = "strawgate";
-export const REPO_NAME = "octo11y";
-export const DATA_SOURCE: DataSource = { owner: REPO_OWNER, repo: REPO_NAME };
+export const PRODUCT_REPO_OWNER = "strawgate";
+export const PRODUCT_REPO_NAME = "o11ykit";
+
+const DEFAULT_DATA_REPO = "strawgate/o11ykit-playground";
+const DATA_REPO_QUERY_KEY = "dataRepo";
+const queryValue = (() => {
+  try {
+    return new URLSearchParams(globalThis.location?.search ?? "").get(
+      DATA_REPO_QUERY_KEY,
+    );
+  } catch {
+    return null;
+  }
+})();
+const DATA_REPO_SLUG =
+  queryValue && queryValue.includes("/") ? queryValue : DEFAULT_DATA_REPO;
+const [parsedDataOwner, parsedDataRepo] = DATA_REPO_SLUG.split("/", 2);
+export const DATA_REPO_OWNER = parsedDataOwner || "strawgate";
+export const DATA_REPO_NAME = parsedDataRepo || "o11ykit-playground";
+export const DATA_SOURCE: DataSource = {
+  owner: DATA_REPO_OWNER,
+  repo: DATA_REPO_NAME,
+};
 
 export const METRIC_LABELS: Record<string, string> = {
   ns_per_op: "Duration",
@@ -76,7 +96,7 @@ export function fmtValue(v: number, metric?: string): string {
 }
 
 export function commitHref(sha: string): string {
-  return `https://github.com/${REPO_OWNER}/${REPO_NAME}/commit/${sha}`;
+  return `https://github.com/${DATA_REPO_OWNER}/${DATA_REPO_NAME}/commit/${sha}`;
 }
 
 export function timeAgo(iso: string): string {

--- a/octo11y/packages/dashboard/src/hooks/use-bench-data.ts
+++ b/octo11y/packages/dashboard/src/hooks/use-bench-data.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "preact/hooks";
 import type { IndexFile, SeriesFile } from "@benchkit/format";
-import { REPO_OWNER, REPO_NAME, fmtBenchName } from "../constants";
+import { DATA_REPO_OWNER, DATA_REPO_NAME, fmtBenchName } from "../constants";
 import { cachedFetchJson } from "../cached-fetch";
 
 export type BenchData = {
@@ -22,7 +22,7 @@ export function useBenchData(): BenchData {
     const ctrl = new AbortController();
     const { signal } = ctrl;
 
-    const base = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/bench-data`;
+    const base = `https://raw.githubusercontent.com/${DATA_REPO_OWNER}/${DATA_REPO_NAME}/bench-data`;
 
     (async () => {
       try {

--- a/octo11y/packages/dashboard/src/hooks/use-repo-metrics.ts
+++ b/octo11y/packages/dashboard/src/hooks/use-repo-metrics.ts
@@ -1,5 +1,11 @@
 import { useState, useEffect } from "preact/hooks";
-import { REPO_OWNER, REPO_NAME, METRIC_LABELS, METRIC_UNITS, METRIC_ICONS } from "../constants";
+import {
+  DATA_REPO_OWNER,
+  DATA_REPO_NAME,
+  METRIC_LABELS,
+  METRIC_UNITS,
+  METRIC_ICONS,
+} from "../constants";
 import { cachedFetchJson } from "../cached-fetch";
 
 /* Repo-health metrics that belong on the GuidePage story.
@@ -32,7 +38,7 @@ export function useRepoMetrics(): RepoMetrics {
   useEffect(() => {
     const ctrl = new AbortController();
     const branch = "bench-data";
-    const base = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${branch}`;
+    const base = `https://raw.githubusercontent.com/${DATA_REPO_OWNER}/${DATA_REPO_NAME}/${branch}`;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const fetchJson = (path: string): Promise<any> =>
       cachedFetchJson(`${base}/${path}`, ctrl.signal).catch(() => null);

--- a/octo11y/packages/dashboard/src/pages/BenchmarkStoryPage.tsx
+++ b/octo11y/packages/dashboard/src/pages/BenchmarkStoryPage.tsx
@@ -1,7 +1,13 @@
 import { T } from "../tokens";
 import { ACCENT_COLORS } from "../tokens";
 import type { Route } from "../router";
-import { REPO_OWNER, REPO_NAME, METRIC_UNITS, fmtMetric, fmtValue } from "../constants";
+import {
+  PRODUCT_REPO_OWNER,
+  PRODUCT_REPO_NAME,
+  METRIC_UNITS,
+  fmtMetric,
+  fmtValue,
+} from "../constants";
 import { useBenchData, deriveBenchmarks } from "../hooks/use-bench-data";
 import { Sparkline, YamlBlock, FadeIn } from "../components/ui";
 
@@ -355,14 +361,14 @@ jobs:
         run: go test -bench=. -benchmem ./... | tee bench.txt
 
       - name: Stash the results
-        uses: strawgate/octo11y/actions/stash@main-dist
+        uses: strawgate/o11ykit/octo11y/actions/stash@main-dist
         with: { results: bench.txt, format: go }
 
       - name: Build the timeline
-        uses: strawgate/octo11y/actions/aggregate@main-dist
+        uses: strawgate/o11ykit/octo11y/actions/aggregate@main-dist
 
       - name: Compare & alert 🚨
-        uses: strawgate/octo11y/actions/compare@main-dist
+        uses: strawgate/o11ykit/octo11y/actions/compare@main-dist
         with: { threshold: 15% }`}
               </YamlBlock>
             </div>
@@ -726,7 +732,7 @@ jobs:
                 Explore the dashboard →
               </button>
               <a
-                href={`https://github.com/${REPO_OWNER}/${REPO_NAME}#getting-started`}
+                href={`https://github.com/${PRODUCT_REPO_OWNER}/${PRODUCT_REPO_NAME}#getting-started`}
                 target="_blank"
                 rel="noreferrer"
                 style={{

--- a/octo11y/packages/dashboard/src/pages/DocsPage.tsx
+++ b/octo11y/packages/dashboard/src/pages/DocsPage.tsx
@@ -126,7 +126,7 @@ jobs:
 
       - run: go test -bench=. -count=5 ./... | tee bench.txt
 
-      - uses: strawgate/octo11y/actions/stash@main-dist
+      - uses: strawgate/o11ykit/octo11y/actions/stash@main-dist
         with:
           results: bench.txt
           format: auto`}</YamlBlock>
@@ -142,10 +142,10 @@ jobs:
   aggregate:
     runs-on: ubuntu-latest
     steps:
-      - uses: strawgate/octo11y/actions/aggregate@main-dist`}</YamlBlock>
+      - uses: strawgate/o11ykit/octo11y/actions/aggregate@main-dist`}</YamlBlock>
 
         <YamlBlock filename="compare.yml">{`# Add to your PR workflow
-- uses: strawgate/octo11y/actions/compare@main-dist
+- uses: strawgate/o11ykit/octo11y/actions/compare@main-dist
   with:
     results: bench.txt
     baseline-runs: 5

--- a/octo11y/packages/dashboard/src/pages/GuidePage.tsx
+++ b/octo11y/packages/dashboard/src/pages/GuidePage.tsx
@@ -1,6 +1,6 @@
 import { T } from "../tokens";
 import type { Route } from "../router";
-import { REPO_OWNER, REPO_NAME, fmtValue } from "../constants";
+import { PRODUCT_REPO_OWNER, PRODUCT_REPO_NAME, fmtValue } from "../constants";
 import { useRepoMetrics } from "../hooks/use-repo-metrics";
 import { Sparkline, YamlBlock, FadeIn } from "../components/ui";
 import { useEffect } from "preact/hooks";
@@ -322,11 +322,11 @@ jobs:
           GH_TOKEN: \${{ github.token }}
 
       - name: Save them forever ✨
-        uses: strawgate/octo11y/actions/stash@main-dist
+        uses: strawgate/o11ykit/octo11y/actions/stash@main-dist
         with: { results: stats.json, format: otlp }
 
       - name: Build the timeline
-        uses: strawgate/octo11y/actions/aggregate@main-dist`}
+        uses: strawgate/o11ykit/octo11y/actions/aggregate@main-dist`}
               </YamlBlock>
             </div>
           </FadeIn>
@@ -528,7 +528,7 @@ jobs:
                 See the live dashboard →
               </button>
               <a
-                href={`https://github.com/${REPO_OWNER}/${REPO_NAME}`}
+                href={`https://github.com/${PRODUCT_REPO_OWNER}/${PRODUCT_REPO_NAME}`}
                 target="_blank"
                 rel="noreferrer"
                 style={{

--- a/octo11y/packages/dashboard/vite.config.ts
+++ b/octo11y/packages/dashboard/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 import { resolve } from "node:path";
 import preact from "@preact/preset-vite";
 
-const base = process.env.BASE_PATH || "/octo11y/";
+const base = process.env.BASE_PATH || "/o11ykit/experiences/dashboard/";
 
 export default defineConfig({
   plugins: [preact()],

--- a/octo11y/packages/dashboard/vite.config.ts
+++ b/octo11y/packages/dashboard/vite.config.ts
@@ -2,9 +2,11 @@ import { defineConfig } from "vite";
 import { resolve } from "node:path";
 import preact from "@preact/preset-vite";
 
+const base = process.env.BASE_PATH || "/octo11y/";
+
 export default defineConfig({
   plugins: [preact()],
-  base: "/octo11y/",
+  base,
   build: {
     commonjsOptions: {
       include: [/format/, /node_modules/],

--- a/site/benchkit/index.html
+++ b/site/benchkit/index.html
@@ -19,7 +19,7 @@
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/" aria-current="page">Benchkit</a>
-          <a href="https://strawgate.github.io/o11ykit-playground/" target="_blank" rel="noreferrer">Playground</a>
+          <a href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">Playground</a>
         </nav>
       </header>
 
@@ -32,7 +32,7 @@
           baselines to catch regressions early.
         </p>
         <div class="hero-actions">
-          <a class="cta cta-primary" href="https://strawgate.github.io/o11ykit-playground/" target="_blank" rel="noreferrer">
+          <a class="cta cta-primary" href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">
             Open End-to-End Playground
           </a>
           <a class="cta" href="https://github.com/strawgate/o11ykit/tree/main/octo11y/actions" target="_blank" rel="noreferrer">

--- a/site/index.html
+++ b/site/index.html
@@ -81,6 +81,7 @@
             </ul>
             <div class="actions">
               <a href="/o11ykit/octo11y/">Open Octo11y Docs</a>
+              <a href="/o11ykit/experiences/dashboard/#guide">Open Octo11y Experience</a>
               <a href="https://strawgate.github.io/o11ykit-playground/" target="_blank" rel="noreferrer">Explore Playground</a>
               <a href="https://github.com/strawgate/o11ykit/tree/main/octo11y" target="_blank" rel="noreferrer">Browse Source</a>
             </div>
@@ -100,6 +101,7 @@
             </ul>
             <div class="actions">
               <a href="/o11ykit/benchkit/">Open Benchkit Docs</a>
+              <a href="/o11ykit/experiences/dashboard/#benchstory">Open Benchkit Experience</a>
               <a href="https://strawgate.github.io/o11ykit-playground/" target="_blank" rel="noreferrer">Run End-to-End Examples</a>
               <a href="https://github.com/strawgate/o11ykit/tree/main/octo11y/actions" target="_blank" rel="noreferrer">Browse Actions</a>
             </div>

--- a/site/index.html
+++ b/site/index.html
@@ -33,7 +33,7 @@
         </p>
         <div class="hero-actions">
           <a class="cta cta-primary" href="/o11ykit/otlpkit-docs/">Start With OtlpKit</a>
-          <a class="cta" href="https://strawgate.github.io/o11ykit-playground/" target="_blank" rel="noreferrer">
+          <a class="cta" href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">
             Open Live Playground
           </a>
         </div>
@@ -82,7 +82,7 @@
             <div class="actions">
               <a href="/o11ykit/octo11y/">Open Octo11y Docs</a>
               <a href="/o11ykit/experiences/dashboard/#guide">Open Octo11y Experience</a>
-              <a href="https://strawgate.github.io/o11ykit-playground/" target="_blank" rel="noreferrer">Explore Playground</a>
+              <a href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">Explore Playground</a>
               <a href="https://github.com/strawgate/o11ykit/tree/main/octo11y" target="_blank" rel="noreferrer">Browse Source</a>
             </div>
           </article>
@@ -102,7 +102,7 @@
             <div class="actions">
               <a href="/o11ykit/benchkit/">Open Benchkit Docs</a>
               <a href="/o11ykit/experiences/dashboard/#benchstory">Open Benchkit Experience</a>
-              <a href="https://strawgate.github.io/o11ykit-playground/" target="_blank" rel="noreferrer">Run End-to-End Examples</a>
+              <a href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">Run End-to-End Examples</a>
               <a href="https://github.com/strawgate/o11ykit/tree/main/octo11y/actions" target="_blank" rel="noreferrer">Browse Actions</a>
             </div>
           </article>

--- a/site/octo11y/index.html
+++ b/site/octo11y/index.html
@@ -19,7 +19,7 @@
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/octo11y/" aria-current="page">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
-          <a href="https://strawgate.github.io/o11ykit-playground/" target="_blank" rel="noreferrer">Playground</a>
+          <a href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">Playground</a>
         </nav>
       </header>
 
@@ -31,7 +31,7 @@
           logs, benchmark outputs, and repo metadata into structured run history and published views.
         </p>
         <div class="hero-actions">
-          <a class="cta cta-primary" href="https://strawgate.github.io/o11ykit-playground/" target="_blank" rel="noreferrer">
+          <a class="cta cta-primary" href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">
             Open Live Playground
           </a>
           <a class="cta" href="https://github.com/strawgate/o11ykit/tree/main/octo11y" target="_blank" rel="noreferrer">


### PR DESCRIPTION
## Summary
- restore and wire o11ykit site experience links for Octo11y and Benchkit
- wire dashboard data source/configuration for the consolidated o11ykit setup
- switch aggregate step in sample workflow to published dist action (`strawgate/o11ykit/octo11y/actions/aggregate@main-dist`)
- make sample benchmark ingest reliable by parsing a benchmark file in the same job (`mode=file`)
- include aggregate ingestion support for OTLP JSONL sidecars and immediate initial hostmetrics scrape behavior used by monitor flows

## Included commits
- f98d95f `site: finish experiences data wiring and sample ingest`
- c394c8c `ci(benchmarks): use main-dist aggregate action`
- 36f6061 `site/dashboard: wire experiences to live o11ykit data flow`
- 03f1500 `site: restore octo11y and benchkit experience links`
- 329cb5e `monitor: force immediate first hostmetrics scrape`
- 46960f1 `aggregate: ingest per-run OTLP jsonl sidecars`
- 2c034b7 `docs: align boundary plan naming with otlpkit`

## Validation
- local Playwright smoke on:
  - `/o11ykit/`
  - `/o11ykit/experiences/dashboard/#guide`
  - `/o11ykit/experiences/dashboard/#benchstory`
  - result: no failed requests / no console errors
- benchmark sample workflow passed after changes:
  - https://github.com/strawgate/o11ykit/actions/runs/24408312829
- `bench-data` now contains non-empty metric series (`allocs_per_op`, `bytes_per_op`, `ns_per_op`)
