### PR TITLE
docs: add o11ytsdb to top-level README and ARCHITECTURE

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,24 +3,27 @@
 This repository is organized as a layered monorepo:
 
 1. `@otlpkit/*` (foundation)
-2. `@octo11y/*` (GitHub-driven metrics product layer)
-3. `@benchkit/*` (benchmark + monitor extensions)
+2. `o11ytsdb` (browser-native time-series database)
+3. `@octo11y/*` (GitHub-driven metrics product layer)
+4. `@benchkit/*` (benchmark + monitor extensions)
 
 ## Dependency Direction
 
 Allowed:
 
+- `o11ytsdb` depends on `@otlpkit/*`
 - `@octo11y/*` depends on `@otlpkit/*`
 - `@benchkit/*` depends on `@octo11y/*`
 
 Disallowed:
 
-- `@otlpkit/*` depending on `@octo11y/*` or `@benchkit/*`
+- `@otlpkit/*` depending on `@octo11y/*`, `@benchkit/*`, or `o11ytsdb`
 - `@octo11y/*` depending on `@benchkit/*`
 
 ## Package Scope Rules
 
 - Generic OTLP parsing, query, view shaping, and chart adapters belong in `@otlpkit/*`.
+- Time-series storage, compression codecs, and in-browser query execution belong in `o11ytsdb`.
 - GitHub Actions/workflows and GitHub-derived metric logic belong in `@octo11y/*`.
 - Benchmark-specific parsers, semantics, and monitor-centric extensions belong in `@benchkit/*`.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Top-level projects:
 
 - `@otlpkit/*` (root `packages/*`): OTLP parsing/query/view/adapters for browser dashboards and app diagnostics.
+- `o11ytsdb` (root `packages/o11ytsdb`): browser-native time-series database for OpenTelemetry data with WASM-accelerated codecs.
 - `octo11y` (`/octo11y`): GitHub Actions-driven metrics pipeline and UI packages.
 - `benchkit` (`/octo11y`): benchmark-focused packages/actions layered on octo11y.
 
@@ -14,6 +15,10 @@ The root project currently hosts the `@otlpkit/*` JavaScript libraries:
 - `@otlpkit/query`: filter, group, and bucket materialized telemetry records
 - `@otlpkit/views`: build reusable frames such as time series, latest-value tables, histograms, trace waterfalls, and event timelines
 - `@otlpkit/adapters`: project frames into library-native Chart.js, Recharts, ECharts, and uPlot shapes
+
+And the `o11ytsdb` time-series database:
+
+- `o11ytsdb`: XOR-delta (Gorilla) codec with TypeScript, Zig→WASM, and Rust→WASM implementations; chunked and columnar storage backends; baseline query engine. See [`packages/o11ytsdb/README.md`](./packages/o11ytsdb/README.md) for benchmarks and status.
 
 The root project currently hosts this GitHub Action:
 


### PR DESCRIPTION
Adds o11ytsdb (browser-native time-series database) to the monorepo documentation:  - **README.md**: Listed as a top-level project alongside @otlpkit/*, added package description with link to detailed README and benchmarks - **ARCHITECTURE.md**: Added as layer 2 in the dependency stack, defined scope rules for time-series storage/codecs, updated dependency direction rules  This brings the docs up to date after PR #72 merged the o11ytsdb M1 codec.