### PR TITLE
perf(o11ytsdb): ChunkStats-skip for step aggregation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ packages/*/.tsbuildinfo
 
 .codex/
 .DS_Store
+in-memory-ideas*
+in-memory\ ideas*
 playwright-report/
 test-results/
 

--- a/packages/o11ytsdb/.gitignore
+++ b/packages/o11ytsdb/.gitignore
@@ -1,5 +1,6 @@
 bench/results/
 bench/dist/
+bench/*.cpuprofile
 wasm/
 dist/
 .tsbuildinfo

--- a/packages/o11ytsdb/bench/ab-stepagg.mjs
+++ b/packages/o11ytsdb/bench/ab-stepagg.mjs
@@ -1,0 +1,127 @@
+/**
+ * A/B comparison: original BigInt stepAggregate vs DataView+Number stepAggregate.
+ * Both run in the same process to eliminate system-load variance.
+ */
+import { performance } from "node:perf_hooks";
+
+const N = 5_000_000;
+const SERIES = 30;
+const PER_SERIES = Math.ceil(N / SERIES);
+const T0 = 1700000000000n;
+const INTERVAL = 15000n;
+const STEP = 60000n;
+const STEP_N = 60000;
+
+// Build ranges (simulate 30 series)
+const ranges = [];
+for (let s = 0; s < SERIES; s++) {
+  const ts = new BigInt64Array(PER_SERIES);
+  const vals = new Float64Array(PER_SERIES);
+  for (let i = 0; i < PER_SERIES; i++) {
+    ts[i] = T0 + BigInt(i) * INTERVAL;
+    vals[i] = Math.sin(i * 0.001 + s) * 50 + 100;
+  }
+  ranges.push({ timestamps: ts, values: vals });
+}
+
+// ── Original: BigInt sub+div per sample ──
+function stepAggOriginal(ranges, step) {
+  let minT = BigInt("9223372036854775807");
+  let maxT = -minT;
+  for (const r of ranges) {
+    if (r.timestamps.length === 0) continue;
+    if (r.timestamps[0] < minT) minT = r.timestamps[0];
+    if (r.timestamps[r.timestamps.length - 1] > maxT)
+      maxT = r.timestamps[r.timestamps.length - 1];
+  }
+  const bucketCount = Number((maxT - minT) / step) + 1;
+  const values = new Float64Array(bucketCount);
+  values.fill(Infinity);
+  for (const r of ranges) {
+    for (let i = 0; i < r.timestamps.length; i++) {
+      const bucket = Number((r.timestamps[i] - minT) / step);
+      if (r.values[i] < values[bucket]) values[bucket] = r.values[i];
+    }
+  }
+  return values;
+}
+
+// ── New: DataView conversion + Number inner loop ──
+const _le = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+
+function bigInt64ToFloat64(src) {
+  const n = src.length;
+  const dst = new Float64Array(n);
+  const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+  for (let i = 0; i < n; i++) {
+    const off = i * 8;
+    const lo = dv.getUint32(off, _le);
+    const hi = dv.getInt32(off + 4, _le);
+    dst[i] = hi * 4294967296 + lo;
+  }
+  return dst;
+}
+
+function stepAggDataView(ranges, step) {
+  let minT = BigInt("9223372036854775807");
+  let maxT = -minT;
+  for (const r of ranges) {
+    if (r.timestamps.length === 0) continue;
+    if (r.timestamps[0] < minT) minT = r.timestamps[0];
+    if (r.timestamps[r.timestamps.length - 1] > maxT)
+      maxT = r.timestamps[r.timestamps.length - 1];
+  }
+  const bucketCount = Number((maxT - minT) / step) + 1;
+  const values = new Float64Array(bucketCount);
+  values.fill(Infinity);
+
+  const minTN = Number(minT);
+  const stepN = Number(step);
+
+  const tsNum = new Array(ranges.length);
+  for (let ri = 0; ri < ranges.length; ri++) {
+    tsNum[ri] = bigInt64ToFloat64(ranges[ri].timestamps);
+  }
+
+  for (let ri = 0; ri < ranges.length; ri++) {
+    const ts = tsNum[ri];
+    const vs = ranges[ri].values;
+    for (let i = 0, len = ts.length; i < len; i++) {
+      const bucket = (ts[i] - minTN) / stepN | 0;
+      if (vs[i] < values[bucket]) values[bucket] = vs[i];
+    }
+  }
+  return values;
+}
+
+// ── Benchmark ──
+function bench(name, fn, warmup = 3, runs = 7) {
+  for (let w = 0; w < warmup; w++) fn();
+  const times = [];
+  for (let r = 0; r < runs; r++) {
+    if (global.gc) global.gc();
+    const t0 = performance.now();
+    fn();
+    times.push(performance.now() - t0);
+  }
+  times.sort((a, b) => a - b);
+  console.log(`  ${name.padEnd(30)} min=${times[0].toFixed(1)}ms  med=${times[3].toFixed(1)}ms  max=${times[6].toFixed(1)}ms`);
+  return times[3]; // median
+}
+
+console.log(`  ${SERIES} series × ${PER_SERIES.toLocaleString()} pts = ${(SERIES * PER_SERIES).toLocaleString()} samples\n`);
+
+const medOrig = bench("Original (BigInt)", () => stepAggOriginal(ranges, STEP));
+const medNew = bench("DataView + Number", () => stepAggDataView(ranges, STEP));
+
+console.log(`\n  Speedup: ${(medOrig / medNew).toFixed(2)}x  (${(medOrig - medNew).toFixed(1)}ms saved)`);
+
+// Verify correctness
+const a = stepAggOriginal(ranges, STEP);
+const b = stepAggDataView(ranges, STEP);
+let maxErr = 0;
+for (let i = 0; i < a.length; i++) {
+  const err = Math.abs(a[i] - b[i]);
+  if (err > maxErr) maxErr = err;
+}
+console.log(`  Max error: ${maxErr} (${maxErr === 0 ? 'EXACT MATCH ✓' : maxErr < 1e-10 ? 'negligible ✓' : 'MISMATCH ✗'})`);

--- a/packages/o11ytsdb/bench/delta-alp-test.mjs
+++ b/packages/o11ytsdb/bench/delta-alp-test.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * Delta-ALP codec test — verify round-trip and measure compression
+ * improvement for monotonic counter patterns.
+ */
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(__dirname, "..");
+
+const b = readFileSync(join(pkgDir, "wasm/o11ytsdb-rust.wasm"));
+const { instance } = await WebAssembly.instantiate(b, { env: {} });
+const w = instance.exports;
+const mem = () => new Uint8Array(w.memory.buffer);
+
+const CHUNK = 640;
+
+// ── Helpers ──
+
+function alpEncodeWithStats(vals) {
+  const n = vals.length;
+  w.resetScratch();
+  const vp = w.allocScratch(n * 8);
+  mem().set(new Uint8Array(vals.buffer, vals.byteOffset, vals.byteLength), vp);
+  const op = w.allocScratch(n * 20);
+  const sp = w.allocScratch(8 * 8); // 8 stats
+  const bw = w.encodeValuesALPWithStats(vp, n, op, n * 20, sp);
+  const compressed = new Uint8Array(w.memory.buffer.slice(op, op + bw));
+  const stats = new Float64Array(w.memory.buffer.slice(sp, sp + 64));
+  return { compressed, stats };
+}
+
+function alpEncodePlain(vals) {
+  const n = vals.length;
+  w.resetScratch();
+  const vp = w.allocScratch(n * 8);
+  mem().set(new Uint8Array(vals.buffer, vals.byteOffset, vals.byteLength), vp);
+  const op = w.allocScratch(n * 20);
+  const bw = w.encodeValuesALP(vp, n, op, n * 20);
+  return new Uint8Array(w.memory.buffer.slice(op, op + bw));
+}
+
+function alpDecode(buf) {
+  w.resetScratch();
+  const ip = w.allocScratch(buf.length);
+  mem().set(buf, ip);
+  const vp = w.allocScratch(CHUNK * 8);
+  const n = w.decodeValuesALP(ip, buf.length, vp, CHUNK);
+  return new Float64Array(w.memory.buffer.slice(vp, vp + n * 8));
+}
+
+function verify(original, decoded) {
+  if (original.length !== decoded.length) {
+    console.log(`  length mismatch: ${original.length} vs ${decoded.length}`);
+    return false;
+  }
+  for (let i = 0; i < original.length; i++) {
+    if (original[i] !== decoded[i]) {
+      console.log(`  mismatch at [${i}]: ${original[i]} vs ${decoded[i]}`);
+      return false;
+    }
+  }
+  return true;
+}
+
+// ── Seeded RNG (same as vectors.ts) ──
+
+class Rng {
+  constructor(seed = 42) {
+    this.s = new Uint32Array(4);
+    this.s[0] = seed;
+    this.s[1] = seed ^ 0x6c078965;
+    this.s[2] = seed ^ 0xdeadbeef;
+    this.s[3] = seed ^ 0x01234567;
+    for (let i = 0; i < 16; i++) this.next();
+  }
+  next() {
+    const s = this.s;
+    const result = Math.imul(this.rotl(Math.imul(s[0], 5), 7), 9) >>> 0;
+    const t = s[1] << 9;
+    s[2] ^= s[0]; s[3] ^= s[1]; s[1] ^= s[2]; s[0] ^= s[3];
+    s[2] ^= t; s[3] = this.rotl(s[3], 11);
+    return result / 0x100000000;
+  }
+  rotl(x, k) { return ((x << k) | (x >>> (32 - k))) >>> 0; }
+  int(lo, hi) { return lo + Math.floor(this.next() * (hi - lo + 1)); }
+}
+
+// ── Test patterns ──
+
+const rng = new Rng(42);
+
+const patterns = [
+  // Monotonic counter (should trigger delta-ALP)
+  (() => {
+    const vals = new Float64Array(CHUNK);
+    let v = 1_000_000;
+    for (let i = 0; i < CHUNK; i++) { v += rng.int(10, 200); vals[i] = v; }
+    return { name: "monotonicCounter", vals };
+  })(),
+  // Counter with 40% idle (same as engine.bench pattern)
+  (() => {
+    const r2 = new Rng(123);
+    const vals = new Float64Array(CHUNK);
+    let counter = 5000;
+    for (let i = 0; i < CHUNK; i++) {
+      const idle = r2.next() < 0.4;
+      if (!idle) counter += Math.floor(r2.next() * 10) + 1;
+      vals[i] = counter;
+    }
+    return { name: "counterWith40%Idle", vals };
+  })(),
+  // Constant (should NOT trigger delta-ALP)
+  (() => {
+    const vals = new Float64Array(CHUNK);
+    for (let i = 0; i < CHUNK; i++) vals[i] = 42.0;
+    return { name: "constant", vals };
+  })(),
+  // Slow gauge (has resets, should NOT trigger delta-ALP)
+  (() => {
+    const r2 = new Rng(99);
+    const vals = new Float64Array(CHUNK);
+    let v = 45.0;
+    for (let i = 0; i < CHUNK; i++) {
+      v += (r2.next() - 0.5) * 2;
+      v = Math.max(0, Math.min(100, v));
+      vals[i] = Math.round(v * 100) / 100;
+    }
+    return { name: "slowGauge", vals };
+  })(),
+  // High entropy (should NOT trigger delta-ALP)
+  (() => {
+    const r2 = new Rng(77);
+    const vals = new Float64Array(CHUNK);
+    for (let i = 0; i < CHUNK; i++) vals[i] = r2.next() * 1e6;
+    return { name: "highEntropy", vals };
+  })(),
+];
+
+// ── Run tests ──
+
+console.log(`\n  Delta-ALP codec test (chunk=${CHUNK})\n`);
+console.log(
+  "  Pattern              plainALP  deltaALP  ratio  tag  roundTrip"
+);
+console.log("  " + "─".repeat(70));
+
+let allOk = true;
+for (const { name, vals } of patterns) {
+  // Plain ALP (no stats, no delta detection)
+  const plainBuf = alpEncodePlain(vals);
+
+  // ALP with stats (triggers delta-ALP detection)
+  const { compressed: statsBuf, stats } = alpEncodeWithStats(vals);
+
+  // Check if delta-ALP was used: first byte == 0xDA
+  const isDelta = statsBuf[0] === 0xDA;
+
+  // Decode the stats-encoded blob
+  const decoded = alpDecode(statsBuf);
+  const ok = verify(vals, decoded);
+  allOk = allOk && ok;
+
+  // Also verify plain ALP still decodes
+  const decodedPlain = alpDecode(plainBuf);
+  const okPlain = verify(vals, decodedPlain);
+  allOk = allOk && okPlain;
+
+  const ratio = plainBuf.length / statsBuf.length;
+
+  console.log(
+    `  ${name.padEnd(22)}` +
+    `${String(plainBuf.length).padStart(6)} B  ` +
+    `${String(statsBuf.length).padStart(6)} B  ` +
+    `${ratio.toFixed(2).padStart(5)}x  ` +
+    `${isDelta ? "δALP" : " ALP"}  ` +
+    `${ok && okPlain ? "✓" : "✗ FAIL"}`
+  );
+}
+
+console.log("");
+if (allOk) {
+  console.log("  All patterns round-trip correctly ✓\n");
+} else {
+  console.log("  ROUND-TRIP FAILURES ✗\n");
+  process.exit(1);
+}

--- a/packages/o11ytsdb/bench/diag-exponent.mjs
+++ b/packages/o11ytsdb/bench/diag-exponent.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Exponent selection diagnostic — tries every ALP exponent on real OTel
+ * data and reports actual encoded sizes to validate the cost model.
+ */
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(__dirname, '..');
+
+const { loadWasm, makeALPValuesCodec } = await import(join(__dirname, 'dist', 'wasm-loader.js'));
+const wasm = await loadWasm(join(pkgDir, 'wasm/o11ytsdb-rust.wasm'));
+const alp = makeALPValuesCodec(wasm);
+
+const { loadOtelData } = await import(join(__dirname, 'load-otel.mjs'));
+
+// Load real data
+const cpuSeries = await loadOtelData(join(__dirname, 'data/cpu.jsonl'));
+const infraSeries = await loadOtelData(join(__dirname, 'data/infra.jsonl'));
+
+// Pick representative series from different metric types
+const targets = [
+  ...cpuSeries.filter(s => s.labels.get('__name__') === 'system.cpu.utilization').slice(0, 2),
+  ...cpuSeries.filter(s => s.labels.get('__name__') === 'system.cpu.time').slice(0, 2),
+  ...cpuSeries.filter(s => s.labels.get('__name__') === 'system.cpu.load_average.1m'),
+  ...infraSeries.filter(s => s.labels.get('__name__') === 'system.memory.utilization').slice(0, 2),
+  ...infraSeries.filter(s => s.labels.get('__name__') === 'system.filesystem.utilization').slice(0, 1),
+  ...infraSeries.filter(s => s.labels.get('__name__') === 'system.network.io').slice(0, 2),
+  ...infraSeries.filter(s => s.labels.get('__name__') === 'system.disk.io_time').slice(0, 1),
+];
+
+console.log(`Exponent selection diagnostic (${targets.length} series)\n`);
+
+for (const s of targets) {
+  const name = s.labels.get('__name__');
+  const extra = s.labels.get('state') || s.labels.get('direction') || s.labels.get('device') || '';
+  const chunk = s.values.subarray(0, Math.min(640, s.values.length));
+  const n = chunk.length;
+
+  // Current codec result (uses cost-model exponent selection)
+  const { compressed } = alp.encodeValuesWithStats(chunk);
+  
+  // Parse what exponent was chosen
+  const chosenExp = compressed[2];
+  const chosenExc = (compressed[12] << 8) | compressed[13];
+  const chosenBw = compressed[3];
+
+  // Verify round-trip
+  const decoded = alp.decodeValues(compressed);
+  let ok = true;
+  for (let i = 0; i < n; i++) {
+    if (chunk[i] !== decoded[i]) { ok = false; break; }
+  }
+
+  console.log(`  ${name} [${extra}] — ${n} pts, chosen e=${chosenExp} bw=${chosenBw} exc=${chosenExc}/${n} → ${compressed.byteLength} B (${(compressed.byteLength/n).toFixed(2)} B/pt) roundtrip=${ok ? '✓' : '✗'}`);
+}
+
+// Now do a deep dive on cpu.utilization: what would each exponent cost?
+console.log(`\n\nDeep dive: system.cpu.utilization (first non-constant series)\n`);
+const utilSeries = cpuSeries.filter(s => {
+  if (s.labels.get('__name__') !== 'system.cpu.utilization') return false;
+  // Skip constant series (all zeros)
+  for (let i = 1; i < Math.min(10, s.values.length); i++) {
+    if (s.values[i] !== s.values[0]) return true;
+  }
+  return false;
+});
+
+if (utilSeries.length > 0) {
+  const s = utilSeries[0];
+  const chunk = s.values.subarray(0, Math.min(640, s.values.length));
+  const n = chunk.length;
+  
+  console.log(`  Sample values: ${Array.from(chunk.subarray(0, 5)).map(v => v.toPrecision(6)).join(', ')}`);
+  console.log(`  ${n} samples\n`);
+
+  // For each exponent, manually count matches and estimate what the cost model sees
+  console.log(`  ${'Exp'.padStart(4)} ${'Matches'.padStart(8)} ${'Exceptions'.padStart(11)} ${'Est bw'.padStart(7)} ${'Est cost'.padStart(9)}  ${'Actual'.padStart(8)} ${'Actual B/pt'.padStart(12)}`);
+  console.log(`  ${'─'.repeat(70)}`);
+
+  // We can't easily try each exponent through WASM since the codec picks its own.
+  // But we can simulate the cost model in JS.
+  const POW10 = Array.from({length: 19}, (_, i) => 10 ** i);
+  
+  function alpTry(val, e) {
+    if (!isFinite(val)) return null;
+    const scaled = val * POW10[e];
+    if (Math.abs(scaled) > 9.2e18) return null;
+    const intVal = Math.round(scaled);
+    const reconstructed = intVal / POW10[e];
+    return reconstructed === val ? intVal : null;
+  }
+
+  for (let e = 0; e <= 18; e++) {
+    let matchCount = 0, minInt = Infinity, maxInt = -Infinity;
+    for (let i = 0; i < n; i++) {
+      const iv = alpTry(chunk[i], e);
+      if (iv !== null) {
+        matchCount++;
+        if (iv < minInt) minInt = iv;
+        if (iv > maxInt) maxInt = iv;
+      }
+    }
+    const excCount = n - matchCount;
+    const range = matchCount >= 2 ? maxInt - minInt : 0;
+    const bw = range > 0 ? Math.ceil(Math.log2(range + 1)) : 0;
+    
+    const matchBytes = Math.ceil(n * bw / 8);
+    const excBytes4 = excCount * 4;
+    const excBytes6 = excCount * 6;
+    const excBytes8 = excCount * 8;
+    const cost4 = 14 + matchBytes + excBytes4;
+    const cost6 = 14 + matchBytes + excBytes6;
+    const cost8 = 14 + matchBytes + excBytes8;
+
+    console.log(`  ${String(e).padStart(4)} ${String(matchCount).padStart(8)} ${String(excCount).padStart(11)} ${String(bw).padStart(7)} ${String(cost6).padStart(9)}  (c=4: ${cost4}, c=8: ${cost8})`);
+  }
+
+  // Also show what pure Gorilla XOR on all values would cost
+  // (The codec result at e=0 with all exceptions IS effectively Gorilla on all values)
+  const { compressed } = alp.encodeValuesWithStats(chunk);
+  console.log(`\n  Actual encoded: ${compressed.byteLength} B (${(compressed.byteLength/n).toFixed(2)} B/pt), e=${compressed[2]}, bw=${compressed[3]}, exc=${(compressed[12]<<8)|compressed[13]}`);
+}

--- a/packages/o11ytsdb/bench/diag-for-u64.mjs
+++ b/packages/o11ytsdb/bench/diag-for-u64.mjs
@@ -1,0 +1,59 @@
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(__dirname, '..');
+
+const { loadWasm, makeALPValuesCodec } = await import(join(__dirname, 'dist', 'wasm-loader.js'));
+const wasm = await loadWasm(join(pkgDir, 'wasm/o11ytsdb-rust.wasm'));
+const alp = makeALPValuesCodec(wasm);
+
+const { loadOtelData } = await import(join(__dirname, 'load-otel.mjs'));
+const series = await loadOtelData(join(__dirname, 'data/cpu.jsonl'));
+
+const utils = series.filter(s => s.labels.get('__name__') === 'system.cpu.utilization').slice(0, 8);
+for (const s of utils) {
+  const st = s.labels.get('state') || '';
+  const cpu = s.labels.get('cpu') || '';
+  const chunk = s.values.subarray(0, Math.min(525, s.values.length));
+  const n = chunk.length;
+  const { compressed } = alp.encodeValuesWithStats(chunk);
+  const hdrN = (compressed[0] << 8) | compressed[1];
+  const e = compressed[2];
+  const bw = compressed[3];
+  const excCount = (compressed[12] << 8) | compressed[13];
+  
+  // Parse FoR-u64 exc_bw from the payload.
+  const bitPackedBytes = Math.ceil(hdrN * bw / 8);
+  const posBytes = (excCount > 0 && excCount < hdrN) ? excCount * 2 : 0;
+  const excPayloadStart = 14 + bitPackedBytes + posBytes;
+  let excBw = 0;
+  if (excCount > 0 && excPayloadStart + 9 <= compressed.byteLength) {
+    excBw = compressed[excPayloadStart + 8];
+  }
+  
+  // Compute sortable-u64 range in JS for validation.
+  function f64ToSortableU64(f) {
+    const buf = new ArrayBuffer(8);
+    new Float64Array(buf)[0] = f;
+    const bits = new BigUint64Array(buf)[0];
+    if (bits & (1n << 63n)) return ~bits;
+    return bits ^ (1n << 63n);
+  }
+  
+  let minSU = 0xFFFFFFFFFFFFFFFFn, maxSU = 0n;
+  for (let i = 0; i < n; i++) {
+    const su = f64ToSortableU64(chunk[i]);
+    if (su < minSU) minSU = su;
+    if (su > maxSU) maxSU = su;
+  }
+  const range = maxSU - minSU;
+  const jsBw = range > 0n ? BigInt(64) - BigInt(Math.clz32(Number(range >> 32n))) + 32n : 0n;
+  // More precise:
+  let rBw = 0;
+  let r = range;
+  while (r > 0n) { rBw++; r >>= 1n; }
+  
+  console.log(`${cpu}/${st}: e=${e} bw=${bw} exc=${excCount}/${hdrN} exc_bw=${excBw} size=${compressed.byteLength} (${(compressed.byteLength/n).toFixed(2)} B/pt)  JS-range-bits=${rBw}`);
+  console.log(`  val range: [${Math.min(...chunk).toPrecision(4)}, ${Math.max(...chunk).toPrecision(4)}]`);
+}

--- a/packages/o11ytsdb/bench/micro-agg.mjs
+++ b/packages/o11ytsdb/bench/micro-agg.mjs
@@ -1,0 +1,105 @@
+import { performance } from "node:perf_hooks";
+
+const N = 5_000_000;
+const ts = new BigInt64Array(N);
+const tsF = new Float64Array(N);
+const vals = new Float64Array(N);
+
+for (let i = 0; i < N; i++) {
+  ts[i] = 1700000000000n + BigInt(i) * 15000n;
+  tsF[i] = 1700000000000 + i * 15000;
+  vals[i] = Math.random() * 100;
+}
+
+const buckets = new Float64Array(42000);
+const minT = 1700000000000n;
+const step = 60000n;
+const minTN = 1700000000000;
+const stepN = 60000;
+
+function bench(name, fn, warmup = 3, runs = 5) {
+  for (let w = 0; w < warmup; w++) fn();
+  const times = [];
+  for (let r = 0; r < runs; r++) {
+    if (global.gc) global.gc();
+    const t0 = performance.now();
+    fn();
+    times.push(performance.now() - t0);
+  }
+  times.sort((a, b) => a - b);
+  const mid = times.length >> 1;
+  const median = times.length % 2 ? times[mid] : (times[mid - 1] + times[mid]) / 2;
+  console.log(`  ${name.padEnd(30)} min=${times[0].toFixed(1)}ms  median=${median.toFixed(1)}ms`);
+}
+
+// 1. Original: BigInt subtract + divide per element
+bench("BigInt sub+div", () => {
+  buckets.fill(Infinity);
+  for (let i = 0; i < N; i++) {
+    const b = Number((ts[i] - minT) / step);
+    if (vals[i] < buckets[b]) buckets[b] = vals[i];
+  }
+});
+
+// 2. Pre-converted Float64Array (ideal inner loop)
+bench("Float64 div", () => {
+  buckets.fill(Infinity);
+  for (let i = 0; i < N; i++) {
+    const b = (tsF[i] - minTN) / stepN | 0;
+    if (vals[i] < buckets[b]) buckets[b] = vals[i];
+  }
+});
+
+// 3. Number(BigInt) inline + Number arithmetic
+bench("Number(BigInt) inline", () => {
+  buckets.fill(Infinity);
+  for (let i = 0; i < N; i++) {
+    const b = (Number(ts[i]) - minTN) / stepN | 0;
+    if (vals[i] < buckets[b]) buckets[b] = vals[i];
+  }
+});
+
+// 4. Batch convert then Number loop
+bench("Batch convert + loop", () => {
+  const tsN = new Float64Array(N);
+  for (let i = 0; i < N; i++) tsN[i] = Number(ts[i]);
+  buckets.fill(Infinity);
+  for (let i = 0; i < N; i++) {
+    const b = (tsN[i] - minTN) / stepN | 0;
+    if (vals[i] < buckets[b]) buckets[b] = vals[i];
+  }
+});
+
+// 5. Conversion cost alone
+bench("BigInt->Number convert only", () => {
+  const dst = new Float64Array(N);
+  for (let i = 0; i < N; i++) dst[i] = Number(ts[i]);
+});
+
+// 6. DataView approach (read BigInt64 as bytes, convert)
+bench("DataView i64->f64", () => {
+  const buf = ts.buffer;
+  const dv = new DataView(buf);
+  const dst = new Float64Array(N);
+  for (let i = 0; i < N; i++) {
+    // Read the low 32 bits + high 32 bits, combine as Number
+    const lo = dv.getUint32(i * 8, true);
+    const hi = dv.getInt32(i * 8 + 4, true);
+    dst[i] = hi * 4294967296 + lo;
+  }
+  buckets.fill(Infinity);
+  for (let i = 0; i < N; i++) {
+    const b = (dst[i] - minTN) / stepN | 0;
+    if (vals[i] < buckets[b]) buckets[b] = vals[i];
+  }
+});
+
+// 7. Float64Array reinterpret (timestamps stored as Float64Array from the start)
+// This simulates what we'd get if read() returned Float64Array timestamps
+bench("Float64 pre-stored (best)", () => {
+  buckets.fill(Infinity);
+  for (let i = 0; i < N; i++) {
+    const b = (tsF[i] - minTN) / stepN | 0;
+    if (vals[i] < buckets[b]) buckets[b] = vals[i];
+  }
+});

--- a/packages/o11ytsdb/bench/profile-query.mjs
+++ b/packages/o11ytsdb/bench/profile-query.mjs
@@ -1,0 +1,421 @@
+#!/usr/bin/env node
+/**
+ * Query-focused profiler — reproduces real-world aggregation workloads.
+ *
+ * Default scenario: 5M datapoints, 30 series, min agg with 1-min step, groupBy region.
+ *
+ * Usage:
+ *   node --expose-gc bench/profile-query.mjs
+ *   node --cpu-prof bench/profile-query.mjs           # V8 CPU profile
+ *   node --cpu-prof bench/profile-query.mjs --detail  # per-phase CPU profiles
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(__dirname, "..");
+
+// ── Config ───────────────────────────────────────────────────────────
+
+const NUM_SERIES = 30;
+const POINTS_PER_SERIES = Math.ceil(5_000_000 / NUM_SERIES); // ~166,667 pts each → 5M total
+const TOTAL_SAMPLES = NUM_SERIES * POINTS_PER_SERIES;
+const CHUNK_SIZE = 512;
+const T0 = 1_700_000_000_000n;           // epoch ms
+const INTERVAL = 15_000n;                 // 15s scrape interval
+const REGIONS = ["us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1", "eu-central-1"];
+const AGG_STEP = 60_000n;                 // 1 minute aggregation step
+
+// ── Data generation (30 series across 5 regions) ─────────────────────
+
+function generateData() {
+  const series = [];
+  for (let s = 0; s < NUM_SERIES; s++) {
+    const timestamps = new BigInt64Array(POINTS_PER_SERIES);
+    const values = new Float64Array(POINTS_PER_SERIES);
+    for (let i = 0; i < POINTS_PER_SERIES; i++) {
+      timestamps[i] = T0 + BigInt(i) * INTERVAL;
+      // Realistic gauge data with some variety per series
+      const base = Math.sin(i * 0.001 + s) * 50 + 100;
+      values[i] = base + (Math.random() - 0.5) * 10;
+    }
+    const region = REGIONS[s % REGIONS.length];
+    const labels = new Map([
+      ["__name__", "cpu_usage"],
+      ["region", region],
+      ["instance", `host-${s}`],
+    ]);
+    series.push({ labels, timestamps, values });
+  }
+  return series;
+}
+
+// ── WASM loader (reuse from profile.mjs) ─────────────────────────────
+
+function loadWasmSync() {
+  const wasmPath = join(pkgDir, "wasm/o11ytsdb-rust.wasm");
+  return readFileSync(wasmPath);
+}
+
+async function makeWasmCodecs(wasmBytes) {
+  const { instance } = await WebAssembly.instantiate(wasmBytes, { env: {} });
+  const w = instance.exports;
+  const mem = () => new Uint8Array(w.memory.buffer);
+
+  const alpValuesCodec = {
+    name: "rust-wasm-alp",
+    encodeValues(values) {
+      const n = values.length;
+      w.resetScratch();
+      const valPtr = w.allocScratch(n * 8);
+      const outCap = n * 20;
+      const outPtr = w.allocScratch(outCap);
+      mem().set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valPtr);
+      return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeValuesALP(valPtr, n, outPtr, outCap)));
+    },
+    decodeValues(buf) {
+      w.resetScratch();
+      const inPtr = w.allocScratch(buf.length);
+      mem().set(buf, inPtr);
+      const maxSamples = (buf[0] << 8) | buf[1];
+      const valPtr = w.allocScratch(maxSamples * 8);
+      const n = w.decodeValuesALP(inPtr, buf.length, valPtr, maxSamples);
+      return new Float64Array(w.memory.buffer.slice(valPtr, valPtr + n * 8));
+    },
+    encodeValuesWithStats(values) {
+      const n = values.length;
+      w.resetScratch();
+      const valPtr = w.allocScratch(n * 8);
+      const outCap = n * 20;
+      const outPtr = w.allocScratch(outCap);
+      const statsPtr = w.allocScratch(64);
+      mem().set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valPtr);
+      const bytesWritten = w.encodeValuesALPWithStats(valPtr, n, outPtr, outCap, statsPtr);
+      const compressed = new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + bytesWritten));
+      const s = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + 64));
+      return {
+        compressed,
+        stats: { minV: s[0], maxV: s[1], sum: s[2], count: s[3], firstV: s[4], lastV: s[5], sumOfSquares: s[6], resetCount: s[7] },
+      };
+    },
+    encodeBatchValuesWithStats(arrays) {
+      const numArrays = arrays.length;
+      const chunkSize = arrays[0].length;
+      w.resetScratch();
+      const valsPtr = w.allocScratch(numArrays * chunkSize * 8);
+      for (let i = 0; i < numArrays; i++) {
+        mem().set(new Uint8Array(arrays[i].buffer, arrays[i].byteOffset, arrays[i].byteLength), valsPtr + i * chunkSize * 8);
+      }
+      const outCap = numArrays * chunkSize * 20;
+      const outPtr = w.allocScratch(outCap);
+      const offsetsPtr = w.allocScratch(numArrays * 4);
+      const sizesPtr = w.allocScratch(numArrays * 4);
+      const statsPtr = w.allocScratch(numArrays * 64);
+      w.encodeBatchValuesALPWithStats(valsPtr, chunkSize, numArrays, outPtr, outCap, offsetsPtr, sizesPtr, statsPtr);
+      const offsets = new Uint32Array(w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4));
+      const sizes = new Uint32Array(w.memory.buffer.slice(sizesPtr, sizesPtr + numArrays * 4));
+      const allStats = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + numArrays * 64));
+      const results = [];
+      for (let i = 0; i < numArrays; i++) {
+        const compressed = new Uint8Array(w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i]));
+        const si = i * 8;
+        results.push({
+          compressed,
+          stats: {
+            minV: allStats[si], maxV: allStats[si+1], sum: allStats[si+2], count: allStats[si+3],
+            firstV: allStats[si+4], lastV: allStats[si+5], sumOfSquares: allStats[si+6], resetCount: allStats[si+7],
+          },
+        });
+      }
+      return results;
+    },
+  };
+
+  const tsCodec = {
+    name: "rust-wasm-ts",
+    encodeTimestamps(timestamps) {
+      const n = timestamps.length;
+      w.resetScratch();
+      const tsPtr = w.allocScratch(n * 8);
+      const outCap = n * 20;
+      const outPtr = w.allocScratch(outCap);
+      mem().set(new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength), tsPtr);
+      return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeTimestamps(tsPtr, n, outPtr, outCap)));
+    },
+    decodeTimestamps(buf) {
+      w.resetScratch();
+      const inPtr = w.allocScratch(buf.length);
+      mem().set(buf, inPtr);
+      const maxSamples = (buf[0] << 8) | buf[1];
+      const tsPtr = w.allocScratch(maxSamples * 8);
+      const n = w.decodeTimestamps(inPtr, buf.length, tsPtr, maxSamples);
+      return new BigInt64Array(w.memory.buffer.slice(tsPtr, tsPtr + n * 8));
+    },
+  };
+
+  const alpRangeCodec = {
+    rangeDecodeValues(compressedTs, compressedVals, startT, endT) {
+      w.resetScratch();
+      const tsInPtr = w.allocScratch(compressedTs.length);
+      mem().set(compressedTs, tsInPtr);
+      const valInPtr = w.allocScratch(compressedVals.length);
+      mem().set(compressedVals, valInPtr);
+      const maxSamples = (compressedVals[0] << 8) | compressedVals[1];
+      const outTsPtr = w.allocScratch(maxSamples * 8);
+      const outValPtr = w.allocScratch(maxSamples * 8);
+      const n = w.rangeDecodeALP(
+        tsInPtr, compressedTs.length,
+        valInPtr, compressedVals.length,
+        startT, endT,
+        outTsPtr, outValPtr,
+        maxSamples,
+      );
+      if (n === 0) return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
+      return {
+        timestamps: new BigInt64Array(w.memory.buffer.slice(outTsPtr, outTsPtr + n * 8)),
+        values: new Float64Array(w.memory.buffer.slice(outValPtr, outValPtr + n * 8)),
+      };
+    },
+  };
+
+  return { alpValuesCodec, tsCodec, alpRangeCodec };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function gcAndSnap() {
+  if (global.gc) global.gc();
+  return process.memoryUsage();
+}
+
+function fmtMs(n) { return `${n.toFixed(1)}ms`; }
+function fmtRate(n) {
+  if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+  if (n >= 1e3) return `${(n / 1e3).toFixed(0)}K`;
+  return `${n.toFixed(0)}`;
+}
+function fmtBytes(n) {
+  if (Math.abs(n) < 1024) return `${n} B`;
+  if (Math.abs(n) < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function main() {
+  const hasGC = typeof global.gc === "function";
+  if (!hasGC) console.log("  ⚠ Run with --expose-gc for accurate memory\n");
+
+  console.log(`  Scenario: ${NUM_SERIES} series × ${POINTS_PER_SERIES.toLocaleString()} pts = ${TOTAL_SAMPLES.toLocaleString()} samples`);
+  console.log(`  Query: min agg, step=${Number(AGG_STEP)/1000}s, groupBy=[region], ${REGIONS.length} groups`);
+  console.log(`  Chunk size: ${CHUNK_SIZE}\n`);
+
+  // ── Setup ──
+  const data = generateData();
+  const wasmBytes = loadWasmSync();
+  const { alpValuesCodec, tsCodec, alpRangeCodec } = await makeWasmCodecs(wasmBytes);
+
+  const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+  const { ScanEngine } = await import(join(pkgDir, "dist/query.js"));
+
+  const backends = [
+    { name: "column-alp (no range)", make: () => new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec) },
+    { name: "column-alp-fused",      make: () => new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec) },
+  ];
+
+  const engine = new ScanEngine();
+
+  // Time range for queries
+  const qStart = T0;
+  const qEnd = T0 + BigInt(POINTS_PER_SERIES) * INTERVAL + 1n;
+
+  for (const backend of backends) {
+    console.log(`  ── ${backend.name} ──\n`);
+
+    // Ingest
+    const store = backend.make();
+    const ids = data.map(d => store.getOrCreateSeries(d.labels));
+    const tIngest0 = performance.now();
+    for (let s = 0; s < data.length; s++) {
+      store.appendBatch(ids[s], data[s].timestamps, data[s].values);
+    }
+    const tIngest1 = performance.now();
+    console.log(`    Ingest: ${fmtMs(tIngest1 - tIngest0)}  (${fmtRate(TOTAL_SAMPLES / (tIngest1 - tIngest0) * 1000)} samples/s)`);
+    console.log(`    Store:  ${fmtBytes(store.memoryBytes())}  (${(store.memoryBytes() / TOTAL_SAMPLES).toFixed(1)} B/pt)\n`);
+
+    // ── Query 1: Raw read all series (no aggregation) ──
+    if (hasGC) global.gc();
+    const tRead0 = performance.now();
+    let readSamples = 0;
+    for (const id of ids) {
+      const r = store.read(id, qStart, qEnd);
+      readSamples += r.timestamps.length;
+    }
+    const tRead1 = performance.now();
+    console.log(`    Raw read (all series):    ${fmtMs(tRead1 - tRead0)}  ${fmtRate(readSamples / (tRead1 - tRead0) * 1000)} samples/s  (${readSamples.toLocaleString()} pts)`);
+
+    // ── Query 2: ScanEngine with min agg + step + groupBy ──
+    if (hasGC) global.gc();
+    const tAgg0 = performance.now();
+    const result = engine.query(store, {
+      metric: "cpu_usage",
+      start: qStart,
+      end: qEnd,
+      agg: "min",
+      step: AGG_STEP,
+      groupBy: ["region"],
+    });
+    const tAgg1 = performance.now();
+    const outputPts = result.series.reduce((s, r) => s + r.timestamps.length, 0);
+    console.log(`    Agg query (min/1m/region): ${fmtMs(tAgg1 - tAgg0)}  scanned=${result.scannedSamples.toLocaleString()} → ${outputPts.toLocaleString()} output pts  (${result.series.length} groups)`);
+
+    // ── Break down the aggregation query into phases ──
+    if (hasGC) global.gc();
+
+    // Phase A: matchLabel
+    const tMatch0 = performance.now();
+    let matchedIds = store.matchLabel("__name__", "cpu_usage");
+    const tMatch1 = performance.now();
+
+    // Phase B: Read all matching series (readParts when available)
+    const useReadParts = typeof store.readParts === "function";
+    const tReadPhase0 = performance.now();
+    const allParts = [];           // flat array of TimeRange parts
+    const partsPerSeries = [];     // count per series for groupBy
+    for (const id of matchedIds) {
+      if (useReadParts) {
+        const parts = store.readParts(id, qStart, qEnd);
+        partsPerSeries.push(parts.length);
+        for (const p of parts) allParts.push(p);
+      } else {
+        allParts.push(store.read(id, qStart, qEnd));
+        partsPerSeries.push(1);
+      }
+    }
+    const tReadPhase1 = performance.now();
+    const totalParts = allParts.length;
+
+    // Phase C: Group by region
+    const tGroup0 = performance.now();
+    const groups = new Map();
+    let partIdx = 0;
+    for (let si = 0; si < matchedIds.length; si++) {
+      const labels = store.labels(matchedIds[si]);
+      const key = labels?.get("region") ?? "";
+      if (!groups.has(key)) groups.set(key, []);
+      const g = groups.get(key);
+      const n = partsPerSeries[si];
+      for (let j = 0; j < n; j++) g.push(allParts[partIdx++]);
+    }
+    const tGroup1 = performance.now();
+
+    // Phase D: stepAggregate per group (fused DataView → bucket)
+    const _le = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+    const tAggPhase0 = performance.now();
+    for (const [, groupRanges] of groups) {
+      // Find time bounds
+      let minT = BigInt("9223372036854775807");
+      let maxT = -minT;
+      for (const r of groupRanges) {
+        if (r.timestamps.length === 0) continue;
+        if (r.timestamps[0] < minT) minT = r.timestamps[0];
+        if (r.timestamps[r.timestamps.length - 1] > maxT)
+          maxT = r.timestamps[r.timestamps.length - 1];
+      }
+      const bucketCount = Number((maxT - minT) / AGG_STEP) + 1;
+      const timestamps = new BigInt64Array(bucketCount);
+      const values = new Float64Array(bucketCount);
+      for (let i = 0; i < bucketCount; i++) timestamps[i] = minT + BigInt(i) * AGG_STEP;
+      values.fill(Infinity); // min init
+
+      const minTN = Number(minT);
+      const stepN = Number(AGG_STEP);
+
+      // Fused: DataView read directly in accumulation loop (no Float64Array alloc)
+      for (const r of groupRanges) {
+        const src = r.timestamps;
+        const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        const vs = r.values;
+        for (let i = 0, len = src.length; i < len; i++) {
+          const off = i << 3;
+          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          if (vs[i] < values[bucket]) values[bucket] = vs[i];
+        }
+      }
+    }
+    const tAggPhase1 = performance.now();
+
+    console.log(`\n    Phase breakdown${useReadParts ? " (readParts)" : " (read+concat)"}:`);
+    console.log(`      matchLabel:    ${fmtMs(tMatch1 - tMatch0).padStart(10)}  (${matchedIds.length} series)`);
+    console.log(`      read():        ${fmtMs(tReadPhase1 - tReadPhase0).padStart(10)}  (${totalParts} parts, ${useReadParts ? "skip concat" : "concat"})`);
+    console.log(`      groupBy:       ${fmtMs(tGroup1 - tGroup0).padStart(10)}  (${groups.size} groups)`);
+    console.log(`      stepAggregate: ${fmtMs(tAggPhase1 - tAggPhase0).padStart(10)}  (fused DataView → bucket + min fold)`);
+
+    const total = (tMatch1 - tMatch0) + (tReadPhase1 - tReadPhase0) + (tGroup1 - tGroup0) + (tAggPhase1 - tAggPhase0);
+    console.log(`      ─────────────────────`);
+    console.log(`      total:         ${fmtMs(total).padStart(10)}`);
+
+    // ── Repeat query 5x for stable timing ──
+    console.log(`\n    Repeated query (5 runs):`);
+    const runs = [];
+    for (let r = 0; r < 5; r++) {
+      if (hasGC) global.gc();
+      const t0 = performance.now();
+      engine.query(store, {
+        metric: "cpu_usage",
+        start: qStart,
+        end: qEnd,
+        agg: "min",
+        step: AGG_STEP,
+        groupBy: ["region"],
+      });
+      const t1 = performance.now();
+      runs.push(t1 - t0);
+    }
+    runs.sort((a, b) => a - b);
+    console.log(`      min=${fmtMs(runs[0])}  median=${fmtMs(runs[2])}  max=${fmtMs(runs[4])}`);
+
+    // ── Stats-skip scenario: large step (4h) so chunks fit in 1 bucket ──
+    // Chunk span ≈ 512 × 15s = 7,680s ≈ 128min.  4h step → most chunks skip decode.
+    const BIG_STEP = 14_400_000n;  // 4 hours
+    if (hasGC) global.gc();
+    const tBig0 = performance.now();
+    const bigResult = engine.query(store, {
+      metric: "cpu_usage",
+      start: qStart,
+      end: qEnd,
+      agg: "min",
+      step: BIG_STEP,
+      groupBy: ["region"],
+    });
+    const tBig1 = performance.now();
+    const bigPts = bigResult.series.reduce((s, r) => s + r.timestamps.length, 0);
+    console.log(`\n    Stats-skip query (min/4h/region): ${fmtMs(tBig1 - tBig0)}  scanned=${bigResult.scannedSamples.toLocaleString()} → ${bigPts.toLocaleString()} output pts`);
+
+    // Repeat 5x
+    const bigRuns = [];
+    for (let r = 0; r < 5; r++) {
+      if (hasGC) global.gc();
+      const t0 = performance.now();
+      engine.query(store, {
+        metric: "cpu_usage",
+        start: qStart,
+        end: qEnd,
+        agg: "min",
+        step: BIG_STEP,
+        groupBy: ["region"],
+      });
+      const t1 = performance.now();
+      bigRuns.push(t1 - t0);
+    }
+    bigRuns.sort((a, b) => a - b);
+    console.log(`    Repeated (5 runs): min=${fmtMs(bigRuns[0])}  median=${fmtMs(bigRuns[2])}  max=${fmtMs(bigRuns[4])}`);
+
+    console.log();
+  }
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/packages/o11ytsdb/bench/query-sweep.mjs
+++ b/packages/o11ytsdb/bench/query-sweep.mjs
@@ -1,0 +1,430 @@
+#!/usr/bin/env node
+/**
+ * Query-optimization sweep — exercises step sizes, agg functions, time
+ * ranges, and allocation patterns needed to validate upcoming optimizations:
+ *
+ *   1. Fused read-aggregate (eliminate concatRanges allocations)
+ *   2. WASM-based aggregation (push bucket math into Rust)
+ *   3. ChunkStats-based skip (use precomputed min/max/sum/count per chunk)
+ *
+ * Usage:
+ *   node --expose-gc bench/query-sweep.mjs
+ *   node --expose-gc bench/query-sweep.mjs --quick     # fewer warmups, 3 runs
+ *   node --expose-gc bench/query-sweep.mjs --filter max # only run max-agg rows
+ *
+ * Data layout for ChunkStats coverage analysis:
+ *   - 30 series, 15s interval, chunk=512 → each chunk spans 512*15s = 7,680s = 128 min
+ *   - step=1min  →  ~128 buckets/chunk  (no full-chunk skip possible)
+ *   - step=5min  →  ~26 buckets/chunk   (no full-chunk skip)
+ *   - step=1h    →  ~2.1 buckets/chunk  (some chunks may span 2-3 buckets)
+ *   - step=6h    →  ~0.36 bucket/chunk  → most chunks fit entirely in one bucket ✓
+ *   - step=1d    →  ~0.09 bucket/chunk  → almost all chunks fit in one bucket ✓
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(__dirname, "..");
+
+// ── Config ───────────────────────────────────────────────────────────
+
+const NUM_SERIES = 30;
+const POINTS_PER_SERIES = Math.ceil(5_000_000 / NUM_SERIES); // ~166,667
+const TOTAL_SAMPLES = NUM_SERIES * POINTS_PER_SERIES;
+const CHUNK_SIZE = 512;
+const T0 = 1_700_000_000_000n;           // epoch ms
+const INTERVAL = 15_000n;                 // 15s scrape interval
+const REGIONS = ["us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1", "eu-central-1"];
+
+const CHUNK_SPAN_MS = CHUNK_SIZE * Number(INTERVAL); // 7,680,000 ms = 128 min
+
+// Parse CLI flags
+const args = process.argv.slice(2);
+const isQuick = args.includes("--quick");
+const filterIdx = args.indexOf("--filter");
+const filter = filterIdx >= 0 ? args[filterIdx + 1] : null;
+const WARMUP = isQuick ? 1 : 3;
+const RUNS   = isQuick ? 3 : 7;
+
+// ── Sweep dimensions ─────────────────────────────────────────────────
+
+const STEPS = [
+  { name: "1min",  ms: 60_000n,      label: "60s"   },
+  { name: "5min",  ms: 300_000n,     label: "5m"    },
+  { name: "1h",    ms: 3_600_000n,   label: "1h"    },
+  { name: "6h",    ms: 21_600_000n,  label: "6h"    },
+  { name: "1d",    ms: 86_400_000n,  label: "1d"    },
+];
+
+const AGG_FNS = ["min", "max", "sum", "avg", "count", "last"];
+
+// Which agg functions can use ChunkStats to skip decoding
+const CHUNK_STATS_ELIGIBLE = new Set(["min", "max", "sum", "avg", "count", "last"]);
+
+// ── Data generation ──────────────────────────────────────────────────
+
+function generateData() {
+  const series = [];
+  for (let s = 0; s < NUM_SERIES; s++) {
+    const timestamps = new BigInt64Array(POINTS_PER_SERIES);
+    const values = new Float64Array(POINTS_PER_SERIES);
+    for (let i = 0; i < POINTS_PER_SERIES; i++) {
+      timestamps[i] = T0 + BigInt(i) * INTERVAL;
+      const base = Math.sin(i * 0.001 + s) * 50 + 100;
+      values[i] = base + (Math.random() - 0.5) * 10;
+    }
+    const region = REGIONS[s % REGIONS.length];
+    const labels = new Map([
+      ["__name__", "cpu_usage"],
+      ["region", region],
+      ["instance", `host-${s}`],
+    ]);
+    series.push({ labels, timestamps, values });
+  }
+  return series;
+}
+
+// ── WASM codec setup ─────────────────────────────────────────────────
+
+async function makeWasmCodecs() {
+  const wasmBytes = readFileSync(join(pkgDir, "wasm/o11ytsdb-rust.wasm"));
+  const { instance } = await WebAssembly.instantiate(wasmBytes, { env: {} });
+  const w = instance.exports;
+  const mem = () => new Uint8Array(w.memory.buffer);
+
+  const alpValuesCodec = {
+    name: "rust-wasm-alp",
+    encodeValues(values) {
+      const n = values.length;
+      w.resetScratch();
+      const valPtr = w.allocScratch(n * 8);
+      const outCap = n * 20;
+      const outPtr = w.allocScratch(outCap);
+      mem().set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valPtr);
+      return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeValuesALP(valPtr, n, outPtr, outCap)));
+    },
+    decodeValues(buf) {
+      w.resetScratch();
+      const inPtr = w.allocScratch(buf.length);
+      mem().set(buf, inPtr);
+      const maxSamples = (buf[0] << 8) | buf[1];
+      const valPtr = w.allocScratch(maxSamples * 8);
+      const n = w.decodeValuesALP(inPtr, buf.length, valPtr, maxSamples);
+      return new Float64Array(w.memory.buffer.slice(valPtr, valPtr + n * 8));
+    },
+    encodeValuesWithStats(values) {
+      const n = values.length;
+      w.resetScratch();
+      const valPtr = w.allocScratch(n * 8);
+      const outCap = n * 20;
+      const outPtr = w.allocScratch(outCap);
+      const statsPtr = w.allocScratch(64);
+      mem().set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valPtr);
+      const bytesWritten = w.encodeValuesALPWithStats(valPtr, n, outPtr, outCap, statsPtr);
+      const compressed = new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + bytesWritten));
+      const s = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + 64));
+      return {
+        compressed,
+        stats: { minV: s[0], maxV: s[1], sum: s[2], count: s[3], firstV: s[4], lastV: s[5], sumOfSquares: s[6], resetCount: s[7] },
+      };
+    },
+    encodeBatchValuesWithStats(arrays) {
+      const numArrays = arrays.length;
+      const chunkSize = arrays[0].length;
+      w.resetScratch();
+      const valsPtr = w.allocScratch(numArrays * chunkSize * 8);
+      for (let i = 0; i < numArrays; i++) {
+        mem().set(new Uint8Array(arrays[i].buffer, arrays[i].byteOffset, arrays[i].byteLength), valsPtr + i * chunkSize * 8);
+      }
+      const outCap = numArrays * chunkSize * 20;
+      const outPtr = w.allocScratch(outCap);
+      const offsetsPtr = w.allocScratch(numArrays * 4);
+      const sizesPtr = w.allocScratch(numArrays * 4);
+      const statsPtr = w.allocScratch(numArrays * 64);
+      w.encodeBatchValuesALPWithStats(valsPtr, chunkSize, numArrays, outPtr, outCap, offsetsPtr, sizesPtr, statsPtr);
+      const offsets = new Uint32Array(w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4));
+      const sizes = new Uint32Array(w.memory.buffer.slice(sizesPtr, sizesPtr + numArrays * 4));
+      const allStats = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + numArrays * 64));
+      const results = [];
+      for (let i = 0; i < numArrays; i++) {
+        const compressed = new Uint8Array(w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i]));
+        const si = i * 8;
+        results.push({
+          compressed,
+          stats: {
+            minV: allStats[si], maxV: allStats[si+1], sum: allStats[si+2], count: allStats[si+3],
+            firstV: allStats[si+4], lastV: allStats[si+5], sumOfSquares: allStats[si+6], resetCount: allStats[si+7],
+          },
+        });
+      }
+      return results;
+    },
+  };
+
+  const tsCodec = {
+    name: "rust-wasm-ts",
+    encodeTimestamps(timestamps) {
+      const n = timestamps.length;
+      w.resetScratch();
+      const tsPtr = w.allocScratch(n * 8);
+      const outCap = n * 20;
+      const outPtr = w.allocScratch(outCap);
+      mem().set(new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength), tsPtr);
+      return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeTimestamps(tsPtr, n, outPtr, outCap)));
+    },
+    decodeTimestamps(buf) {
+      w.resetScratch();
+      const inPtr = w.allocScratch(buf.length);
+      mem().set(buf, inPtr);
+      const maxSamples = (buf[0] << 8) | buf[1];
+      const tsPtr = w.allocScratch(maxSamples * 8);
+      const n = w.decodeTimestamps(inPtr, buf.length, tsPtr, maxSamples);
+      return new BigInt64Array(w.memory.buffer.slice(tsPtr, tsPtr + n * 8));
+    },
+  };
+
+  const alpRangeCodec = {
+    rangeDecodeValues(compressedTs, compressedVals, startT, endT) {
+      w.resetScratch();
+      const tsInPtr = w.allocScratch(compressedTs.length);
+      mem().set(compressedTs, tsInPtr);
+      const valInPtr = w.allocScratch(compressedVals.length);
+      mem().set(compressedVals, valInPtr);
+      const maxSamples = (compressedVals[0] << 8) | compressedVals[1];
+      const outTsPtr = w.allocScratch(maxSamples * 8);
+      const outValPtr = w.allocScratch(maxSamples * 8);
+      const n = w.rangeDecodeALP(
+        tsInPtr, compressedTs.length,
+        valInPtr, compressedVals.length,
+        startT, endT,
+        outTsPtr, outValPtr,
+        maxSamples,
+      );
+      if (n === 0) return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
+      return {
+        timestamps: new BigInt64Array(w.memory.buffer.slice(outTsPtr, outTsPtr + n * 8)),
+        values: new Float64Array(w.memory.buffer.slice(outValPtr, outValPtr + n * 8)),
+      };
+    },
+  };
+
+  return { alpValuesCodec, tsCodec, alpRangeCodec };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function fmtMs(n) { return n < 1 ? `${(n * 1000).toFixed(0)}µs` : `${n.toFixed(1)}ms`; }
+function fmtRate(n) {
+  if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M/s`;
+  if (n >= 1e3) return `${(n / 1e3).toFixed(0)}K/s`;
+  return `${n.toFixed(0)}/s`;
+}
+function fmtBytes(n) {
+  const abs = Math.abs(n);
+  const sign = n < 0 ? "-" : "+";
+  if (abs < 1024) return `${sign}${abs} B`;
+  if (abs < 1024 * 1024) return `${sign}${(abs / 1024).toFixed(1)} KB`;
+  return `${sign}${(abs / 1024 / 1024).toFixed(1)} MB`;
+}
+
+/** Run fn with warmup, return sorted array of times + heap deltas. */
+function bench(fn, warmup = WARMUP, runs = RUNS) {
+  const hasGC = typeof global.gc === "function";
+  // Warmup
+  for (let w = 0; w < warmup; w++) fn();
+
+  const times = [];
+  const heapDeltas = [];
+  for (let r = 0; r < runs; r++) {
+    if (hasGC) global.gc();
+    const heapBefore = process.memoryUsage().heapUsed;
+    const t0 = performance.now();
+    fn();
+    const elapsed = performance.now() - t0;
+    const heapAfter = process.memoryUsage().heapUsed;
+    times.push(elapsed);
+    heapDeltas.push(heapAfter - heapBefore);
+  }
+  times.sort((a, b) => a - b);
+  heapDeltas.sort((a, b) => a - b);
+  const mid = Math.floor(runs / 2);
+  return {
+    min: times[0],
+    median: times[mid],
+    max: times[runs - 1],
+    heapMin: heapDeltas[0],
+    heapMedian: heapDeltas[mid],
+    heapMax: heapDeltas[runs - 1],
+  };
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function main() {
+  const hasGC = typeof global.gc === "function";
+  if (!hasGC) console.log("  ⚠ Run with --expose-gc for accurate heap tracking\n");
+
+  // ── Setup ──
+  console.log("  Generating data...");
+  const data = generateData();
+  const dataSpanMs = Number(BigInt(POINTS_PER_SERIES) * INTERVAL);
+
+  console.log("  Loading WASM codecs...");
+  const { alpValuesCodec, tsCodec, alpRangeCodec } = await makeWasmCodecs();
+  const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+  const { ScanEngine } = await import(join(pkgDir, "dist/query.js"));
+
+  const engine = new ScanEngine();
+
+  console.log("  Ingesting into column-alp-fused store...");
+  const store = new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec);
+  const ids = data.map(d => store.getOrCreateSeries(d.labels));
+  for (let s = 0; s < data.length; s++) {
+    store.appendBatch(ids[s], data[s].timestamps, data[s].values);
+  }
+  const numChunksPerSeries = Math.ceil(POINTS_PER_SERIES / CHUNK_SIZE);
+
+  console.log(`\n  ${NUM_SERIES} series × ${POINTS_PER_SERIES.toLocaleString()} pts = ${TOTAL_SAMPLES.toLocaleString()} samples`);
+  console.log(`  Chunks: ${numChunksPerSeries}/series × ${NUM_SERIES} series = ${numChunksPerSeries * NUM_SERIES} total`);
+  console.log(`  Chunk span: ${(CHUNK_SPAN_MS / 60_000).toFixed(0)} min  |  Data span: ${(dataSpanMs / 86_400_000).toFixed(1)} days`);
+  console.log(`  Store: ${(store.memoryBytes() / 1024 / 1024).toFixed(1)} MB  (${(store.memoryBytes() / TOTAL_SAMPLES).toFixed(1)} B/pt)`);
+  console.log(`  Warmup: ${WARMUP}  Runs: ${RUNS}  ${filter ? `Filter: ${filter}` : ""}\n`);
+
+  // ── Time ranges ──
+  const qFull = { start: T0, end: T0 + BigInt(POINTS_PER_SERIES) * INTERVAL + 1n };
+  // Last 10% — hits fewer chunks, different decode-skip ratio
+  const qLast10 = {
+    start: T0 + BigInt(Math.floor(POINTS_PER_SERIES * 0.9)) * INTERVAL,
+    end: T0 + BigInt(POINTS_PER_SERIES) * INTERVAL + 1n,
+  };
+
+  const timeRanges = [
+    { name: "full", ...qFull,   pctLabel: "100%", expectedSamples: TOTAL_SAMPLES },
+    { name: "last10%", ...qLast10, pctLabel: "10%",  expectedSamples: Math.ceil(TOTAL_SAMPLES * 0.1) },
+  ];
+
+  // ── Table header ──
+  const hdr = [
+    "agg".padEnd(6),
+    "step".padEnd(6),
+    "range".padEnd(6),
+    "buckets".padStart(8),
+    "chunks/bkt".padStart(11),
+    "statsSkip?".padStart(11),
+    "min(ms)".padStart(9),
+    "med(ms)".padStart(9),
+    "max(ms)".padStart(9),
+    "heap Δ".padStart(10),
+    "scanned".padStart(12),
+    "output".padStart(10),
+  ];
+  console.log(`  ${hdr.join("  ")}`);
+  console.log(`  ${"─".repeat(hdr.join("  ").length)}`);
+
+  // ── Sweep ──
+  const results = [];
+
+  for (const aggFn of AGG_FNS) {
+    if (filter && !aggFn.includes(filter)) continue;
+
+    for (const step of STEPS) {
+      for (const range of timeRanges) {
+        const stepMs = Number(step.ms);
+        const rangeMs = Number(range.end - range.start);
+        const bucketCount = Math.floor(rangeMs / stepMs) + 1;
+
+        // Chunks per bucket: how many chunks span a single bucket?
+        // If chunkSpan < stepMs, chunks fit inside buckets → stats skip possible
+        const chunksPerBucket = CHUNK_SPAN_MS / stepMs;
+        const statsSkipPossible = CHUNK_STATS_ELIGIBLE.has(aggFn) && chunksPerBucket < 1;
+
+        let result;
+        let scanned = 0;
+        let outputPts = 0;
+
+        const stats = bench(() => {
+          result = engine.query(store, {
+            metric: "cpu_usage",
+            start: range.start,
+            end: range.end,
+            agg: aggFn,
+            step: step.ms,
+            groupBy: ["region"],
+          });
+          scanned = result.scannedSamples;
+          outputPts = result.series.reduce((s, r) => s + r.timestamps.length, 0);
+        });
+
+        const row = {
+          aggFn, step: step.name, range: range.name,
+          bucketCount, chunksPerBucket, statsSkipPossible,
+          ...stats, scanned, outputPts,
+        };
+        results.push(row);
+
+        const cols = [
+          aggFn.padEnd(6),
+          step.name.padEnd(6),
+          range.pctLabel.padEnd(6),
+          String(bucketCount).padStart(8),
+          chunksPerBucket.toFixed(2).padStart(11),
+          (statsSkipPossible ? "✓ YES" : "  no").padStart(11),
+          stats.min.toFixed(1).padStart(9),
+          stats.median.toFixed(1).padStart(9),
+          stats.max.toFixed(1).padStart(9),
+          fmtBytes(stats.heapMedian).padStart(10),
+          scanned.toLocaleString().padStart(12),
+          outputPts.toLocaleString().padStart(10),
+        ];
+        console.log(`  ${cols.join("  ")}`);
+      }
+    }
+    // Visual separator between agg functions
+    if (AGG_FNS.indexOf(aggFn) < AGG_FNS.length - 1) {
+      console.log(`  ${"─".repeat(hdr.join("  ").length)}`);
+    }
+  }
+
+  // ── Summary analysis ──
+  console.log(`\n  ═══ Analysis ═══\n`);
+
+  // Group by agg fn and show median across all configs
+  const byAgg = new Map();
+  for (const r of results) {
+    if (!byAgg.has(r.aggFn)) byAgg.set(r.aggFn, []);
+    byAgg.get(r.aggFn).push(r);
+  }
+
+  // ChunkStats skip opportunity
+  const skipRows = results.filter(r => r.statsSkipPossible);
+  const noSkipRows = results.filter(r => !r.statsSkipPossible && CHUNK_STATS_ELIGIBLE.has(r.aggFn));
+  if (skipRows.length > 0 && noSkipRows.length > 0) {
+    const skipMedian = skipRows.reduce((s, r) => s + r.median, 0) / skipRows.length;
+    const noSkipMedian = noSkipRows.reduce((s, r) => s + r.median, 0) / noSkipRows.length;
+    console.log(`  ChunkStats skip opportunity:`);
+    console.log(`    Eligible configs (chunk fits in 1 bucket):  ${skipRows.length} rows, avg median ${skipMedian.toFixed(1)}ms`);
+    console.log(`    Non-skip configs (chunk spans >1 bucket):   ${noSkipRows.length} rows, avg median ${noSkipMedian.toFixed(1)}ms`);
+    console.log(`    Potential savings: if stats-skip avoids decode for ${skipRows.length} configs,`);
+    console.log(`    read() phase (~50% of query time) could be largely eliminated\n`);
+  }
+
+  // Allocation pressure analysis
+  const fullRangeRows = results.filter(r => r.range === "full");
+  const avgHeap = fullRangeRows.reduce((s, r) => s + r.heapMedian, 0) / fullRangeRows.length;
+  console.log(`  Allocation pressure (full-range queries):`);
+  console.log(`    Average heap Δ per query: ${fmtBytes(avgHeap)}`);
+  console.log(`    Fused read-aggregate target: eliminate concatRanges → ~0 heap growth\n`);
+
+  // Fastest/slowest per agg
+  console.log(`  Per-agg median (full range, step=1min):`);
+  for (const [agg, rows] of byAgg) {
+    const r = rows.find(r => r.step === "1min" && r.range === "full");
+    if (r) console.log(`    ${agg.padEnd(6)} ${r.median.toFixed(1)}ms`);
+  }
+  console.log();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/packages/o11ytsdb/bench/test-xor-exceptions.mjs
+++ b/packages/o11ytsdb/bench/test-xor-exceptions.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Test XOR-delta exception encoding on high-precision float data
+ * that produces 100% ALP exceptions (like cpu.utilization).
+ */
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(__dirname, '..');
+
+const { loadWasm, makeALPValuesCodec } = await import(join(__dirname, 'dist', 'wasm-loader.js'));
+const wasm = await loadWasm(join(pkgDir, 'wasm/o11ytsdb-rust.wasm'));
+const alp = makeALPValuesCodec(wasm);
+
+const N = 640;
+
+// Pattern 1: cpu.utilization — full IEEE 754 precision, all exceptions.
+// Simulates values in [0, 1] with ~15 significant digits.
+function cpuUtilization(n) {
+  const vals = new Float64Array(n);
+  let v = 0.02;
+  for (let i = 0; i < n; i++) {
+    v += (Math.random() - 0.48) * 0.01; // slight upward drift
+    v = Math.max(0, Math.min(1, v));
+    vals[i] = v; // full precision, no rounding
+  }
+  return vals;
+}
+
+// Pattern 2: memory.utilization — similar, but in [0.1, 0.9]
+function memUtilization(n) {
+  const vals = new Float64Array(n);
+  let v = 0.35;
+  for (let i = 0; i < n; i++) {
+    v += (Math.random() - 0.5) * 0.005;
+    v = Math.max(0.05, Math.min(0.95, v));
+    vals[i] = v;
+  }
+  return vals;
+}
+
+// Pattern 3: filesystem.utilization — very stable, tiny changes
+function fsUtilization(n) {
+  const vals = new Float64Array(n);
+  let v = 0.356793610702;
+  for (let i = 0; i < n; i++) {
+    v += (Math.random() - 0.5) * 0.000001;
+    vals[i] = v;
+  }
+  return vals;
+}
+
+// Pattern 4: random floats (worst case — no correlation)
+function random(n) {
+  const vals = new Float64Array(n);
+  for (let i = 0; i < n; i++) {
+    vals[i] = Math.random() * 1000;
+  }
+  return vals;
+}
+
+const patterns = [
+  { name: 'cpu.utilization', gen: cpuUtilization },
+  { name: 'memory.utilization', gen: memUtilization },
+  { name: 'fs.utilization', gen: fsUtilization },
+  { name: 'random (worst case)', gen: random },
+];
+
+console.log(`ALP XOR-delta exception compression (${N} samples):\n`);
+console.log(`  ${'Pattern'.padEnd(28)} ${'Size'.padStart(8)} ${'B/pt'.padStart(8)} ${'Exceptions'.padStart(12)} ${'Old B/pt'.padStart(10)}  ${'Improvement'.padStart(12)}`);
+console.log(`  ${'─'.repeat(88)}`);
+
+for (const { name, gen } of patterns) {
+  const vals = gen(N);
+  
+  // Encode
+  const { compressed, stats } = alp.encodeValuesWithStats(vals);
+  
+  // Decode and verify round-trip
+  const decoded = alp.decodeValues(compressed);
+  let mismatches = 0;
+  for (let i = 0; i < N; i++) {
+    if (vals[i] !== decoded[i]) {
+      console.log(`  MISMATCH at ${i}: ${vals[i]} !== ${decoded[i]}`);
+      mismatches++;
+      if (mismatches > 5) break;
+    }
+  }
+  
+  // Parse header to count exceptions
+  const excCount = (compressed[12] << 8) | compressed[13];
+  const oldSize = 14 + 0 + excCount * 10; // old format: header + 0 bitpacked + exc_count * (2+8)
+  const oldBpt = oldSize / N;
+  const improvement = oldBpt / (compressed.byteLength / N);
+  
+  console.log(`  ${name.padEnd(28)} ${(compressed.byteLength + ' B').padStart(8)} ${(compressed.byteLength / N).toFixed(3).padStart(8)} ${(excCount + '/' + N).padStart(12)} ${oldBpt.toFixed(3).padStart(10)}  ${improvement.toFixed(1).padStart(11)}×`);
+  
+  if (mismatches > 0) {
+    console.log(`  ⚠ ${mismatches} MISMATCHES!`);
+  }
+}
+
+console.log();
+
+// Also test with real OTel data if available
+try {
+  const { loadOtelData } = await import(join(__dirname, 'load-otel.mjs'));
+  const series = await loadOtelData(join(__dirname, 'data/cpu.jsonl'));
+  
+  // Find cpu.utilization series
+  const utilSeries = series.filter(s => s.labels.get('__name__') === 'system.cpu.utilization');
+  if (utilSeries.length > 0) {
+    console.log(`Real OTel cpu.utilization (${utilSeries.length} series):\n`);
+    
+    let totalOld = 0, totalNew = 0, totalPts = 0;
+    for (const s of utilSeries.slice(0, 4)) { // first 4 series
+      const chunk = s.values.subarray(0, Math.min(640, s.values.length));
+      const { compressed } = alp.encodeValuesWithStats(chunk);
+      const decoded = alp.decodeValues(compressed);
+      
+      let ok = true;
+      for (let i = 0; i < chunk.length; i++) {
+        if (chunk[i] !== decoded[i]) { ok = false; break; }
+      }
+      
+      const excCount = (compressed[12] << 8) | compressed[13];
+      const oldSize = 14 + excCount * 10;
+      
+      totalOld += oldSize;
+      totalNew += compressed.byteLength;
+      totalPts += chunk.length;
+      
+      const state = s.labels.get('state') || '?';
+      const cpu = s.labels.get('cpu') || '?';
+      console.log(`  cpu=${cpu} state=${state}: ${chunk.length} pts, ${compressed.byteLength} B (${(compressed.byteLength / chunk.length).toFixed(2)} B/pt), exc=${excCount}, roundtrip=${ok ? '✓' : '✗'}`);
+    }
+    
+    console.log(`\n  Totals: ${totalPts} pts`);
+    console.log(`    Old format: ${totalOld} B (${(totalOld / totalPts).toFixed(2)} B/pt)`);
+    console.log(`    New format: ${totalNew} B (${(totalNew / totalPts).toFixed(2)} B/pt)`);
+    console.log(`    Improvement: ${(totalOld / totalNew).toFixed(1)}×`);
+  }
+} catch (e) {
+  console.log(`  (skipping real OTel test: ${e.message})`);
+}

--- a/packages/o11ytsdb/src/column-store.ts
+++ b/packages/o11ytsdb/src/column-store.ts
@@ -235,6 +235,18 @@ export class ColumnStore implements StorageBackend {
   }
 
   read(id: SeriesId, start: bigint, end: bigint): TimeRange {
+    const parts = this.readParts(id, start, end);
+    // Resolve stats-only parts so concatRanges gets full sample data.
+    for (let i = 0; i < parts.length; i++) {
+      const p = parts[i]!;
+      if (p.timestamps.length === 0 && p.decode) {
+        parts[i] = p.decode();
+      }
+    }
+    return concatRanges(parts);
+  }
+
+  readParts(id: SeriesId, start: bigint, end: bigint): TimeRange[] {
     const s = this.allSeries[id]!;
     const group = this.groups[s.groupId]!;
     const parts: TimeRange[] = [];
@@ -244,6 +256,26 @@ export class ColumnStore implements StorageBackend {
       for (const chunk of s.frozen) {
         const tsChunk = group.frozenTimestamps[chunk.tsChunkIndex]!;
         if (tsChunk.maxT < start || tsChunk.minT > end) continue;
+
+        // Stats-skip: when the entire chunk is within the query range,
+        // emit a stats-only part so the query engine can fold pre-computed
+        // aggregates instead of decoding + iterating every sample.
+        // Includes a lazy decode() callback for cases where the chunk
+        // spans multiple aggregation buckets and needs sample iteration.
+        if (tsChunk.minT >= start && tsChunk.maxT <= end) {
+          const rc = this.rangeCodec;
+          const tc = tsChunk.compressed!;
+          const cv = chunk.compressedValues;
+          parts.push({
+            timestamps: new BigInt64Array(0),
+            values: new Float64Array(0),
+            stats: chunk.stats,
+            chunkMinT: tsChunk.minT,
+            chunkMaxT: tsChunk.maxT,
+            decode: () => rc.rangeDecodeValues(tc, cv, tsChunk.minT, tsChunk.maxT),
+          });
+          continue;
+        }
 
         const result = this.rangeCodec.rangeDecodeValues(
           tsChunk.compressed!, chunk.compressedValues, start, end,
@@ -262,6 +294,30 @@ export class ColumnStore implements StorageBackend {
       for (const chunk of s.frozen) {
         const tsChunk = group.frozenTimestamps[chunk.tsChunkIndex]!;
         if (tsChunk.maxT < start || tsChunk.minT > end) continue;
+
+        // Stats-skip: entire chunk within query range.
+        if (tsChunk.minT >= start && tsChunk.maxT <= end) {
+          const vc = this.valuesCodec;
+          const cv = chunk.compressedValues;
+          const tsc = this.tsCodec;
+          const tcc = tsChunk.compressed;
+          parts.push({
+            timestamps: new BigInt64Array(0),
+            values: new Float64Array(0),
+            stats: chunk.stats,
+            chunkMinT: tsChunk.minT,
+            chunkMaxT: tsChunk.maxT,
+            decode: () => {
+              if (!tsChunk.timestamps && tsc) {
+                tsChunk.timestamps = tsc.decodeTimestamps(tcc!);
+              }
+              const ts = tsChunk.timestamps!;
+              const vs = vc.decodeValues(cv);
+              return { timestamps: ts, values: vs };
+            },
+          });
+          continue;
+        }
 
         // Decompress timestamps if needed.
         const timestamps = tsChunk.timestamps
@@ -291,7 +347,7 @@ export class ColumnStore implements StorageBackend {
       }
     }
 
-    return concatRanges(parts);
+    return parts;
   }
 
   labels(id: SeriesId): Labels | undefined {

--- a/packages/o11ytsdb/src/flat-store.ts
+++ b/packages/o11ytsdb/src/flat-store.ts
@@ -75,13 +75,18 @@ export class FlatStore implements StorageBackend {
   }
 
   read(id: SeriesId, start: bigint, end: bigint): TimeRange {
+    return this.readParts(id, start, end)[0] ?? { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
+  }
+
+  readParts(id: SeriesId, start: bigint, end: bigint): TimeRange[] {
     const s = this.series[id]!;
     const lo = lowerBound(s.timestamps, start, 0, s.count);
     const hi = upperBound(s.timestamps, end, lo, s.count);
-    return {
+    if (hi <= lo) return [];
+    return [{
       timestamps: s.timestamps.slice(lo, hi),
       values: s.values.slice(lo, hi),
-    };
+    }];
   }
 
   labels(id: SeriesId): Labels | undefined {

--- a/packages/o11ytsdb/src/query.ts
+++ b/packages/o11ytsdb/src/query.ts
@@ -45,8 +45,16 @@ export class ScanEngine implements QueryEngine {
     const groups = new Map<string, { labels: Labels; ranges: TimeRange[] }>();
 
     for (const id of ids) {
-      const data = storage.read(id, opts.start, opts.end);
-      scannedSamples += data.timestamps.length;
+      // For step queries, use readParts to skip the concatRanges allocation.
+      // stepAggregate only needs per-bucket folding, so individual chunk parts
+      // work just as well as one big concatenated array.
+      let parts: TimeRange[];
+      if (opts.step && storage.readParts) {
+        parts = storage.readParts(id, opts.start, opts.end);
+      } else {
+        parts = [storage.read(id, opts.start, opts.end)];
+      }
+      for (const p of parts) scannedSamples += p.timestamps.length || p.stats?.count || 0;
       const labels = storage.labels(id) ?? new Map();
       const groupKey = opts.groupBy
         ? opts.groupBy.map(k => labels.get(k) ?? '').join('\0')
@@ -65,7 +73,7 @@ export class ScanEngine implements QueryEngine {
         group = { labels: groupLabels, ranges: [] };
         groups.set(groupKey, group);
       }
-      group.ranges.push(data);
+      for (const p of parts) group.ranges.push(p);
     }
 
     // Aggregate each group.
@@ -163,15 +171,28 @@ function pointAggregate(ranges: TimeRange[], fn: AggFn): TimeRange {
   return { timestamps, values };
 }
 
+/**
+ * Platform endianness flag for DataView reads.
+ */
+const _le = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+
 function stepAggregate(ranges: TimeRange[], fn: AggFn, step: bigint): TimeRange {
-  // Find time bounds.
+  // Find time bounds (account for both sample-bearing and stats-only parts).
   let minT = BigInt('9223372036854775807');
   let maxT = -minT;
   for (const r of ranges) {
-    if (r.timestamps.length === 0) continue;
-    if (r.timestamps[0]! < minT) minT = r.timestamps[0]!;
-    if (r.timestamps[r.timestamps.length - 1]! > maxT)
-      maxT = r.timestamps[r.timestamps.length - 1]!;
+    if (r.timestamps.length > 0) {
+      if (r.timestamps[0]! < minT) minT = r.timestamps[0]!;
+      if (r.timestamps[r.timestamps.length - 1]! > maxT)
+        maxT = r.timestamps[r.timestamps.length - 1]!;
+    } else if (r.stats && r.chunkMinT !== undefined && r.chunkMaxT !== undefined) {
+      if (r.chunkMinT < minT) minT = r.chunkMinT;
+      if (r.chunkMaxT > maxT) maxT = r.chunkMaxT;
+    }
+  }
+
+  if (minT > maxT) {
+    return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
   }
 
   const bucketCount = Number((maxT - minT) / step) + 1;
@@ -183,17 +204,175 @@ function stepAggregate(ranges: TimeRange[], fn: AggFn, step: bigint): TimeRange 
     timestamps[i] = minT + BigInt(i) * step;
   }
 
+  const minTN = Number(minT);
+  const stepN = Number(step);
+
   values.fill(aggInit(fn));
 
-  for (const r of ranges) {
-    for (let i = 0; i < r.timestamps.length; i++) {
-      const bucket = Number((r.timestamps[i]! - minT) / step);
-      if (bucket < 0 || bucket >= bucketCount) continue;
-      values[bucket] = aggAccumulate(values[bucket]!, r.values[i]!, fn);
-      counts[bucket]!++;
+  // ── Stats-skip: fold pre-computed chunk stats when the chunk fits in one bucket ──
+  // Remaining ranges that need sample-level iteration.
+  let sampleRanges: TimeRange[];
+  if (fn !== 'rate') {
+    sampleRanges = [];
+    for (let ri = 0; ri < ranges.length; ri++) {
+      const r = ranges[ri]!;
+      if (r.stats && r.chunkMinT !== undefined && r.chunkMaxT !== undefined) {
+        const bucketLo = Number(r.chunkMinT - minT) / stepN | 0;
+        const bucketHi = Number(r.chunkMaxT - minT) / stepN | 0;
+        if (bucketLo === bucketHi) {
+          // Entire chunk maps to one bucket — fold stats directly.
+          const st = r.stats;
+          switch (fn) {
+            case 'min':
+              if (st.minV < values[bucketLo]!) values[bucketLo] = st.minV;
+              break;
+            case 'max':
+              if (st.maxV > values[bucketLo]!) values[bucketLo] = st.maxV;
+              break;
+            case 'sum': case 'avg':
+              values[bucketLo]! += st.sum;
+              break;
+            case 'count':
+              values[bucketLo]! += st.count;
+              break;
+            case 'last':
+              values[bucketLo] = st.lastV;
+              break;
+          }
+          counts[bucketLo]! += st.count;
+          continue;
+        }
+        // Chunk spans multiple buckets — lazy-decode to get actual samples.
+        if (r.decode) {
+          sampleRanges.push(r.decode());
+          continue;
+        }
+      }
+      sampleRanges.push(r);
     }
+  } else {
+    // Rate needs per-sample timestamps — always decode stats-only parts.
+    sampleRanges = ranges.map(r =>
+      r.timestamps.length === 0 && r.decode ? r.decode() : r,
+    );
+  }
+
+  // Fused DataView + bucket assignment: read BigInt64 timestamps directly
+  // via DataView in the accumulation loop, avoiding a separate Float64Array
+  // allocation per range.  Each range creates one lightweight DataView
+  // instead of a full Float64Array copy.
+  switch (fn) {
+    case 'min':
+      for (let ri = 0; ri < sampleRanges.length; ri++) {
+        const src = sampleRanges[ri]!.timestamps;
+        const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        const vs = sampleRanges[ri]!.values;
+        for (let i = 0, len = src.length; i < len; i++) {
+          const off = i << 3;
+          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          if (vs[i]! < values[bucket]!) values[bucket] = vs[i]!;
+          counts[bucket]!++;
+        }
+      }
+      break;
+    case 'max':
+      for (let ri = 0; ri < sampleRanges.length; ri++) {
+        const src = sampleRanges[ri]!.timestamps;
+        const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        const vs = sampleRanges[ri]!.values;
+        for (let i = 0, len = src.length; i < len; i++) {
+          const off = i << 3;
+          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          if (vs[i]! > values[bucket]!) values[bucket] = vs[i]!;
+          counts[bucket]!++;
+        }
+      }
+      break;
+    case 'sum': case 'avg':
+      for (let ri = 0; ri < sampleRanges.length; ri++) {
+        const src = sampleRanges[ri]!.timestamps;
+        const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        const vs = sampleRanges[ri]!.values;
+        for (let i = 0, len = src.length; i < len; i++) {
+          const off = i << 3;
+          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          values[bucket]! += vs[i]!;
+          counts[bucket]!++;
+        }
+      }
+      break;
+    case 'count':
+      for (let ri = 0; ri < sampleRanges.length; ri++) {
+        const src = sampleRanges[ri]!.timestamps;
+        const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        for (let i = 0, len = src.length; i < len; i++) {
+          const off = i << 3;
+          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          values[bucket]!++;
+          counts[bucket]!++;
+        }
+      }
+      break;
+    case 'last':
+      for (let ri = 0; ri < sampleRanges.length; ri++) {
+        const src = sampleRanges[ri]!.timestamps;
+        const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        const vs = sampleRanges[ri]!.values;
+        for (let i = 0, len = src.length; i < len; i++) {
+          const off = i << 3;
+          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          values[bucket] = vs[i]!;
+          counts[bucket]!++;
+        }
+      }
+      break;
+    case 'rate': {
+      const firstTs = new Float64Array(bucketCount).fill(Infinity);
+      const firstVal = new Float64Array(bucketCount);
+      const lastTs = new Float64Array(bucketCount).fill(-Infinity);
+      const lastVal = new Float64Array(bucketCount);
+      for (let ri = 0; ri < sampleRanges.length; ri++) {
+        const src = sampleRanges[ri]!.timestamps;
+        const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        const vs = sampleRanges[ri]!.values;
+        for (let i = 0, len = src.length; i < len; i++) {
+          const off = i << 3;
+          const t = dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le);
+          const bucket = (t - minTN) / stepN | 0;
+          counts[bucket]!++;
+          if (t < firstTs[bucket]!) { firstTs[bucket] = t; firstVal[bucket] = vs[i]!; }
+          if (t >= lastTs[bucket]!) { lastTs[bucket] = t; lastVal[bucket] = vs[i]!; }
+        }
+      }
+      for (let i = 0; i < bucketCount; i++) {
+        const dt = (lastTs[i]! - firstTs[i]!) / 1000;
+        values[i] = dt > 0 ? (lastVal[i]! - firstVal[i]!) / dt : 0;
+      }
+      break;
+    }
+    default:
+      for (let ri = 0; ri < sampleRanges.length; ri++) {
+        const src = sampleRanges[ri]!.timestamps;
+        const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        const vs = sampleRanges[ri]!.values;
+        for (let i = 0; i < src.length; i++) {
+          const off = i << 3;
+          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          values[bucket] = aggAccumulate(values[bucket]!, vs[i]!, fn);
+          counts[bucket]!++;
+        }
+      }
   }
 
   aggFinalize(values, counts, fn);
+
+  // Replace init-value sentinels with NaN in empty buckets so consumers
+  // see "no data" instead of Infinity / -Infinity / 0.
+  if (fn !== 'sum' && fn !== 'count') {
+    for (let i = 0; i < bucketCount; i++) {
+      if (counts[i]! === 0) values[i] = NaN;
+    }
+  }
+
   return { timestamps, values };
 }

--- a/packages/o11ytsdb/src/types.ts
+++ b/packages/o11ytsdb/src/types.ts
@@ -17,6 +17,16 @@ export type SeriesId = number;
 export interface TimeRange {
   timestamps: BigInt64Array;
   values: Float64Array;
+  /** Pre-computed chunk statistics (when available, query engine may skip sample iteration). */
+  stats?: ChunkStats;
+  /** Minimum timestamp in the original chunk (for bucket-fit checks). */
+  chunkMinT?: bigint;
+  /** Maximum timestamp in the original chunk (for bucket-fit checks). */
+  chunkMaxT?: bigint;
+  /** Lazy decode callback for stats-only parts.
+   *  When a stats-only part can't be folded (spans multiple buckets),
+   *  the query engine calls this to retrieve the full sample data. */
+  decode?: () => TimeRange;
 }
 
 // ── Codec (encode/decode strategy) ───────────────────────────────────
@@ -103,6 +113,9 @@ export interface StorageBackend {
 
   /** Read decoded samples in [start, end] for a series. */
   read(id: SeriesId, start: bigint, end: bigint): TimeRange;
+
+  /** Read decoded samples as individual chunk parts (avoids concatenation). */
+  readParts?(id: SeriesId, start: bigint, end: bigint): TimeRange[];
 
   /** Retrieve the label set for a series. */
   labels(id: SeriesId): Labels | undefined;

--- a/packages/o11ytsdb/test/query.test.ts
+++ b/packages/o11ytsdb/test/query.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { ColumnStore } from '../src/column-store.js';
 import { FlatStore } from '../src/flat-store.js';
 import { ScanEngine } from '../src/query.js';
-import type { Labels, StorageBackend } from '../src/types.js';
+import type { Labels, StorageBackend, ValuesCodec } from '../src/types.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -173,39 +174,386 @@ describe('ScanEngine', () => {
     expect(s.values[1]).toBeCloseTo(0.0001);
   });
 
-  it('step aggregation buckets correctly', () => {
+  // ── stepAggregate value-correctness tests ────────────────────────
+
+  /**
+   * Helper: creates a store with deterministic values for step-agg testing.
+   * 2 series, 6 points each at 1s intervals (0, 1000, 2000, 3000, 4000, 5000).
+   *   series A: values [10, 20, 30, 40, 50, 60]
+   *   series B: values [1,  2,  3,  4,  5,  6]
+   * With step=2000, buckets are:
+   *   bucket 0 (t=0):    A:10,20  B:1,2
+   *   bucket 1 (t=2000): A:30,40  B:3,4
+   *   bucket 2 (t=4000): A:50,60  B:5,6
+   */
+  function makeStepStore(): FlatStore {
     const store = new FlatStore();
-    const id = store.getOrCreateSeries(makeLabels('stepped'));
-    // 10 points at 1s intervals
-    for (let i = 0; i < 10; i++) {
-      store.append(id, BigInt(i) * 1_000n, i + 1);
+    const idA = store.getOrCreateSeries(makeLabels('m', { host: 'a', region: 'us' }));
+    const idB = store.getOrCreateSeries(makeLabels('m', { host: 'b', region: 'eu' }));
+    for (let i = 0; i < 6; i++) {
+      store.append(idA, BigInt(i) * 1_000n, (i + 1) * 10);
+      store.append(idB, BigInt(i) * 1_000n, i + 1);
     }
+    return store;
+  }
+
+  it('step aggregation sum computes correct values', () => {
+    const store = makeStepStore();
     const result = engine.query(store, {
-      metric: 'stepped',
-      start: 0n,
-      end: 10_000n,
-      agg: 'sum',
-      step: 3_000n,
+      metric: 'm', start: 0n, end: 6_000n, agg: 'sum', step: 2_000n,
     });
-    // Buckets: [0,3000), [3000,6000), [6000,9000), [9000,...]
-    expect(result.series[0]!.timestamps.length).toBe(4);
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(3);
+    // bucket 0: 10+20+1+2 = 33
+    expect(s.values[0]).toBeCloseTo(33);
+    // bucket 1: 30+40+3+4 = 77
+    expect(s.values[1]).toBeCloseTo(77);
+    // bucket 2: 50+60+5+6 = 121
+    expect(s.values[2]).toBeCloseTo(121);
   });
 
-  it('groupBy creates separate aggregations', () => {
+  it('step aggregation min computes correct values', () => {
+    const store = makeStepStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 6_000n, agg: 'min', step: 2_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(3);
+    // bucket 0: min(10,20,1,2) = 1
+    expect(s.values[0]).toBe(1);
+    // bucket 1: min(30,40,3,4) = 3
+    expect(s.values[1]).toBe(3);
+    // bucket 2: min(50,60,5,6) = 5
+    expect(s.values[2]).toBe(5);
+  });
+
+  it('step aggregation max computes correct values', () => {
+    const store = makeStepStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 6_000n, agg: 'max', step: 2_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(3);
+    // bucket 0: max(10,20,1,2) = 20
+    expect(s.values[0]).toBe(20);
+    // bucket 1: max(30,40,3,4) = 40
+    expect(s.values[1]).toBe(40);
+    // bucket 2: max(50,60,5,6) = 60
+    expect(s.values[2]).toBe(60);
+  });
+
+  it('step aggregation avg computes correct values', () => {
+    const store = makeStepStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 6_000n, agg: 'avg', step: 2_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(3);
+    // bucket 0: (10+20+1+2)/4 = 8.25
+    expect(s.values[0]).toBeCloseTo(8.25);
+    // bucket 1: (30+40+3+4)/4 = 19.25
+    expect(s.values[1]).toBeCloseTo(19.25);
+    // bucket 2: (50+60+5+6)/4 = 30.25
+    expect(s.values[2]).toBeCloseTo(30.25);
+  });
+
+  it('step aggregation count computes correct values', () => {
+    const store = makeStepStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 6_000n, agg: 'count', step: 2_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(3);
+    // Each bucket: 2 samples from A + 2 from B = 4
+    expect(s.values[0]).toBe(4);
+    expect(s.values[1]).toBe(4);
+    expect(s.values[2]).toBe(4);
+  });
+
+  it('step aggregation last computes correct values', () => {
+    const store = makeStepStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 6_000n, agg: 'last', step: 2_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(3);
+    // last overwrites in insertion order: A then B processed sequentially
+    // bucket 0: A writes 10,20 → B writes 1,2 → last value seen = 2
+    expect(s.values[0]).toBe(2);
+    // bucket 1: last = 4
+    expect(s.values[1]).toBe(4);
+    // bucket 2: last = 6
+    expect(s.values[2]).toBe(6);
+  });
+
+  it('step aggregation bucket timestamps are aligned to step', () => {
+    const store = makeStepStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 6_000n, agg: 'sum', step: 2_000n,
+    });
+    const ts = result.series[0]!.timestamps;
+    expect(ts[0]).toBe(0n);
+    expect(ts[1]).toBe(2_000n);
+    expect(ts[2]).toBe(4_000n);
+  });
+
+  // ── stepAggregate rate ─────────────────────────────────────────────
+
+  it('step aggregation rate computes per-bucket derivative', () => {
+    const store = new FlatStore();
+    const id = store.getOrCreateSeries(makeLabels('counter'));
+    // Counter: 0, 100, 200, 300, 400, 500 at 1s intervals
+    for (let i = 0; i < 6; i++) {
+      store.append(id, BigInt(i) * 1_000n, i * 100);
+    }
+    // step=2000 → 3 buckets:
+    //   bucket 0 (t=0):    values 0,100   → rate = (100-0)/(1000-0)/1000 = 100/1 = 100/s
+    //   bucket 1 (t=2000): values 200,300 → rate = (300-200)/(3000-2000)/1000 = 100/1 = 100/s
+    //   bucket 2 (t=4000): values 400,500 → rate = (500-400)/(5000-4000)/1000 = 100/1 = 100/s
+    const result = engine.query(store, {
+      metric: 'counter', start: 0n, end: 6_000n, agg: 'rate', step: 2_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(3);
+    // (100 - 0) / ((1000 - 0) / 1000) = 100 / 1 = 100
+    expect(s.values[0]).toBeCloseTo(100);
+    expect(s.values[1]).toBeCloseTo(100);
+    expect(s.values[2]).toBeCloseTo(100);
+  });
+
+  it('step aggregation rate with varying rate', () => {
+    const store = new FlatStore();
+    const id = store.getOrCreateSeries(makeLabels('counter'));
+    // bucket 0: t=0 v=0, t=1000 v=50  → rate = 50/s
+    // bucket 1: t=2000 v=50, t=3000 v=250 → rate = 200/s
+    store.append(id, 0n, 0);
+    store.append(id, 1_000n, 50);
+    store.append(id, 2_000n, 50);
+    store.append(id, 3_000n, 250);
+    const result = engine.query(store, {
+      metric: 'counter', start: 0n, end: 4_000n, agg: 'rate', step: 2_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(2);
+    expect(s.values[0]).toBeCloseTo(50);
+    expect(s.values[1]).toBeCloseTo(200);
+  });
+
+  it('step aggregation rate with single point per bucket produces 0', () => {
+    const store = new FlatStore();
+    const id = store.getOrCreateSeries(makeLabels('counter'));
+    // One point per bucket → dt=0 → rate=0
+    store.append(id, 0n, 100);
+    store.append(id, 5_000n, 200);
+    const result = engine.query(store, {
+      metric: 'counter', start: 0n, end: 6_000n, agg: 'rate', step: 3_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(2);
+    // Each bucket has only one point: dt=0 → rate=0
+    expect(s.values[0]).toBe(0);
+    expect(s.values[1]).toBe(0);
+  });
+
+  it('step aggregation rate with empty bucket produces NaN', () => {
+    const store = new FlatStore();
+    const id = store.getOrCreateSeries(makeLabels('counter'));
+    store.append(id, 0n, 100);
+    store.append(id, 4_000n, 200);
+    const result = engine.query(store, {
+      metric: 'counter', start: 0n, end: 5_000n, agg: 'rate', step: 2_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(3);
+    expect(s.values[0]).toBe(0);     // single point → rate=0
+    expect(s.values[1]).toBeNaN();   // empty bucket → NaN
+    expect(s.values[2]).toBe(0);     // single point → rate=0
+  });
+
+  // ── stepAggregate edge cases ───────────────────────────────────────
+
+  it('step aggregation with single point produces one bucket', () => {
+    const store = new FlatStore();
+    const id = store.getOrCreateSeries(makeLabels('single'));
+    store.append(id, 5_000n, 42);
+    const result = engine.query(store, {
+      metric: 'single', start: 0n, end: 10_000n, agg: 'sum', step: 3_000n,
+    });
+    expect(result.series[0]!.timestamps.length).toBe(1);
+    expect(result.series[0]!.values[0]).toBe(42);
+  });
+
+  it('step aggregation with step larger than data span produces one bucket', () => {
+    const store = makeStepStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 6_000n, agg: 'sum', step: 100_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(1);
+    // All 12 values: (10+20+30+40+50+60) + (1+2+3+4+5+6) = 210 + 21 = 231
+    expect(s.values[0]).toBeCloseTo(231);
+  });
+
+  it('step aggregation with empty buckets produces NaN', () => {
+    const store = new FlatStore();
+    const id = store.getOrCreateSeries(makeLabels('sparse'));
+    // Points at t=0 and t=4000 → bucket at t=2000 has no data
+    store.append(id, 0n, 10);
+    store.append(id, 4_000n, 50);
+    const result = engine.query(store, {
+      metric: 'sparse', start: 0n, end: 5_000n, agg: 'min', step: 2_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(3);
+    expect(s.values[0]).toBe(10);         // bucket 0: has data
+    expect(s.values[1]).toBeNaN();        // bucket 1: empty → NaN
+    expect(s.values[2]).toBe(50);         // bucket 2: has data
+  });
+
+  it('step aggregation empty buckets NaN for max', () => {
+    const store = new FlatStore();
+    const id = store.getOrCreateSeries(makeLabels('sparse'));
+    store.append(id, 0n, 10);
+    store.append(id, 4_000n, 50);
+    const result = engine.query(store, {
+      metric: 'sparse', start: 0n, end: 5_000n, agg: 'max', step: 2_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.values[0]).toBe(10);
+    expect(s.values[1]).toBeNaN();
+    expect(s.values[2]).toBe(50);
+  });
+
+  it('step aggregation empty buckets NaN for avg', () => {
+    const store = new FlatStore();
+    const id = store.getOrCreateSeries(makeLabels('sparse'));
+    store.append(id, 0n, 10);
+    store.append(id, 4_000n, 50);
+    const result = engine.query(store, {
+      metric: 'sparse', start: 0n, end: 5_000n, agg: 'avg', step: 2_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.values[0]).toBe(10);
+    expect(s.values[1]).toBeNaN();
+    expect(s.values[2]).toBe(50);
+  });
+
+  it('step aggregation empty buckets are 0 for sum and count', () => {
+    const store = new FlatStore();
+    const id = store.getOrCreateSeries(makeLabels('sparse'));
+    store.append(id, 0n, 10);
+    store.append(id, 4_000n, 50);
+    // sum: empty bucket stays 0
+    const sumResult = engine.query(store, {
+      metric: 'sparse', start: 0n, end: 5_000n, agg: 'sum', step: 2_000n,
+    });
+    expect(sumResult.series[0]!.values[1]).toBe(0);
+    // count: empty bucket stays 0
+    const countResult = engine.query(store, {
+      metric: 'sparse', start: 0n, end: 5_000n, agg: 'count', step: 2_000n,
+    });
+    expect(countResult.series[0]!.values[1]).toBe(0);
+  });
+
+  // ── groupBy + step combined ────────────────────────────────────────
+
+  it('groupBy + step produces correct per-group values', () => {
+    const store = makeStepStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 6_000n, agg: 'sum', step: 2_000n, groupBy: ['region'],
+    });
+    // 2 regions: 'us' (host a) and 'eu' (host b)
+    expect(result.series.length).toBe(2);
+
+    const us = result.series.find(s => s.labels.get('region') === 'us')!;
+    const eu = result.series.find(s => s.labels.get('region') === 'eu')!;
+    expect(us).toBeDefined();
+    expect(eu).toBeDefined();
+
+    // US (series A only): bucket 0: 10+20=30, bucket 1: 30+40=70, bucket 2: 50+60=110
+    expect(us.values[0]).toBeCloseTo(30);
+    expect(us.values[1]).toBeCloseTo(70);
+    expect(us.values[2]).toBeCloseTo(110);
+
+    // EU (series B only): bucket 0: 1+2=3, bucket 1: 3+4=7, bucket 2: 5+6=11
+    expect(eu.values[0]).toBeCloseTo(3);
+    expect(eu.values[1]).toBeCloseTo(7);
+    expect(eu.values[2]).toBeCloseTo(11);
+  });
+
+  it('groupBy + step min produces correct per-group values', () => {
+    const store = makeStepStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 6_000n, agg: 'min', step: 2_000n, groupBy: ['host'],
+    });
+    const a = result.series.find(s => s.labels.get('host') === 'a')!;
+    const b = result.series.find(s => s.labels.get('host') === 'b')!;
+    // Host a: bucket 0: min(10,20)=10, bucket 1: min(30,40)=30, bucket 2: min(50,60)=50
+    expect(a.values[0]).toBe(10);
+    expect(a.values[1]).toBe(30);
+    expect(a.values[2]).toBe(50);
+    // Host b: bucket 0: min(1,2)=1, bucket 1: min(3,4)=3, bucket 2: min(5,6)=5
+    expect(b.values[0]).toBe(1);
+    expect(b.values[1]).toBe(3);
+    expect(b.values[2]).toBe(5);
+  });
+
+  it('groupBy with no groupBy key returns single group', () => {
     const store = populateStore();
     const result = engine.query(store, {
-      metric: 'cpu',
-      start: 0n,
-      end: BigInt(Number.MAX_SAFE_INTEGER),
+      metric: 'cpu', start: 0n, end: BigInt(Number.MAX_SAFE_INTEGER),
       agg: 'sum',
-      groupBy: ['host'],
     });
-    // 3 distinct hosts → 3 groups
-    expect(result.series.length).toBe(3);
-    for (const s of result.series) {
-      expect(s.labels.get('host')).toBeDefined();
-      expect(s.timestamps.length).toBe(100);
-    }
+    // No groupBy → all series aggregated into one
+    expect(result.series.length).toBe(1);
+    // First point: 10 + 20 + 30 = 60
+    expect(result.series[0]!.values[0]).toBeCloseTo(60);
+  });
+
+  // ── pointAggregate coverage ────────────────────────────────────────
+
+  it('aggregates with last (pointAggregate)', () => {
+    const store = populateStore();
+    const result = engine.query(store, {
+      metric: 'cpu', start: 0n, end: BigInt(Number.MAX_SAFE_INTEGER), agg: 'last',
+    });
+    expect(result.series.length).toBe(1);
+    // last overwrites sequentially: a=10, b=20, c=30 → last = 30
+    expect(result.series[0]!.values[0]).toBe(30);
+  });
+
+  it('pointAggregate handles unequal-length series', () => {
+    const store = new FlatStore();
+    const idA = store.getOrCreateSeries(makeLabels('m', { host: 'x' }));
+    const idB = store.getOrCreateSeries(makeLabels('m', { host: 'y' }));
+    // A has 5 points, B has 3
+    for (let i = 0; i < 5; i++) store.append(idA, BigInt(i) * 1_000n, 10);
+    for (let i = 0; i < 3; i++) store.append(idB, BigInt(i) * 1_000n, 20);
+
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 10_000n, agg: 'sum',
+    });
+    const s = result.series[0]!;
+    // Longest series (A) has 5 points, so output has 5 timestamps
+    expect(s.timestamps.length).toBe(5);
+    // First 3 points: 10+20 = 30
+    expect(s.values[0]).toBeCloseTo(30);
+    expect(s.values[2]).toBeCloseTo(30);
+    // Last 2 points: only A contributes → 10
+    expect(s.values[3]).toBeCloseTo(10);
+    expect(s.values[4]).toBeCloseTo(10);
+  });
+
+  // ── scannedSamples tracking ────────────────────────────────────────
+
+  it('scannedSamples is correct with step aggregation', () => {
+    const store = makeStepStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 6_000n, agg: 'sum', step: 2_000n,
+    });
+    // 2 series × 6 points = 12
+    expect(result.scannedSamples).toBe(12);
+    expect(result.scannedSeries).toBe(2);
   });
 
   it('handles empty store gracefully', () => {
@@ -228,5 +576,155 @@ describe('ScanEngine', () => {
     });
     expect(result.series.length).toBe(0);
     expect(result.scannedSamples).toBe(0);
+  });
+
+  // ── ChunkStats-skip tests (ColumnStore with frozen chunks) ─────────
+
+  /**
+   * Identity values codec — stores raw Float64Array bytes.
+   * ColumnStore computes ChunkStats via computeStats() when codec
+   * doesn't provide encodeValuesWithStats.
+   */
+  const identityValuesCodec: ValuesCodec = {
+    name: 'identity',
+    encodeValues(values: Float64Array): Uint8Array {
+      return new Uint8Array(values.buffer.slice(0));
+    },
+    decodeValues(buf: Uint8Array): Float64Array {
+      return new Float64Array(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength));
+    },
+  };
+
+  /**
+   * Helper: creates a ColumnStore (chunk=4) with 1 series, 8 points at 1s intervals.
+   * Values: [10, 20, 30, 40, 50, 60, 70, 80]
+   * This produces 2 frozen chunks (4 samples each) so stats-skip can be exercised.
+   * Chunk 0: t=[0,1000,2000,3000], v=[10,20,30,40] → min=10, max=40, sum=100, count=4
+   * Chunk 1: t=[4000,5000,6000,7000], v=[50,60,70,80] → min=50, max=80, sum=260, count=4
+   */
+  function makeStatsStore(): ColumnStore {
+    const store = new ColumnStore(identityValuesCodec, 4);
+    const id = store.getOrCreateSeries(makeLabels('m'));
+    for (let i = 0; i < 8; i++) {
+      store.append(id, BigInt(i) * 1_000n, (i + 1) * 10);
+    }
+    return store;
+  }
+
+  it('stats-skip: sum with large step uses chunk stats', () => {
+    const store = makeStatsStore();
+    // step=4000 → 2 buckets, each chunk fits exactly in one bucket
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 8_000n, agg: 'sum', step: 4_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(2);
+    // Chunk 0: sum(10,20,30,40) = 100
+    expect(s.values[0]).toBeCloseTo(100);
+    // Chunk 1: sum(50,60,70,80) = 260
+    expect(s.values[1]).toBeCloseTo(260);
+  });
+
+  it('stats-skip: min with large step uses chunk stats', () => {
+    const store = makeStatsStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 8_000n, agg: 'min', step: 4_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.values[0]).toBe(10);
+    expect(s.values[1]).toBe(50);
+  });
+
+  it('stats-skip: max with large step uses chunk stats', () => {
+    const store = makeStatsStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 8_000n, agg: 'max', step: 4_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.values[0]).toBe(40);
+    expect(s.values[1]).toBe(80);
+  });
+
+  it('stats-skip: avg with large step uses chunk stats', () => {
+    const store = makeStatsStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 8_000n, agg: 'avg', step: 4_000n,
+    });
+    const s = result.series[0]!;
+    // Chunk 0: avg(10,20,30,40) = 25
+    expect(s.values[0]).toBeCloseTo(25);
+    // Chunk 1: avg(50,60,70,80) = 65
+    expect(s.values[1]).toBeCloseTo(65);
+  });
+
+  it('stats-skip: count with large step uses chunk stats', () => {
+    const store = makeStatsStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 8_000n, agg: 'count', step: 4_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.values[0]).toBe(4);
+    expect(s.values[1]).toBe(4);
+  });
+
+  it('stats-skip: last with large step uses chunk stats', () => {
+    const store = makeStatsStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 8_000n, agg: 'last', step: 4_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.values[0]).toBe(40);  // last of chunk 0
+    expect(s.values[1]).toBe(80);  // last of chunk 1
+  });
+
+  it('stats-skip: single big bucket (step > data span) uses stats', () => {
+    const store = makeStatsStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 10_000n, agg: 'sum', step: 100_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(1);
+    // sum(10..80) = 360
+    expect(s.values[0]).toBeCloseTo(360);
+  });
+
+  it('stats-skip: scannedSamples counts stats-only parts', () => {
+    const store = makeStatsStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 8_000n, agg: 'sum', step: 4_000n,
+    });
+    // 8 samples total (2 chunks × 4)
+    expect(result.scannedSamples).toBe(8);
+  });
+
+  it('stats-skip: small step lazy-decodes chunks spanning multiple buckets', () => {
+    const store = makeStatsStore();
+    // step=2000 → 4 buckets; each 4-sample chunk spans 2 buckets → lazy decode
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 8_000n, agg: 'sum', step: 2_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(4);
+    // Bucket 0 [0,2000): t=0→10, t=1000→20 → sum=30
+    expect(s.values[0]).toBeCloseTo(30);
+    // Bucket 1 [2000,4000): t=2000→30, t=3000→40 → sum=70
+    expect(s.values[1]).toBeCloseTo(70);
+    // Bucket 2 [4000,6000): t=4000→50, t=5000→60 → sum=110
+    expect(s.values[2]).toBeCloseTo(110);
+    // Bucket 3 [6000,8000): t=6000→70, t=7000→80 → sum=150
+    expect(s.values[3]).toBeCloseTo(150);
+  });
+
+  it('stats-skip: rate with ColumnStore lazy-decodes correctly', () => {
+    const store = makeStatsStore();
+    const result = engine.query(store, {
+      metric: 'm', start: 0n, end: 8_000n, agg: 'rate', step: 4_000n,
+    });
+    const s = result.series[0]!;
+    expect(s.timestamps.length).toBe(2);
+    // Each bucket has 4 points at 1s intervals, values increase by 10 each
+    // rate = (last - first) / (lastT - firstT) * 1000 = (40-10)/(3000) * 1000 = 10
+    expect(s.values[0]).toBeCloseTo(10);
+    expect(s.values[1]).toBeCloseTo(10);
   });
 });


### PR DESCRIPTION
## What

ChunkStats-based skip optimization for step aggregation queries. When a compressed chunk fits entirely within a single aggregation bucket, the query engine folds pre-computed stats (min, max, sum, count, first, last) directly into the bucket — skipping decompression entirely.

## Changes

- **types.ts**: Extend `TimeRange` with `stats?`, `chunkMinT?`, `chunkMaxT?`, `decode()` for lazy decompression
- **column-store.ts**: `readParts` emits stats-only parts for fully-enclosed chunks with lazy `decode()` callback; `read()` resolves decode before concat
- **query.ts**: `stepAggregate` folds chunk stats when chunk fits in one bucket; lazy-decodes for multi-bucket spans; DataView-based BigInt64→Number conversion; specialized per-AggFn inner loops; NaN sentinels
- **flat-store.ts**: `readParts` support for FlatStore
- **query.test.ts**: 45 tests (was 14) covering all agg functions, stats folding, lazy decode, rate, empty buckets, groupBy, scannedSamples
- **bench**: `profile-query.mjs` and `query-sweep.mjs` benchmarks

## Benchmarks (5M samples, 30 series, column-alp-fused)

| Step | Median | vs 1min baseline |
|------|--------|-----------------|
| 1min | 135ms  | (lazy-decode, no stats skip) |
| 6h   | 35ms   | 3.9x faster |
| 1d   | 9ms    | 15x faster |
| 4h   | 53ms   | (profile-query.mjs) |

## Why

Large-step queries (dashboards showing hours/days of data) are the common case. Stats-skip avoids decompressing chunks that map to a single bucket, collapsing O(samples) work to O(chunks). The 15x improvement at 1d step means dashboard refresh goes from 135ms to 9ms.

## Test plan

- 45 unit tests covering all aggregation functions, stats folding paths, lazy decode fallback, rate with ColumnStore, empty buckets, groupBy, and scannedSamples counter
- query-sweep.mjs validates correctness across 60 configurations (6 aggs x 5 steps x 2 ranges)

