### PR TITLE
fix(learn): UX audit — breadcrumbs, autoscroll, nav, code sharing

### DIFF
--- a/site/tsdb-engine/index.html
+++ b/site/tsdb-engine/index.html
@@ -54,6 +54,7 @@
         </p>
         <div class="hero-actions">
           <a class="cta cta-primary" href="#live-demo">Launch Live Demo ↓</a>
+          <a class="cta" href="learn/">Learn How It Works</a>
           <a class="cta" href="https://github.com/strawgate/o11ykit/tree/main/packages/o11ytsdb" target="_blank" rel="noreferrer">
             Browse Source
           </a>

--- a/site/tsdb-engine/learn/alp/alp-experience.css
+++ b/site/tsdb-engine/learn/alp/alp-experience.css
@@ -1,0 +1,433 @@
+/* ─── ALP Compression Experience ─────────────────────────────────── */
+
+/* ─── Data Values Card ────────────────────────────────────────────── */
+.alp-values-card {
+  padding: 16px;
+}
+
+.alp-values-scroll {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding-bottom: 8px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--xp-border-strong) transparent;
+}
+
+.alp-values-scroll::-webkit-scrollbar {
+  height: 6px;
+}
+
+.alp-values-scroll::-webkit-scrollbar-thumb {
+  background: var(--xp-border-strong);
+  border-radius: 3px;
+}
+
+.alp-val-chip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 8px 10px;
+  background: var(--xp-surface-raised);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  flex-shrink: 0;
+  min-width: 60px;
+  transition: all 200ms;
+}
+
+.alp-val-chip .idx {
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--xp-text-dim);
+}
+
+.alp-val-chip .val {
+  font-family: var(--xp-mono);
+  font-size: 13px;
+  color: var(--xp-text);
+  white-space: nowrap;
+}
+
+.alp-val-chip.exception {
+  border-color: var(--xp-warn);
+  background: var(--xp-warn-glow);
+}
+
+.alp-val-chip.exception .val {
+  color: var(--xp-warn);
+}
+
+/* ─── Custom Input ────────────────────────────────────────────────── */
+.custom-input-wrap {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  margin-bottom: 16px;
+}
+
+.alp-textarea {
+  flex: 1;
+  padding: 10px 14px;
+  font-family: var(--xp-mono);
+  font-size: 13px;
+  color: var(--xp-text);
+  background: var(--xp-surface-raised);
+  border: 1px solid var(--xp-border-strong);
+  border-radius: var(--xp-radius-sm);
+  resize: vertical;
+  outline: none;
+  transition: border-color 150ms;
+}
+
+.alp-textarea:focus {
+  border-color: var(--xp-accent);
+}
+
+/* ─── Stage Panels ────────────────────────────────────────────────── */
+.alp-panel {
+  animation: xp-fade-in 350ms ease both;
+  margin-bottom: 24px;
+}
+
+.alp-panel[hidden] {
+  display: none;
+}
+
+.alp-panel h3 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #fff;
+  margin: 0 0 6px;
+}
+
+.alp-panel p {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--xp-text-muted);
+  margin: 0 0 16px;
+  max-width: 65ch;
+}
+
+/* ─── Exponent Scan Table ─────────────────────────────────────────── */
+.alp-exp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  margin-bottom: 8px;
+}
+
+.alp-exp-table th {
+  text-align: left;
+  padding: 8px 10px;
+  font-weight: 600;
+  color: var(--xp-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 11px;
+  border-bottom: 1px solid var(--xp-border-strong);
+}
+
+.alp-exp-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--xp-border);
+  font-family: var(--xp-mono);
+  font-size: 12px;
+  color: var(--xp-text);
+}
+
+.alp-exp-table tr.winner td {
+  background: var(--xp-success-glow);
+  color: var(--xp-success);
+  font-weight: 600;
+}
+
+.alp-exp-table tr:hover td {
+  background: var(--xp-accent-glow);
+}
+
+.alp-exp-table tr.winner:hover td {
+  background: var(--xp-success-glow);
+}
+
+.alp-check { color: var(--xp-success); }
+.alp-cross { color: var(--xp-error); }
+
+/* ─── Quantize Two-Column ─────────────────────────────────────────── */
+.alp-quant-grid {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr;
+  gap: 6px 12px;
+  align-items: center;
+  font-family: var(--xp-mono);
+  font-size: 13px;
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.alp-quant-grid .arrow {
+  text-align: center;
+  color: var(--xp-accent);
+  font-size: 16px;
+}
+
+.alp-quant-grid .from, .alp-quant-grid .to {
+  padding: 6px 10px;
+  background: var(--xp-surface-raised);
+  border-radius: var(--xp-radius-xs);
+  transition: all 300ms ease;
+}
+
+.alp-quant-grid .to {
+  color: var(--xp-success);
+  background: var(--xp-success-glow);
+}
+
+.alp-quant-grid .hdr {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--xp-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-family: var(--xp-font);
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--xp-border);
+}
+
+/* ─── Frame-of-Reference Range Bar ────────────────────────────────── */
+.alp-for-visual {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.alp-range-bar {
+  position: relative;
+  height: 32px;
+  background: var(--xp-surface-raised);
+  border-radius: var(--xp-radius-sm);
+  overflow: hidden;
+}
+
+.alp-range-fill {
+  height: 100%;
+  border-radius: var(--xp-radius-sm);
+  display: flex;
+  align-items: center;
+  padding-left: 10px;
+  font-family: var(--xp-mono);
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  transition: width 600ms ease;
+}
+
+.alp-range-label {
+  font-size: 12px;
+  color: var(--xp-text-muted);
+  margin-bottom: 4px;
+}
+
+.alp-for-offsets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.alp-offset-chip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 6px 10px;
+  background: var(--xp-surface-raised);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-xs);
+  font-family: var(--xp-mono);
+  font-size: 12px;
+  min-width: 50px;
+  text-align: center;
+}
+
+.alp-offset-chip .lbl {
+  font-size: 9px;
+  color: var(--xp-text-dim);
+  font-family: var(--xp-font);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* ─── Bit Grid (Packing) ─────────────────────────────────────────── */
+.alp-bitpack-wrap {
+  overflow-x: auto;
+  padding-bottom: 8px;
+}
+
+.alp-bitpack-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1px;
+  font-family: var(--xp-mono);
+  font-size: 11px;
+  line-height: 1;
+}
+
+.alp-packed-bit {
+  width: 18px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 2px;
+  transition: all 120ms;
+}
+
+.alp-bitpack-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--xp-text-muted);
+}
+
+.alp-bitpack-legend .swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+
+/* Alternating value colors for packed bits */
+.alp-packed-bit.v-even { background: rgba(96, 165, 250, 0.15); color: var(--xp-accent-light); }
+.alp-packed-bit.v-odd  { background: rgba(52, 211, 153, 0.15); color: var(--xp-success); }
+.alp-packed-bit.v-even[data-b="0"] { color: rgba(96, 165, 250, 0.35); }
+.alp-packed-bit.v-odd[data-b="0"]  { color: rgba(52, 211, 153, 0.35); }
+
+/* ─── Exceptions Panel ────────────────────────────────────────────── */
+.alp-exc-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.alp-exc-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 14px;
+  background: var(--xp-warn-glow);
+  border: 1px solid rgba(251, 191, 36, 0.25);
+  border-radius: var(--xp-radius-sm);
+  font-family: var(--xp-mono);
+  font-size: 13px;
+}
+
+.alp-exc-item .pos {
+  color: var(--xp-warn);
+  font-weight: 600;
+  min-width: 40px;
+}
+
+.alp-exc-item .raw {
+  color: var(--xp-text);
+}
+
+.alp-exc-item .cost {
+  margin-left: auto;
+  color: var(--xp-text-dim);
+  font-size: 11px;
+}
+
+/* ─── Wire Format Breakdown ───────────────────────────────────────── */
+.alp-wire-bar {
+  display: flex;
+  height: 36px;
+  border-radius: var(--xp-radius-sm);
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+
+.alp-wire-seg {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--xp-mono);
+  font-size: 11px;
+  font-weight: 500;
+  transition: flex 400ms ease;
+  min-width: 2px;
+}
+
+.alp-wire-seg.seg-header    { background: var(--region-header); color: #fff; }
+.alp-wire-seg.seg-packed    { background: var(--region-values); color: #fff; }
+.alp-wire-seg.seg-exc-pos   { background: var(--region-exceptions); color: #000; }
+.alp-wire-seg.seg-exc-val   { background: var(--xp-warn); color: #000; }
+
+.alp-wire-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 12px;
+  color: var(--xp-text-muted);
+}
+
+.alp-wire-legend .dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+
+/* ─── Summary Stats enhancements ──────────────────────────────────── */
+.alp-ratio-highlight {
+  color: var(--xp-success);
+}
+
+/* ─── Pipeline stage cursor ───────────────────────────────────────── */
+.xp-pipe-stage.clickable {
+  cursor: pointer;
+}
+
+.xp-pipe-stage.clickable:hover {
+  border-color: var(--xp-accent);
+  background: rgba(96, 165, 250, 0.06);
+}
+
+.xp-pipe-stage.done {
+  border-color: var(--xp-success);
+  background: var(--xp-success-glow);
+}
+
+.xp-pipe-stage.done .stage-label {
+  color: var(--xp-success);
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .alp-quant-grid {
+    font-size: 11px;
+    gap: 4px 8px;
+  }
+
+  .alp-quant-grid .from, .alp-quant-grid .to {
+    padding: 4px 6px;
+  }
+
+  .custom-input-wrap {
+    flex-direction: column;
+  }
+
+  .alp-wire-seg {
+    font-size: 9px;
+  }
+}

--- a/site/tsdb-engine/learn/alp/alp-experience.css
+++ b/site/tsdb-engine/learn/alp/alp-experience.css
@@ -10,17 +10,6 @@
   gap: 6px;
   overflow-x: auto;
   padding-bottom: 8px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--xp-border-strong) transparent;
-}
-
-.alp-values-scroll::-webkit-scrollbar {
-  height: 6px;
-}
-
-.alp-values-scroll::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 3px;
 }
 
 .alp-val-chip {

--- a/site/tsdb-engine/learn/alp/alp-experience.js
+++ b/site/tsdb-engine/learn/alp/alp-experience.js
@@ -144,8 +144,6 @@ let stepper;
 
 function init() {
   $("#breadcrumb-nav").innerHTML = buildBreadcrumb("ALP Compression");
-  buildPatternButtons();
-  selectPreset("temperature");
 
   const stages = [
     { icon: "🔍", label: "Scan" },
@@ -173,6 +171,9 @@ function init() {
   });
 
   stepper = new Stepper(5, onStageChange);
+
+  buildPatternButtons();
+  selectPreset("temperature");
 
   $("#btn-prev").addEventListener("click", () => stepper.prev());
   $("#btn-next").addEventListener("click", () => stepper.next());

--- a/site/tsdb-engine/learn/alp/alp-experience.js
+++ b/site/tsdb-engine/learn/alp/alp-experience.js
@@ -1,0 +1,662 @@
+/**
+ * ALP Compression — Interactive Experience
+ *
+ * Walks through the Adaptive Lossless floating-Point pipeline:
+ *   Exponent Scan → Quantize → Frame-of-Reference → Bit-Width → Pack
+ */
+
+import { $, $$, buildBreadcrumb, el, fmt, fmtBytes, Stepper } from "../shared.js";
+
+/* ─── Sample Data Presets ─────────────────────────────────────────── */
+
+const PRESETS = {
+  temperature: {
+    label: "🌡️ Temperature",
+    values: [
+      20.5, 21.3, 20.8, 21.1, 20.95, 21.45, 20.7, 21.2, 20.6, 21.35, 20.9, 21.05, 20.75, 21.4,
+      20.85, 21.15, 20.55, 21.25, 20.65, 21.0, 20.8, 21.3, 20.7, 21.1,
+    ],
+  },
+  percentage: {
+    label: "📊 Percentages",
+    values: [
+      45.2, 67.8, 89.1, 34.5, 72.3, 56.7, 91.4, 23.6, 78.9, 45.1, 62.3, 88.7, 31.2, 74.5, 58.9,
+      93.2, 41.7, 69.3, 85.6, 27.8, 76.1, 54.3, 92.8, 38.4,
+    ],
+  },
+  counter: {
+    label: "🔢 Counter",
+    values: [
+      1000, 1005, 1010, 1015, 1020, 1025, 1030, 1035, 1040, 1045, 1050, 1055, 1060, 1065, 1070,
+      1075, 1080, 1085, 1090, 1095, 1100, 1105, 1110, 1115,
+    ],
+  },
+  custom: {
+    label: "✏️ Custom",
+    values: null,
+  },
+};
+
+/* ─── ALP Algorithm ───────────────────────────────────────────────── */
+
+const POW10 = Array.from({ length: 19 }, (_, i) => 10 ** i);
+
+function alpRoundTrips(val, exp) {
+  const scaled = Math.round(val * POW10[exp]);
+  return scaled / POW10[exp] === val;
+}
+
+function findExponent(values) {
+  for (let e = 0; e <= 18; e++) {
+    if (values.every((v) => alpRoundTrips(v, e))) return e;
+  }
+  return -1;
+}
+
+function alpEncode(values) {
+  const exp = findExponent(values);
+  const exceptions = [];
+  const integers = [];
+
+  if (exp === -1) {
+    // All exceptions
+    for (let i = 0; i < values.length; i++) exceptions.push({ idx: i, value: values[i] });
+    return {
+      exp: 0,
+      integers: new Array(values.length).fill(0),
+      minInt: 0,
+      offsets: new Array(values.length).fill(0),
+      bitWidth: 0,
+      exceptions,
+      values,
+      exponentScan: buildExponentScan(values),
+    };
+  }
+
+  for (let i = 0; i < values.length; i++) {
+    const scaled = Math.round(values[i] * POW10[exp]);
+    if (scaled / POW10[exp] !== values[i]) {
+      exceptions.push({ idx: i, value: values[i] });
+      integers.push(0); // placeholder
+    } else {
+      integers.push(scaled);
+    }
+  }
+
+  const nonExcIdxs = new Set(exceptions.map((e) => e.idx));
+  const validInts = integers.filter((_, i) => !nonExcIdxs.has(i));
+  const minInt = validInts.length > 0 ? Math.min(...validInts) : 0;
+
+  const offsets = integers.map((v, i) => (nonExcIdxs.has(i) ? 0 : v - minInt));
+
+  const maxOffset = offsets.length > 0 ? Math.max(...offsets) : 0;
+  const bitWidth = maxOffset === 0 ? 0 : Math.ceil(Math.log2(maxOffset + 1));
+
+  return {
+    exp,
+    integers,
+    minInt,
+    offsets,
+    bitWidth,
+    exceptions,
+    values,
+    exponentScan: buildExponentScan(values),
+  };
+}
+
+function buildExponentScan(values) {
+  const rows = [];
+  const winExp = findExponent(values);
+  for (let e = 0; e <= Math.min(18, Math.max(5, winExp + 1)); e++) {
+    const samples = values.slice(0, 3).map((v) => {
+      const scaled = Math.round(v * POW10[e]);
+      const trips = scaled / POW10[e] === v;
+      return { original: v, scaled, trips };
+    });
+    const allTrip = values.every((v) => alpRoundTrips(v, e));
+    rows.push({ exp: e, samples, allTrip, isWinner: e === winExp });
+  }
+  return rows;
+}
+
+function wireSize(encoded) {
+  const headerBytes = 14;
+  const packedBits = (encoded.values.length - encoded.exceptions.length) * encoded.bitWidth;
+  const packedBytes = Math.ceil(packedBits / 8);
+  const excPosBytes = encoded.exceptions.length * 2;
+  const excValBytes = encoded.exceptions.length * 8;
+  return {
+    headerBytes,
+    packedBytes,
+    excPosBytes,
+    excValBytes,
+    total: headerBytes + packedBytes + excPosBytes + excValBytes,
+  };
+}
+
+/* ─── State ───────────────────────────────────────────────────────── */
+
+let currentValues = [];
+let encoded = null;
+let stepper;
+
+/* ─── DOM Init ────────────────────────────────────────────────────── */
+
+function init() {
+  $("#breadcrumb-nav").innerHTML = buildBreadcrumb("ALP Compression");
+  buildPatternButtons();
+  selectPreset("temperature");
+
+  const stages = [
+    { icon: "🔍", label: "Scan" },
+    { icon: "×10ᵉ", label: "Quantize" },
+    { icon: "−min", label: "Frame-of-Ref" },
+    { icon: "🔢", label: "Bit-Width" },
+    { icon: "📦", label: "Pack" },
+  ];
+
+  const pipelineBar = $("#pipeline-bar");
+  stages.forEach((s, i) => {
+    if (i > 0)
+      pipelineBar.appendChild(el("span", { class: "xp-pipe-arrow", "aria-hidden": "true" }, "→"));
+    const stageEl = el(
+      "div",
+      {
+        class: "xp-pipe-stage clickable",
+        "data-stage": String(i),
+        onClick: () => stepper.goto(i),
+      },
+      el("span", { class: "stage-icon" }, s.icon),
+      el("span", { class: "stage-label" }, s.label)
+    );
+    pipelineBar.appendChild(stageEl);
+  });
+
+  stepper = new Stepper(5, onStageChange);
+
+  $("#btn-prev").addEventListener("click", () => stepper.prev());
+  $("#btn-next").addEventListener("click", () => stepper.next());
+  $("#btn-play").addEventListener("click", () => stepper.play(1800));
+  $("#btn-reset").addEventListener("click", () => {
+    stepper.stop();
+    stepper.reset();
+  });
+  $("#apply-custom").addEventListener("click", applyCustom);
+}
+
+/* ─── Pattern Buttons ─────────────────────────────────────────────── */
+
+function buildPatternButtons() {
+  const container = $("#pattern-buttons");
+  for (const [key, preset] of Object.entries(PRESETS)) {
+    const btn = el(
+      "button",
+      {
+        class: "xp-btn",
+        "data-preset": key,
+        onClick: () => selectPreset(key),
+      },
+      preset.label
+    );
+    container.appendChild(btn);
+  }
+}
+
+function selectPreset(key) {
+  $$("[data-preset]").forEach((b) => {
+    b.classList.toggle("active", b.dataset.preset === key);
+  });
+
+  const customWrap = $("#custom-input-wrap");
+  if (key === "custom") {
+    customWrap.hidden = false;
+    const ta = $("#custom-textarea");
+    if (!ta.value.trim()) {
+      ta.value =
+        "3.14, 2.71, 1.41, 98.6, 0.577, 42.0, 7.77, 12.34, 56.78, 90.12, 3.14, 6.28, 9.42, 12.56, 15.70, 18.84";
+    }
+    applyCustom();
+    return;
+  }
+  customWrap.hidden = true;
+  setValues(PRESETS[key].values);
+}
+
+function applyCustom() {
+  const raw = $("#custom-textarea").value;
+  const parsed = raw
+    .split(/[,\s]+/)
+    .map(Number)
+    .filter((n) => Number.isFinite(n));
+  if (parsed.length < 2) return;
+  setValues(parsed);
+}
+
+/* ─── Set Values & Re-encode ──────────────────────────────────────── */
+
+function setValues(values) {
+  currentValues = values;
+  encoded = alpEncode(values);
+  renderValueChips();
+  stepper.stop();
+  stepper.reset();
+  $("#summary-section").hidden = true;
+}
+
+function renderValueChips() {
+  const scroll = $("#values-scroll");
+  scroll.innerHTML = "";
+  const excIdxs = new Set((encoded?.exceptions || []).map((e) => e.idx));
+  currentValues.forEach((v, i) => {
+    const isExc = excIdxs.has(i);
+    const chip = el(
+      "div",
+      { class: `alp-val-chip${isExc ? " exception" : ""}` },
+      el("span", { class: "idx" }, `#${i}`),
+      el("span", { class: "val" }, formatNum(v))
+    );
+    scroll.appendChild(chip);
+  });
+}
+
+/* ─── Stage Change Handler ────────────────────────────────────────── */
+
+function onStageChange(stage) {
+  // Update pipeline bar
+  $$(".xp-pipe-stage").forEach((el, i) => {
+    el.classList.remove("active", "done");
+    if (i === stage) el.classList.add("active");
+    else if (i < stage) el.classList.add("done");
+  });
+
+  // Hide all panels
+  $$(".alp-panel").forEach((p) => {
+    p.hidden = true;
+  });
+
+  if (stage === -1) {
+    $("#summary-section").hidden = true;
+    return;
+  }
+
+  // Show relevant panel
+  const panels = ["panel-scan", "panel-quantize", "panel-for", "panel-bitpack", "panel-exceptions"];
+
+  if (stage <= 4) {
+    const p = $(`#${panels[stage]}`);
+    p.hidden = false;
+    // Re-render the content with fresh animation
+    p.style.animation = "none";
+    // eslint-disable-next-line no-unused-expressions
+    p.offsetHeight; // trigger reflow
+    p.style.animation = "";
+  }
+
+  switch (stage) {
+    case 0:
+      renderExponentScan();
+      break;
+    case 1:
+      renderQuantize();
+      break;
+    case 2:
+      renderFrameOfRef();
+      break;
+    case 3:
+      renderBitWidthPack();
+      break;
+    case 4:
+      renderFinalSummary();
+      break;
+  }
+}
+
+/* ─── Stage 0: Exponent Scan ──────────────────────────────────────── */
+
+function renderExponentScan() {
+  const panel = $("#panel-scan");
+  const scan = encoded.exponentScan;
+  const winExp = encoded.exp;
+
+  let html = `
+    <div class="xp-card xp-card-raised">
+      <h3>Exponent Scan</h3>
+      <p>Try each exponent <code class="xp-code">e = 0…${scan.length - 1}</code>:
+        multiply by 10<sup>e</sup>, round, and check if the value round-trips exactly.
+        ${winExp >= 0 ? `Smallest working exponent: <strong class="alp-check">e = ${winExp}</strong>` : '<strong class="alp-cross">No exponent works — all values become exceptions</strong>'}
+      </p>
+      <div style="overflow-x:auto">
+      <table class="alp-exp-table">
+        <thead><tr>
+          <th>e</th><th>10<sup>e</sup></th>
+          ${scan[0].samples.map((_, j) => `<th>val[${j}] × 10<sup>e</sup></th>`).join("")}
+          <th>Round-trips?</th>
+        </tr></thead>
+        <tbody>`;
+
+  for (const row of scan) {
+    const cls = row.isWinner ? ' class="winner"' : "";
+    html += `<tr${cls}>
+      <td>${row.exp}</td>
+      <td>${fmt(POW10[row.exp])}</td>`;
+    for (const s of row.samples) {
+      const icon = s.trips
+        ? '<span class="alp-check">✓</span>'
+        : '<span class="alp-cross">✗</span>';
+      html += `<td>${fmt(s.scaled)} ${icon}</td>`;
+    }
+    html += `<td>${
+      row.allTrip ? '<span class="alp-check">✓ All</span>' : '<span class="alp-cross">✗</span>'
+    }</td></tr>`;
+  }
+
+  html += `</tbody></table></div></div>`;
+  panel.innerHTML = html;
+}
+
+/* ─── Stage 1: Quantize ───────────────────────────────────────────── */
+
+function renderQuantize() {
+  const panel = $("#panel-quantize");
+  const excIdxs = new Set(encoded.exceptions.map((e) => e.idx));
+
+  let gridHTML = `
+    <div class="alp-quant-grid">
+      <div class="hdr">Original (f64)</div>
+      <div class="hdr"></div>
+      <div class="hdr">× 10<sup>${encoded.exp}</sup> → integer</div>`;
+
+  currentValues.forEach((v, i) => {
+    const isExc = excIdxs.has(i);
+    const intVal = encoded.integers[i];
+    gridHTML += `
+      <div class="from${isExc ? " exception" : ""}">${formatNum(v)}</div>
+      <div class="arrow">→</div>
+      <div class="to${isExc ? " exception" : ""}">${isExc ? "⚠ exception" : fmt(intVal)}</div>`;
+  });
+
+  gridHTML += "</div>";
+
+  panel.innerHTML = `
+    <div class="xp-card xp-card-raised">
+      <h3>Integer Quantization</h3>
+      <p>Multiply every value by <code class="xp-code">10<sup>${encoded.exp}</sup> = ${fmt(POW10[encoded.exp])}</code> and round to get exact integers.
+        ${encoded.exceptions.length > 0 ? `<span class="alp-cross">${encoded.exceptions.length} value(s) don't round-trip — stored as exceptions.</span>` : ""}
+      </p>
+      ${gridHTML}
+    </div>`;
+}
+
+/* ─── Stage 2: Frame-of-Reference ─────────────────────────────────── */
+
+function renderFrameOfRef() {
+  const panel = $("#panel-for");
+  const excIdxs = new Set(encoded.exceptions.map((e) => e.idx));
+  const validInts = encoded.integers.filter((_, i) => !excIdxs.has(i));
+  const maxInt = validInts.length > 0 ? Math.max(...validInts) : 0;
+  const maxOffset = encoded.offsets.length > 0 ? Math.max(...encoded.offsets) : 0;
+  const intRange = maxInt - encoded.minInt;
+
+  const origPct = 100;
+  const offsetPct = intRange > 0 ? Math.max(8, (maxOffset / maxInt) * 100) : 8;
+
+  let offsetChips = "";
+  currentValues.forEach((_, i) => {
+    if (excIdxs.has(i)) return;
+    offsetChips += `
+      <div class="alp-offset-chip">
+        <span class="lbl">#${i}</span>
+        <span>${fmt(encoded.offsets[i])}</span>
+      </div>`;
+  });
+
+  panel.innerHTML = `
+    <div class="xp-card xp-card-raised">
+      <h3>Frame-of-Reference</h3>
+      <p>Subtract the minimum integer <code class="xp-code">${fmt(encoded.minInt)}</code>
+         so all offsets start at 0. Range shrinks from
+         <strong>${fmt(encoded.minInt)}–${fmt(maxInt)}</strong> to
+         <strong>0–${fmt(maxOffset)}</strong>.
+      </p>
+      <div class="alp-for-visual">
+        <div>
+          <div class="alp-range-label">Original integer range</div>
+          <div class="alp-range-bar">
+            <div class="alp-range-fill" style="width:${origPct}%; background: rgba(96,165,250,0.25); color: var(--xp-accent-light);">
+              ${fmt(encoded.minInt)} … ${fmt(maxInt)}
+            </div>
+          </div>
+        </div>
+        <div>
+          <div class="alp-range-label">After subtracting min</div>
+          <div class="alp-range-bar">
+            <div class="alp-range-fill" style="width:${offsetPct}%; background: rgba(52,211,153,0.25); color: var(--xp-success);">
+              0 … ${fmt(maxOffset)}
+            </div>
+          </div>
+        </div>
+      </div>
+      <h3 style="font-size:14px; margin-top:16px;">Offsets</h3>
+      <div class="alp-for-offsets">${offsetChips}</div>
+    </div>`;
+}
+
+/* ─── Stage 3–4: Bit-Width + Packing ──────────────────────────────── */
+
+function renderBitWidthPack() {
+  const panel = $("#panel-bitpack");
+  const excIdxs = new Set(encoded.exceptions.map((e) => e.idx));
+  const bw = encoded.bitWidth;
+  const validCount = currentValues.length - encoded.exceptions.length;
+
+  // Build packed bits display
+  let bitsHTML = "";
+  let valIdx = 0;
+  currentValues.forEach((_, i) => {
+    if (excIdxs.has(i)) return;
+    const offset = encoded.offsets[i];
+    const bits = offset.toString(2).padStart(bw, "0");
+    const parity = valIdx % 2 === 0 ? "v-even" : "v-odd";
+    for (let b = 0; b < bw; b++) {
+      bitsHTML += `<div class="alp-packed-bit ${parity}" data-b="${bits[b]}" title="val[${i}] bit ${b}">${bits[b]}</div>`;
+    }
+    valIdx++;
+  });
+
+  const rawBits = currentValues.length * 64;
+  const packedBits = validCount * bw;
+  const ratio = packedBits > 0 ? (rawBits / packedBits).toFixed(1) : "∞";
+
+  panel.innerHTML = `
+    <div class="xp-card xp-card-raised">
+      <h3>Bit-Width & Packing</h3>
+      <p>Maximum offset is <code class="xp-code">${fmt(Math.max(...encoded.offsets))}</code>,
+         which needs <code class="xp-code">${bw} bits</code> to represent.
+         Each value is packed at exactly ${bw} bits — no wasted space.
+      </p>
+      <div class="xp-stats-row" style="margin-bottom:16px">
+        <div class="xp-stat">
+          <span class="xp-stat-label">Bit width</span>
+          <span class="xp-stat-value">${bw}<span class="xp-stat-unit"> bits</span></span>
+        </div>
+        <div class="xp-stat">
+          <span class="xp-stat-label">Raw bits</span>
+          <span class="xp-stat-value">${fmt(rawBits)}<span class="xp-stat-unit"> bits</span></span>
+        </div>
+        <div class="xp-stat">
+          <span class="xp-stat-label">Packed bits</span>
+          <span class="xp-stat-value tier-0">${fmt(packedBits)}<span class="xp-stat-unit"> bits</span></span>
+        </div>
+        <div class="xp-stat">
+          <span class="xp-stat-label">Ratio (values only)</span>
+          <span class="xp-stat-value alp-ratio-highlight">${ratio}×</span>
+        </div>
+      </div>
+      ${
+        bw > 0
+          ? `
+      <h3 style="font-size:14px;">Packed Bit Stream</h3>
+      <p>Each color alternates per value. ${bw} bits per value, read left-to-right.</p>
+      <div class="alp-bitpack-wrap">
+        <div class="alp-bitpack-grid">${bitsHTML}</div>
+      </div>
+      <div class="alp-bitpack-legend">
+        <span><span class="swatch" style="background:rgba(96,165,250,0.3)"></span>Even values</span>
+        <span><span class="swatch" style="background:rgba(52,211,153,0.3)"></span>Odd values</span>
+      </div>`
+          : '<p class="tier-0" style="font-weight:600">All values are identical — 0 bits needed!</p>'
+      }
+    </div>`;
+
+  // Also show exceptions if any
+  renderExceptionsInline();
+}
+
+function renderExceptionsInline() {
+  const panel = $("#panel-exceptions");
+  if (encoded.exceptions.length === 0) {
+    panel.hidden = true;
+    return;
+  }
+
+  panel.hidden = false;
+  let items = "";
+  for (const exc of encoded.exceptions) {
+    items += `
+      <div class="alp-exc-item">
+        <span class="pos">pos ${exc.idx}</span>
+        <span class="raw">${formatNum(exc.value)}</span>
+        <span class="cost">8 bytes (raw f64)</span>
+      </div>`;
+  }
+
+  panel.innerHTML = `
+    <div class="xp-card xp-card-raised" style="border-color: rgba(251,191,36,0.25);">
+      <h3>⚠ Exceptions</h3>
+      <p>${encoded.exceptions.length} value(s) didn't round-trip with exponent
+         <code class="xp-code">e = ${encoded.exp}</code>.
+         Each is stored as a raw 64-bit float (8 bytes) plus a 2-byte position index.</p>
+      <div class="alp-exc-list">${items}</div>
+    </div>`;
+}
+
+/* ─── Final Summary (after stage 4) ───────────────────────────────── */
+
+function renderFinalSummary() {
+  const summary = $("#summary-section");
+  summary.hidden = false;
+  summary.style.animation = "none";
+  // eslint-disable-next-line no-unused-expressions
+  summary.offsetHeight;
+  summary.style.animation = "";
+  summary.classList.add("xp-animate-in");
+
+  const wire = wireSize(encoded);
+  const rawSize = currentValues.length * 8;
+  const ratio = (rawSize / wire.total).toFixed(2);
+  const bpv = ((wire.total * 8) / currentValues.length).toFixed(1);
+
+  // Stats row
+  const statsRow = $("#summary-stats");
+  statsRow.innerHTML = "";
+  const stats = [
+    { label: "Raw size", value: fmtBytes(rawSize), unit: `${currentValues.length} × 8B` },
+    { label: "Compressed", value: fmtBytes(wire.total), unit: "" },
+    { label: "Ratio", value: `${ratio}×`, unit: "", cls: "alp-ratio-highlight" },
+    { label: "Bits / value", value: bpv, unit: "bits" },
+    { label: "Exponent", value: `e=${encoded.exp}`, unit: "" },
+    { label: "Bit width", value: `${encoded.bitWidth}`, unit: "bits" },
+  ];
+
+  for (const s of stats) {
+    statsRow.appendChild(
+      el(
+        "div",
+        { class: "xp-stat" },
+        el("span", { class: "xp-stat-label" }, s.label),
+        el(
+          "span",
+          { class: `xp-stat-value ${s.cls || ""}` },
+          s.value,
+          s.unit ? ` ` : "",
+          s.unit ? el("span", { class: "xp-stat-unit" }, s.unit) : ""
+        )
+      )
+    );
+  }
+
+  // Wire format bar
+  const wireCard = $("#wire-format-card");
+  const segments = [
+    { cls: "seg-header", bytes: wire.headerBytes, label: `Header ${wire.headerBytes}B` },
+    { cls: "seg-packed", bytes: wire.packedBytes, label: `Packed ${wire.packedBytes}B` },
+  ];
+  if (wire.excPosBytes > 0) {
+    segments.push({
+      cls: "seg-exc-pos",
+      bytes: wire.excPosBytes,
+      label: `Exc pos ${wire.excPosBytes}B`,
+    });
+    segments.push({
+      cls: "seg-exc-val",
+      bytes: wire.excValBytes,
+      label: `Exc val ${wire.excValBytes}B`,
+    });
+  }
+
+  let barHTML = '<h3 style="font-size:14px; margin-bottom:12px;">Wire Format</h3>';
+  barHTML += '<div class="alp-wire-bar">';
+  for (const seg of segments) {
+    barHTML += `<div class="alp-wire-seg ${seg.cls}" style="flex:${seg.bytes}">${seg.label}</div>`;
+  }
+  barHTML += "</div>";
+
+  barHTML += '<div class="alp-wire-legend">';
+  barHTML += `<span><span class="dot" style="background:var(--region-header)"></span>Header (14B: count, exp, bit_width, min_int, exc_count)</span>`;
+  barHTML += `<span><span class="dot" style="background:var(--region-values)"></span>Bit-packed offsets (${wire.packedBytes}B)</span>`;
+  if (wire.excPosBytes > 0) {
+    barHTML += `<span><span class="dot" style="background:var(--region-exceptions)"></span>Exception positions (${wire.excPosBytes}B)</span>`;
+    barHTML += `<span><span class="dot" style="background:var(--xp-warn)"></span>Exception values (${wire.excValBytes}B)</span>`;
+  }
+  barHTML += "</div>";
+
+  // Compression meter
+  const meterPct = Math.min(100, (wire.total / rawSize) * 100);
+  barHTML += `
+    <div style="margin-top:20px">
+      <div style="display:flex; justify-content:space-between; font-size:12px; color:var(--xp-text-muted); margin-bottom:4px;">
+        <span>Compressed: ${fmtBytes(wire.total)}</span>
+        <span>Raw: ${fmtBytes(rawSize)}</span>
+      </div>
+      <div class="xp-meter">
+        <div class="xp-meter-fill" style="width:${meterPct}%"></div>
+      </div>
+    </div>`;
+
+  wireCard.innerHTML = barHTML;
+
+  // Animate the stat values
+  $$(".xp-stat-value", summary).forEach((el) => {
+    el.style.animation = "none";
+    // eslint-disable-next-line no-unused-expressions
+    el.offsetHeight;
+    el.style.animation = "xp-fade-in 400ms ease both";
+  });
+}
+
+/* ─── Helpers ─────────────────────────────────────────────────────── */
+
+function formatNum(n) {
+  if (Number.isInteger(n)) return fmt(n);
+  // Show enough decimal places to be faithful
+  const s = String(n);
+  const decimals = s.includes(".") ? s.split(".")[1].length : 0;
+  return n.toLocaleString("en-US", {
+    minimumFractionDigits: Math.min(decimals, 6),
+    maximumFractionDigits: 6,
+  });
+}
+
+/* ─── Boot ────────────────────────────────────────────────────────── */
+
+init();

--- a/site/tsdb-engine/learn/alp/index.html
+++ b/site/tsdb-engine/learn/alp/index.html
@@ -73,8 +73,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/alp/index.html
+++ b/site/tsdb-engine/learn/alp/index.html
@@ -38,7 +38,7 @@
           <button class="xp-btn xp-btn-primary" id="apply-custom">Apply</button>
         </div>
         <div class="xp-card alp-values-card" id="values-card">
-          <div class="alp-values-scroll" id="values-scroll"></div>
+          <div class="alp-values-scroll xp-scroll-x" id="values-scroll"></div>
         </div>
       </section>
 

--- a/site/tsdb-engine/learn/alp/index.html
+++ b/site/tsdb-engine/learn/alp/index.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ALP Compression — Interactive Experience | o11ytsdb</title>
+    <meta name="description" content="Watch floating-point numbers get quantized, bit-packed, and compressed to a fraction of their size — interactively, step by step." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500&display=swap" />
+    <link rel="stylesheet" href="../shared.css" />
+    <link rel="stylesheet" href="alp-experience.css" />
+  </head>
+  <body>
+    <a href="#main" class="xp-skip-link">Skip to content</a>
+    <div class="xp-ambient" aria-hidden="true"></div>
+    <div class="xp-page" id="main">
+
+      <div id="breadcrumb-nav"></div>
+
+      <div class="xp-hero">
+        <p class="xp-eyebrow">Compression</p>
+        <h1>ALP Compression</h1>
+        <p class="lede">
+          Adaptive Lossless floating-Point compression turns decimal floats into
+          tightly bit-packed integers — often <strong>4–8×</strong> smaller than raw f64.
+          Step through the pipeline and watch every transformation.
+        </p>
+      </div>
+
+      <!-- A. Data Pattern Picker -->
+      <section class="xp-section" id="data-section">
+        <h2>① Choose Your Data</h2>
+        <div class="xp-controls" id="pattern-buttons"></div>
+        <div id="custom-input-wrap" class="custom-input-wrap" hidden>
+          <textarea id="custom-textarea" class="alp-textarea" rows="3"
+            placeholder="Enter comma-separated floats, e.g. 3.14, 2.71, 1.41, 98.6, 0.577"></textarea>
+          <button class="xp-btn xp-btn-primary" id="apply-custom">Apply</button>
+        </div>
+        <div class="xp-card alp-values-card" id="values-card">
+          <div class="alp-values-scroll" id="values-scroll"></div>
+        </div>
+      </section>
+
+      <!-- B. Pipeline Visualization -->
+      <section class="xp-section" id="pipeline-section">
+        <h2>② Compression Pipeline</h2>
+        <p>Click any stage or use the controls to step through.</p>
+        <div class="xp-pipeline" id="pipeline-bar"></div>
+        <div class="xp-controls">
+          <button class="xp-btn" id="btn-prev">← Prev</button>
+          <button class="xp-btn" id="btn-next">Next →</button>
+          <button class="xp-btn" id="btn-play">▶ Play All</button>
+          <button class="xp-btn" id="btn-reset">Reset</button>
+        </div>
+      </section>
+
+      <!-- C–G. Stage Detail Panels -->
+      <div id="stage-panels">
+        <div class="alp-panel" id="panel-scan" hidden></div>
+        <div class="alp-panel" id="panel-quantize" hidden></div>
+        <div class="alp-panel" id="panel-for" hidden></div>
+        <div class="alp-panel" id="panel-bitpack" hidden></div>
+        <div class="alp-panel" id="panel-exceptions" hidden></div>
+      </div>
+
+      <!-- H. Compression Summary -->
+      <section class="xp-section" id="summary-section" hidden>
+        <h2>③ Compression Summary</h2>
+        <div class="xp-stats-row" id="summary-stats"></div>
+        <div class="xp-card" id="wire-format-card"></div>
+      </section>
+
+      <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
+        <p style="font-size: 13px; color: var(--xp-text-dim);">
+          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+        </p>
+      </footer>
+
+    </div>
+    <script type="module" src="alp-experience.js"></script>
+  </body>
+</html>

--- a/site/tsdb-engine/learn/chunk-stats/index.html
+++ b/site/tsdb-engine/learn/chunk-stats/index.html
@@ -41,7 +41,7 @@
       <section class="xp-section" id="timeline-section">
         <h2>② Chunk Timeline</h2>
         <p>Click any chunk to inspect its pre-computed stats.</p>
-        <div class="cs-timeline-strip" id="timeline-strip"></div>
+        <div class="cs-timeline-strip xp-scroll-x" id="timeline-strip"></div>
         <div class="xp-card cs-detail-panel" id="chunk-detail" hidden>
           <div class="cs-detail-header" id="detail-header"></div>
           <div class="xp-stats-row" id="detail-stats"></div>

--- a/site/tsdb-engine/learn/chunk-stats/index.html
+++ b/site/tsdb-engine/learn/chunk-stats/index.html
@@ -130,8 +130,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/chunk-stats/index.html
+++ b/site/tsdb-engine/learn/chunk-stats/index.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chunk Stats — Interactive Experience | o11ytsdb</title>
+    <meta name="description" content="See how pre-computed chunk statistics let the TSDB engine answer aggregation queries without decompressing data — up to 100× faster." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500&display=swap" />
+    <link rel="stylesheet" href="../shared.css" />
+    <link rel="stylesheet" href="stats-experience.css" />
+  </head>
+  <body>
+    <a href="#main" class="xp-skip-link">Skip to content</a>
+    <div class="xp-ambient" aria-hidden="true"></div>
+    <div class="xp-page" id="main">
+
+      <div id="breadcrumb-nav"></div>
+
+      <div class="xp-hero">
+        <p class="xp-eyebrow">Query Optimization</p>
+        <h1>Chunk Stats</h1>
+        <p class="lede">
+          When a chunk is frozen, the TSDB pre-computes <strong>min, max, sum, count</strong>.
+          During query execution, aligned buckets can be answered from stats alone —
+          no decompression needed. This can be <strong>100× faster</strong>.
+        </p>
+      </div>
+
+      <!-- A. Full Dataset Sparkline -->
+      <section class="xp-section" id="data-section">
+        <h2>① Dataset &amp; Chunks</h2>
+        <p>12 chunks of temperature data, 64 samples each. Chunk boundaries are marked with dashed lines.</p>
+        <div class="xp-card cs-sparkline-card">
+          <canvas id="sparkline-canvas" height="140"></canvas>
+        </div>
+      </section>
+
+      <!-- B. Chunk Timeline -->
+      <section class="xp-section" id="timeline-section">
+        <h2>② Chunk Timeline</h2>
+        <p>Click any chunk to inspect its pre-computed stats.</p>
+        <div class="cs-timeline-strip" id="timeline-strip"></div>
+        <div class="xp-card cs-detail-panel" id="chunk-detail" hidden>
+          <div class="cs-detail-header" id="detail-header"></div>
+          <div class="xp-stats-row" id="detail-stats"></div>
+          <canvas id="detail-sparkline" height="80"></canvas>
+        </div>
+      </section>
+
+      <!-- C. Query Builder -->
+      <section class="xp-section" id="query-section">
+        <h2>③ Query Builder</h2>
+        <p>Configure an aggregation query and watch the engine decide which chunks to decode.</p>
+        <div class="xp-card">
+          <div class="xp-controls cs-query-controls">
+            <div class="cs-control-group">
+              <label class="xp-label" for="agg-select">Aggregation</label>
+              <select class="xp-select" id="agg-select">
+                <option value="max">max</option>
+                <option value="min">min</option>
+                <option value="sum">sum</option>
+                <option value="avg">avg</option>
+              </select>
+            </div>
+            <div class="cs-control-group">
+              <label class="xp-label" for="step-select">Step Size</label>
+              <select class="xp-select" id="step-select">
+                <option value="1">1 chunk</option>
+                <option value="2">2 chunks</option>
+                <option value="4">4 chunks</option>
+              </select>
+            </div>
+            <div class="cs-control-group">
+              <label class="xp-label" for="range-slider">Range</label>
+              <div class="xp-slider-row">
+                <input type="range" class="xp-slider" id="range-slider" min="2" max="12" value="12" />
+                <span class="xp-slider-value" id="range-value">12 chunks</span>
+              </div>
+            </div>
+            <button type="button" class="xp-btn xp-btn-primary" id="btn-run">▶ Run Query</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- D. Query Execution Animation -->
+      <section class="xp-section" id="execution-section" hidden>
+        <h2>④ Query Execution</h2>
+        <p id="exec-description"></p>
+        <div class="cs-exec-grid" id="exec-grid"></div>
+        <div class="cs-exec-progress" id="exec-progress"></div>
+      </section>
+
+      <!-- E. Results Dashboard -->
+      <section class="xp-section" id="results-section" hidden>
+        <h2>⑤ Results</h2>
+        <div class="xp-stats-row" id="result-summary-stats"></div>
+        <div class="xp-card cs-speedup-card" id="speedup-card"></div>
+        <div class="cs-bucket-results" id="bucket-results"></div>
+      </section>
+
+      <!-- F. Skip Logic Explanation -->
+      <section class="xp-section" id="explain-section">
+        <h2>⑥ Skip Logic</h2>
+        <p>How the engine decides whether to decode or skip each chunk:</p>
+        <div class="cs-explain-grid" id="explain-grid">
+          <div class="xp-card cs-explain-card" data-agg="max">
+            <div class="cs-explain-icon">📈</div>
+            <h3>max</h3>
+            <p>If <code class="xp-code">chunk.max ≤ running_max</code> → <strong>skip</strong>. The chunk can't improve the answer.</p>
+          </div>
+          <div class="xp-card cs-explain-card" data-agg="min">
+            <div class="cs-explain-icon">📉</div>
+            <h3>min</h3>
+            <p>If <code class="xp-code">chunk.min ≥ running_min</code> → <strong>skip</strong>. The chunk can't lower the answer.</p>
+          </div>
+          <div class="xp-card cs-explain-card" data-agg="sum">
+            <div class="cs-explain-icon">➕</div>
+            <h3>sum</h3>
+            <p>If bucket aligns with chunk → use <code class="xp-code">chunk.sum</code> directly. No decode needed.</p>
+          </div>
+          <div class="xp-card cs-explain-card" data-agg="avg">
+            <div class="cs-explain-icon">📊</div>
+            <h3>avg</h3>
+            <p>If aligned → compute <code class="xp-code">chunk.sum / chunk.count</code>. Both are pre-computed.</p>
+          </div>
+        </div>
+      </section>
+
+      <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
+        <p style="font-size: 13px; color: var(--xp-text-dim);">
+          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+        </p>
+      </footer>
+
+    </div>
+    <script type="module" src="stats-experience.js"></script>
+  </body>
+</html>

--- a/site/tsdb-engine/learn/chunk-stats/stats-experience.css
+++ b/site/tsdb-engine/learn/chunk-stats/stats-experience.css
@@ -18,17 +18,6 @@
   overflow-x: auto;
   padding-bottom: 10px;
   margin-bottom: 16px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--xp-border-strong) transparent;
-}
-
-.cs-timeline-strip::-webkit-scrollbar {
-  height: 6px;
-}
-
-.cs-timeline-strip::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 3px;
 }
 
 .cs-chunk-block {

--- a/site/tsdb-engine/learn/chunk-stats/stats-experience.css
+++ b/site/tsdb-engine/learn/chunk-stats/stats-experience.css
@@ -1,0 +1,425 @@
+/* ─── Chunk Stats Experience ──────────────────────────────────────── */
+
+/* ─── Sparkline Card ──────────────────────────────────────────────── */
+.cs-sparkline-card {
+  padding: 16px;
+}
+
+.cs-sparkline-card canvas {
+  width: 100%;
+  display: block;
+  border-radius: var(--xp-radius-sm);
+}
+
+/* ─── Chunk Timeline Strip ────────────────────────────────────────── */
+.cs-timeline-strip {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding-bottom: 10px;
+  margin-bottom: 16px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--xp-border-strong) transparent;
+}
+
+.cs-timeline-strip::-webkit-scrollbar {
+  height: 6px;
+}
+
+.cs-timeline-strip::-webkit-scrollbar-thumb {
+  background: var(--xp-border-strong);
+  border-radius: 3px;
+}
+
+.cs-chunk-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 12px;
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  cursor: pointer;
+  flex-shrink: 0;
+  min-width: 72px;
+  transition: all 200ms;
+  position: relative;
+}
+
+.cs-chunk-block:hover {
+  border-color: var(--xp-accent);
+  background: var(--xp-accent-glow);
+}
+
+.cs-chunk-block.selected {
+  border-color: var(--xp-accent);
+  background: var(--xp-accent-glow);
+  box-shadow: 0 0 16px rgba(96, 165, 250, 0.15);
+}
+
+.cs-chunk-block .chunk-num {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--xp-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.cs-chunk-block .chunk-time {
+  font-size: 9px;
+  color: var(--xp-text-dim);
+  font-family: var(--xp-mono);
+  white-space: nowrap;
+}
+
+.cs-chunk-block .chunk-range-bar {
+  width: 6px;
+  border-radius: 3px;
+  background: linear-gradient(to top, var(--xp-accent), var(--xp-success));
+  min-height: 20px;
+  max-height: 48px;
+  transition: all 200ms;
+}
+
+.cs-chunk-block .chunk-count {
+  font-size: 10px;
+  font-family: var(--xp-mono);
+  color: var(--xp-text-muted);
+  background: var(--xp-surface-raised);
+  padding: 1px 6px;
+  border-radius: 99px;
+}
+
+/* ─── Detail Panel ────────────────────────────────────────────────── */
+.cs-detail-panel {
+  animation: xp-fade-in 300ms ease both;
+}
+
+.cs-detail-panel[hidden] {
+  display: none;
+}
+
+.cs-detail-header {
+  margin-bottom: 12px;
+}
+
+.cs-detail-header h3 {
+  margin: 0 0 2px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.cs-detail-header .time-range {
+  font-size: 12px;
+  color: var(--xp-text-dim);
+  font-family: var(--xp-mono);
+}
+
+.cs-detail-panel canvas {
+  width: 100%;
+  display: block;
+  border-radius: var(--xp-radius-sm);
+  margin-top: 12px;
+}
+
+/* ─── Query Controls ──────────────────────────────────────────────── */
+.cs-query-controls {
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.cs-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* ─── Execution Grid ──────────────────────────────────────────────── */
+.cs-exec-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.cs-bucket-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  transition: all 300ms;
+  opacity: 0.3;
+}
+
+.cs-bucket-row.active {
+  opacity: 1;
+  border-color: var(--xp-accent);
+  background: var(--xp-accent-glow);
+}
+
+.cs-bucket-row.done {
+  opacity: 1;
+}
+
+.cs-bucket-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--xp-text-muted);
+  min-width: 70px;
+  flex-shrink: 0;
+}
+
+.cs-bucket-chunks {
+  display: flex;
+  gap: 6px;
+  flex: 1;
+  flex-wrap: wrap;
+}
+
+.cs-exec-chip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: var(--xp-radius-xs);
+  font-family: var(--xp-mono);
+  font-size: 12px;
+  font-weight: 500;
+  border: 1px solid var(--xp-border);
+  background: var(--xp-surface-raised);
+  color: var(--xp-text-dim);
+  transition: all 300ms;
+}
+
+.cs-exec-chip.stats-only {
+  background: var(--xp-success-glow);
+  border-color: rgba(52, 211, 153, 0.4);
+  color: var(--xp-success);
+}
+
+.cs-exec-chip.must-decode {
+  background: var(--xp-error-glow);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: var(--xp-error);
+}
+
+.cs-exec-chip.skipped {
+  background: var(--xp-surface);
+  border-color: var(--xp-border);
+  color: var(--xp-text-dim);
+  opacity: 0.5;
+}
+
+.cs-exec-chip .chip-icon {
+  font-size: 12px;
+}
+
+.cs-bucket-result {
+  font-family: var(--xp-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+  min-width: 60px;
+  text-align: right;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 300ms;
+}
+
+.cs-bucket-result.visible {
+  opacity: 1;
+}
+
+/* ─── Execution Progress ──────────────────────────────────────────── */
+.cs-exec-progress {
+  font-size: 13px;
+  color: var(--xp-text-muted);
+  min-height: 20px;
+}
+
+/* ─── Speedup Card ────────────────────────────────────────────────── */
+.cs-speedup-card {
+  text-align: center;
+  padding: 24px;
+  margin-bottom: 20px;
+}
+
+.cs-speedup-value {
+  font-family: var(--xp-mono);
+  font-size: 36px;
+  font-weight: 700;
+  color: var(--xp-success);
+  line-height: 1;
+  margin-bottom: 6px;
+}
+
+.cs-speedup-label {
+  font-size: 14px;
+  color: var(--xp-text-muted);
+}
+
+.cs-speedup-detail {
+  font-size: 13px;
+  color: var(--xp-text-dim);
+  margin-top: 8px;
+}
+
+/* ─── Bucket Results Table ────────────────────────────────────────── */
+.cs-bucket-results {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 8px;
+}
+
+.cs-result-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  animation: xp-fade-in 300ms ease both;
+}
+
+.cs-result-cell .cell-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--xp-text-dim);
+}
+
+.cs-result-cell .cell-value {
+  font-family: var(--xp-mono);
+  font-size: 16px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.cs-result-cell .cell-method {
+  font-size: 10px;
+  font-weight: 500;
+  margin-top: 2px;
+}
+
+.cs-result-cell .cell-method.stats-only {
+  color: var(--xp-success);
+}
+
+.cs-result-cell .cell-method.decoded {
+  color: var(--xp-error);
+}
+
+/* ─── Explain Grid ────────────────────────────────────────────────── */
+.cs-explain-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.cs-explain-card {
+  text-align: center;
+  padding: 20px 16px;
+  transition: all 200ms;
+}
+
+.cs-explain-card.highlight {
+  border-color: var(--xp-accent);
+  background: var(--xp-accent-glow);
+  box-shadow: 0 0 24px rgba(96, 165, 250, 0.1);
+}
+
+.cs-explain-icon {
+  font-size: 28px;
+  margin-bottom: 8px;
+}
+
+.cs-explain-card h3 {
+  font-family: var(--xp-mono);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--xp-accent);
+  margin: 0 0 6px;
+}
+
+.cs-explain-card p {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--xp-text-muted);
+  margin: 0;
+  max-width: none;
+}
+
+/* ─── Flash Animations ────────────────────────────────────────────── */
+@keyframes cs-flash-green {
+  0% {
+    box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 20px 4px rgba(52, 211, 153, 0.3);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(52, 211, 153, 0);
+  }
+}
+
+@keyframes cs-flash-red {
+  0% {
+    box-shadow: 0 0 0 0 rgba(248, 113, 113, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 20px 4px rgba(248, 113, 113, 0.3);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(248, 113, 113, 0);
+  }
+}
+
+.cs-exec-chip.flash-green {
+  animation: cs-flash-green 500ms ease;
+}
+
+.cs-exec-chip.flash-red {
+  animation: cs-flash-red 500ms ease;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .cs-query-controls {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .cs-bucket-row {
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px 10px;
+  }
+
+  .cs-bucket-label {
+    min-width: unset;
+    flex-basis: 100%;
+  }
+
+  .cs-bucket-result {
+    flex-basis: 100%;
+    text-align: left;
+  }
+
+  .cs-explain-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .cs-bucket-results {
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  }
+
+  .cs-speedup-value {
+    font-size: 28px;
+  }
+}

--- a/site/tsdb-engine/learn/chunk-stats/stats-experience.js
+++ b/site/tsdb-engine/learn/chunk-stats/stats-experience.js
@@ -14,6 +14,7 @@ import {
   el,
   fmt,
   generateSamples,
+  revealSection,
 } from "../shared.js";
 
 /* ─── Constants ───────────────────────────────────────────────────── */
@@ -243,7 +244,7 @@ function runQuery() {
 function showExecution(buckets, agg, _startChunk) {
   const execSection = $("#execution-section");
   execSection.hidden = false;
-  execSection.scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection(execSection);
 
   const resultsSection = $("#results-section");
   resultsSection.hidden = true;
@@ -503,7 +504,7 @@ function showResults(bucketResults, agg, decoded, statsOnly, skipped) {
     resultsGrid.appendChild(cell);
   });
 
-  section.scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection(section);
 }
 
 /* ─── Init ────────────────────────────────────────────────────────── */

--- a/site/tsdb-engine/learn/chunk-stats/stats-experience.js
+++ b/site/tsdb-engine/learn/chunk-stats/stats-experience.js
@@ -1,0 +1,544 @@
+/**
+ * Chunk Stats — Interactive Experience
+ *
+ * Demonstrates how pre-computed chunk statistics (min, max, sum, count)
+ * let the TSDB engine answer aggregation queries without decompressing data.
+ */
+
+import {
+  $,
+  $$,
+  animateValue,
+  buildBreadcrumb,
+  drawSparkline,
+  el,
+  fmt,
+  generateSamples,
+} from "../shared.js";
+
+/* ─── Constants ───────────────────────────────────────────────────── */
+
+const NUM_CHUNKS = 12;
+const SAMPLES_PER_CHUNK = 64;
+const TOTAL_SAMPLES = NUM_CHUNKS * SAMPLES_PER_CHUNK;
+
+/* ─── Data Generation ─────────────────────────────────────────────── */
+
+function generateChunkedData() {
+  const { values } = generateSamples("temperature", TOTAL_SAMPLES, {
+    base: 22,
+    noise: 0.15,
+  });
+
+  const chunks = [];
+  const baseTime = Date.now() - NUM_CHUNKS * 3600_000;
+
+  for (let c = 0; c < NUM_CHUNKS; c++) {
+    const start = c * SAMPLES_PER_CHUNK;
+    const end = start + SAMPLES_PER_CHUNK;
+    const slice = Array.from(values.slice(start, end));
+
+    const min = Math.min(...slice);
+    const max = Math.max(...slice);
+    const sum = slice.reduce((a, b) => a + b, 0);
+    const count = slice.length;
+    const first = slice[0];
+    const last = slice[count - 1];
+
+    chunks.push({
+      id: c,
+      values: slice,
+      startTime: baseTime + c * 3600_000,
+      endTime: baseTime + (c + 1) * 3600_000,
+      stats: { min, max, sum, count, first, last },
+    });
+  }
+
+  return { allValues: Array.from(values), chunks };
+}
+
+const DATA = generateChunkedData();
+
+/* ─── Helpers ─────────────────────────────────────────────────────── */
+
+function fmtTime(ms) {
+  const d = new Date(ms);
+  return d.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+}
+
+function fmtVal(v) {
+  return v.toFixed(2);
+}
+
+/* ─── A. Full-dataset Sparkline ───────────────────────────────────── */
+
+function drawFullSparkline() {
+  const canvas = $("#sparkline-canvas");
+  const ctx = canvas.getContext("2d");
+  const dpr = window.devicePixelRatio || 1;
+  const w = canvas.clientWidth;
+  const h = canvas.clientHeight;
+  canvas.width = w * dpr;
+  canvas.height = h * dpr;
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, w, h);
+
+  const vals = DATA.allValues;
+  const min = Math.min(...vals);
+  const max = Math.max(...vals);
+  const range = max - min || 1;
+  const pad = 6;
+
+  // draw chunk boundary lines first
+  ctx.setLineDash([4, 4]);
+  ctx.strokeStyle = "rgba(96, 165, 250, 0.18)";
+  ctx.lineWidth = 1;
+  for (let i = 1; i < NUM_CHUNKS; i++) {
+    const x = ((i * SAMPLES_PER_CHUNK) / (vals.length - 1)) * w;
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, h);
+    ctx.stroke();
+  }
+  ctx.setLineDash([]);
+
+  // chunk label background bands (alternating subtle)
+  for (let i = 0; i < NUM_CHUNKS; i++) {
+    if (i % 2 === 0) continue;
+    const x0 = ((i * SAMPLES_PER_CHUNK) / (vals.length - 1)) * w;
+    const x1 = (((i + 1) * SAMPLES_PER_CHUNK) / (vals.length - 1)) * w;
+    ctx.fillStyle = "rgba(96, 165, 250, 0.03)";
+    ctx.fillRect(x0, 0, x1 - x0, h);
+  }
+
+  // draw the sparkline
+  ctx.beginPath();
+  for (let i = 0; i < vals.length; i++) {
+    const x = (i / (vals.length - 1)) * w;
+    const y = pad + (1 - (vals[i] - min) / range) * (h - 2 * pad);
+    i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+  }
+  ctx.strokeStyle = "#60a5fa";
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+
+  // fill under curve
+  ctx.lineTo(w, h);
+  ctx.lineTo(0, h);
+  ctx.closePath();
+  ctx.fillStyle = "rgba(96, 165, 250, 0.08)";
+  ctx.fill();
+
+  // chunk number labels at top
+  ctx.font = `500 ${(10 * dpr) / dpr}px "Space Grotesk", sans-serif`;
+  ctx.textAlign = "center";
+  ctx.fillStyle = "rgba(96, 165, 250, 0.4)";
+  for (let i = 0; i < NUM_CHUNKS; i++) {
+    const cx = (((i + 0.5) * SAMPLES_PER_CHUNK) / (vals.length - 1)) * w;
+    ctx.fillText(`C${i}`, cx, 14);
+  }
+}
+
+/* ─── B. Chunk Timeline ───────────────────────────────────────────── */
+
+let _selectedChunkId = null;
+
+function buildTimeline() {
+  const strip = $("#timeline-strip");
+  strip.innerHTML = "";
+
+  const globalMin = Math.min(...DATA.chunks.map((c) => c.stats.min));
+  const globalMax = Math.max(...DATA.chunks.map((c) => c.stats.max));
+  const globalRange = globalMax - globalMin || 1;
+
+  DATA.chunks.forEach((chunk) => {
+    const { id, stats } = chunk;
+    const barHeight = 20 + ((stats.max - stats.min) / globalRange) * 28;
+
+    const block = el(
+      "div",
+      { class: "cs-chunk-block", "data-id": String(id) },
+      el("span", { class: "chunk-num" }, `C${id}`),
+      el("span", { class: "chunk-time" }, `${fmtTime(chunk.startTime)}`),
+      el("div", { class: "chunk-range-bar", style: { height: `${barHeight}px` } }),
+      el("span", { class: "chunk-count" }, `n=${stats.count}`)
+    );
+
+    block.addEventListener("click", () => selectChunk(id));
+    strip.appendChild(block);
+  });
+}
+
+function selectChunk(id) {
+  _selectedChunkId = id;
+  const chunk = DATA.chunks[id];
+
+  // update selected highlight
+  $$(".cs-chunk-block").forEach((b) => {
+    b.classList.toggle("selected", Number(b.dataset.id) === id);
+  });
+
+  const detail = $("#chunk-detail");
+  detail.hidden = false;
+
+  // header
+  $("#detail-header").innerHTML = `
+    <h3>Chunk ${id}</h3>
+    <span class="time-range">${fmtTime(chunk.startTime)} – ${fmtTime(chunk.endTime)}</span>
+  `;
+
+  // stats
+  const { stats } = chunk;
+  $("#detail-stats").innerHTML = [
+    { label: "Min", value: fmtVal(stats.min), color: "var(--xp-accent)" },
+    { label: "Max", value: fmtVal(stats.max), color: "var(--xp-error)" },
+    { label: "Sum", value: fmt(stats.sum, 1), color: "var(--xp-success)" },
+    { label: "Count", value: String(stats.count), color: "var(--xp-warn)" },
+    { label: "First", value: fmtVal(stats.first), color: "var(--xp-text)" },
+    { label: "Last", value: fmtVal(stats.last), color: "var(--xp-text)" },
+  ]
+    .map(
+      (s) => `
+    <div class="xp-stat">
+      <span class="xp-stat-label">${s.label}</span>
+      <span class="xp-stat-value" style="color:${s.color}">${s.value}</span>
+    </div>
+  `
+    )
+    .join("");
+
+  // mini sparkline
+  drawSparkline($("#detail-sparkline"), chunk.values, {
+    color: "#60a5fa",
+    fillAlpha: 0.12,
+    lineWidth: 2,
+  });
+}
+
+/* ─── C/D. Query Execution ────────────────────────────────────────── */
+
+function runQuery() {
+  const agg = $("#agg-select").value;
+  const stepSize = Number($("#step-select").value);
+  const rangeChunks = Number($("#range-slider").value);
+
+  const startChunk = NUM_CHUNKS - rangeChunks;
+  const chunks = DATA.chunks.slice(startChunk, NUM_CHUNKS);
+
+  // build buckets
+  const buckets = [];
+  for (let i = 0; i < chunks.length; i += stepSize) {
+    const bucketChunks = chunks.slice(i, i + stepSize);
+    buckets.push({ index: buckets.length, chunks: bucketChunks });
+  }
+
+  // highlight the matching explain card
+  $$(".cs-explain-card").forEach((card) => {
+    card.classList.toggle("highlight", card.dataset.agg === agg);
+  });
+
+  showExecution(buckets, agg, startChunk);
+}
+
+function showExecution(buckets, agg, _startChunk) {
+  const execSection = $("#execution-section");
+  execSection.hidden = false;
+  execSection.scrollIntoView({ behavior: "smooth", block: "start" });
+
+  const resultsSection = $("#results-section");
+  resultsSection.hidden = true;
+
+  $("#exec-description").textContent =
+    `Running ${agg}() over ${buckets.reduce((s, b) => s + b.chunks.length, 0)} chunks in ${buckets.length} buckets…`;
+
+  const grid = $("#exec-grid");
+  grid.innerHTML = "";
+
+  // build the execution grid rows
+  const rows = buckets.map((bucket, bi) => {
+    const row = el(
+      "div",
+      { class: "cs-bucket-row" },
+      el("span", { class: "cs-bucket-label" }, `Bucket ${bi}`)
+    );
+
+    const chipsContainer = el("div", { class: "cs-bucket-chunks" });
+    const chips = bucket.chunks.map((chunk) => {
+      const chip = el(
+        "div",
+        {
+          class: "cs-exec-chip",
+          "data-chunk": String(chunk.id),
+        },
+        el("span", { class: "chip-icon" }, "⏳"),
+        `C${chunk.id}`
+      );
+      chipsContainer.appendChild(chip);
+      return chip;
+    });
+
+    const resultEl = el("span", { class: "cs-bucket-result" }, "—");
+    row.appendChild(chipsContainer);
+    row.appendChild(resultEl);
+    grid.appendChild(row);
+
+    return { row, chips, resultEl, bucket };
+  });
+
+  // animate bucket-by-bucket
+  let totalDecoded = 0;
+  let totalStatsOnly = 0;
+  let totalSkipped = 0;
+  let bucketIdx = 0;
+
+  const bucketResults = [];
+
+  function processBucket() {
+    if (bucketIdx >= rows.length) {
+      showResults(bucketResults, agg, totalDecoded, totalStatsOnly, totalSkipped);
+      return;
+    }
+
+    const { row, chips, resultEl, bucket } = rows[bucketIdx];
+    row.classList.add("active");
+
+    let chipIdx = 0;
+    let runningValue = null;
+
+    function processChip() {
+      if (chipIdx >= chips.length) {
+        // bucket done
+        resultEl.textContent = fmtVal(runningValue ?? 0);
+        resultEl.classList.add("visible");
+        row.classList.remove("active");
+        row.classList.add("done");
+
+        const allStatsOnly = chips.every((c) => c.classList.contains("stats-only"));
+        bucketResults.push({
+          bucketIndex: bucketIdx,
+          value: runningValue,
+          method: allStatsOnly ? "stats-only" : "decoded",
+          chunks: bucket.chunks,
+        });
+
+        bucketIdx++;
+        setTimeout(processBucket, 200);
+        return;
+      }
+
+      const chip = chips[chipIdx];
+      const chunk = bucket.chunks[chipIdx];
+      const { stats } = chunk;
+
+      // determine decision
+      const decision = decideChunk(agg, stats, runningValue, bucket.chunks.length);
+
+      // apply the decision with animation
+      setTimeout(() => {
+        chip.querySelector(".chip-icon").textContent = decision.icon;
+        chip.classList.add(decision.cls);
+        chip.classList.add(decision.flashCls);
+
+        if (decision.type === "stats-only") {
+          totalStatsOnly++;
+          runningValue = mergeResult(agg, runningValue, stats);
+        } else if (decision.type === "must-decode") {
+          totalDecoded++;
+          runningValue = mergeResult(agg, runningValue, stats);
+        } else {
+          totalSkipped++;
+        }
+
+        // remove flash after animation
+        setTimeout(() => chip.classList.remove(decision.flashCls), 500);
+
+        chipIdx++;
+        setTimeout(processChip, 300);
+      }, 150);
+    }
+
+    processChip();
+  }
+
+  setTimeout(processBucket, 300);
+}
+
+function decideChunk(agg, stats, runningValue, bucketSize) {
+  if (agg === "max") {
+    if (bucketSize === 1) {
+      return { type: "stats-only", cls: "stats-only", flashCls: "flash-green", icon: "✓" };
+    }
+    // multi-chunk bucket: can skip if chunk.max <= running max
+    if (runningValue !== null && stats.max <= runningValue) {
+      return { type: "skipped", cls: "skipped", flashCls: "", icon: "⊘" };
+    }
+    return { type: "stats-only", cls: "stats-only", flashCls: "flash-green", icon: "✓" };
+  }
+
+  if (agg === "min") {
+    if (bucketSize === 1) {
+      return { type: "stats-only", cls: "stats-only", flashCls: "flash-green", icon: "✓" };
+    }
+    if (runningValue !== null && stats.min >= runningValue) {
+      return { type: "skipped", cls: "skipped", flashCls: "", icon: "⊘" };
+    }
+    return { type: "stats-only", cls: "stats-only", flashCls: "flash-green", icon: "✓" };
+  }
+
+  if (agg === "sum") {
+    // sum: if 1-chunk bucket → stats-only, otherwise must accumulate (but still from stats)
+    return { type: "stats-only", cls: "stats-only", flashCls: "flash-green", icon: "✓" };
+  }
+
+  if (agg === "avg") {
+    // avg: needs sum and count from each chunk — stats-only if aligned
+    if (bucketSize === 1) {
+      return { type: "stats-only", cls: "stats-only", flashCls: "flash-green", icon: "✓" };
+    }
+    // multi-chunk: we can still compute from chunk.sum/chunk.count
+    return { type: "stats-only", cls: "stats-only", flashCls: "flash-green", icon: "✓" };
+  }
+
+  return { type: "must-decode", cls: "must-decode", flashCls: "flash-red", icon: "⚙" };
+}
+
+function mergeResult(agg, running, stats) {
+  if (running === null) {
+    if (agg === "avg") return { sum: stats.sum, count: stats.count };
+    if (agg === "max") return stats.max;
+    if (agg === "min") return stats.min;
+    if (agg === "sum") return stats.sum;
+  }
+
+  switch (agg) {
+    case "max":
+      return Math.max(running, stats.max);
+    case "min":
+      return Math.min(running, stats.min);
+    case "sum":
+      return running + stats.sum;
+    case "avg":
+      return { sum: running.sum + stats.sum, count: running.count + stats.count };
+    default:
+      return running;
+  }
+}
+
+/* ─── E. Results Dashboard ────────────────────────────────────────── */
+
+function showResults(bucketResults, agg, decoded, statsOnly, skipped) {
+  const section = $("#results-section");
+  section.hidden = false;
+
+  const total = decoded + statsOnly + skipped;
+  const statsPercent = total > 0 ? Math.round((statsOnly / total) * 100) : 0;
+  // rough speedup: stats-only is ~100x, decoded is 1x, skipped is free
+  const effectiveWork = decoded + statsOnly * 0.01 + skipped * 0;
+  const baselineWork = total;
+  const speedup = effectiveWork > 0 ? baselineWork / effectiveWork : baselineWork;
+
+  // summary stats
+  $("#result-summary-stats").innerHTML = [
+    { label: "Total Chunks", value: String(total), color: "var(--xp-accent)" },
+    { label: "Stats-only", value: String(statsOnly), color: "var(--xp-success)" },
+    { label: "Decoded", value: String(decoded), color: "var(--xp-error)" },
+    { label: "Skipped", value: String(skipped), color: "var(--xp-text-dim)" },
+  ]
+    .map(
+      (s) => `
+    <div class="xp-stat">
+      <span class="xp-stat-label">${s.label}</span>
+      <span class="xp-stat-value" style="color:${s.color}">${s.value}</span>
+    </div>
+  `
+    )
+    .join("");
+
+  // speedup card
+  const speedupCard = $("#speedup-card");
+  speedupCard.innerHTML = `
+    <div class="cs-speedup-value" id="speedup-number">1×</div>
+    <div class="cs-speedup-label">Estimated Speedup</div>
+    <div class="cs-speedup-detail">
+      Stats answered ${statsOnly} of ${total} chunks (${statsPercent}%)${skipped > 0 ? ` — ${skipped} skipped entirely` : ""}
+    </div>
+  `;
+
+  // animate the speedup number
+  const speedupEl = $("#speedup-number");
+  animateValue(1, speedup, 800, (v) => {
+    speedupEl.textContent = `${Math.round(v)}×`;
+  });
+
+  // bucket results grid
+  const resultsGrid = $("#bucket-results");
+  resultsGrid.innerHTML = "";
+
+  bucketResults.forEach((br, i) => {
+    let displayValue;
+    if (agg === "avg" && br.value && typeof br.value === "object") {
+      displayValue = fmtVal(br.value.sum / br.value.count);
+    } else if (typeof br.value === "number") {
+      displayValue = agg === "sum" ? fmt(br.value, 1) : fmtVal(br.value);
+    } else {
+      displayValue = "—";
+    }
+
+    const cell = el(
+      "div",
+      {
+        class: "cs-result-cell",
+        style: { animationDelay: `${i * 60}ms` },
+      },
+      el("span", { class: "cell-label" }, `Bucket ${i}`),
+      el("span", { class: "cell-value" }, displayValue),
+      el(
+        "span",
+        {
+          class: `cell-method ${br.method}`,
+        },
+        br.method === "stats-only" ? "✓ stats" : "⚙ decoded"
+      )
+    );
+    resultsGrid.appendChild(cell);
+  });
+
+  section.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+/* ─── Init ────────────────────────────────────────────────────────── */
+
+function init() {
+  // breadcrumb
+  $("#breadcrumb-nav").innerHTML = buildBreadcrumb("Chunk Stats");
+
+  // draw the full sparkline
+  drawFullSparkline();
+  window.addEventListener("resize", drawFullSparkline);
+
+  // build timeline
+  buildTimeline();
+
+  // select first chunk by default
+  selectChunk(0);
+
+  // range slider
+  const rangeSlider = $("#range-slider");
+  const rangeValue = $("#range-value");
+  rangeSlider.addEventListener("input", () => {
+    rangeValue.textContent = `${rangeSlider.value} chunks`;
+  });
+
+  // run query button
+  $("#btn-run").addEventListener("click", runQuery);
+
+  // highlight explain card on aggregation change
+  $("#agg-select").addEventListener("change", () => {
+    const agg = $("#agg-select").value;
+    $$(".cs-explain-card").forEach((card) => {
+      card.classList.toggle("highlight", card.dataset.agg === agg);
+    });
+  });
+}
+
+init();

--- a/site/tsdb-engine/learn/delta-of-delta/dod-experience.css
+++ b/site/tsdb-engine/learn/delta-of-delta/dod-experience.css
@@ -1,0 +1,254 @@
+/* ─── Delta-of-Delta Experience ───────────────────────────────────── */
+
+/* ─── Control Groups ──────────────────────────────────────────────── */
+.dod-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dod-slider-wide {
+  flex: 1;
+  min-width: 200px;
+}
+
+.dod-slider-wide .xp-slider {
+  width: 100%;
+}
+
+/* ─── Transformation Table ────────────────────────────────────────── */
+.dod-table-wrap {
+  padding: 0;
+  overflow: hidden;
+}
+
+.dod-table-scroll {
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--xp-border-strong) transparent;
+}
+
+.dod-table-scroll::-webkit-scrollbar {
+  height: 6px;
+}
+
+.dod-table-scroll::-webkit-scrollbar-thumb {
+  background: var(--xp-border-strong);
+  border-radius: 3px;
+}
+
+.dod-table {
+  min-width: 720px;
+}
+
+.dod-table td {
+  font-family: var(--xp-mono);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.dod-table td.dod-idx {
+  color: var(--xp-text-dim);
+  font-weight: 600;
+  width: 36px;
+}
+
+.dod-table td.dod-ts {
+  color: var(--xp-text-muted);
+  font-size: 11px;
+}
+
+.dod-table td.dod-na {
+  color: var(--xp-text-dim);
+  font-style: italic;
+  font-family: var(--xp-font);
+}
+
+.dod-table td.dod-prefix {
+  letter-spacing: 0.1em;
+}
+
+.dod-table td.dod-bits {
+  font-weight: 600;
+}
+
+/* Tier row tinting */
+.dod-table tr.tier-row-0 td { border-left: 3px solid var(--tier-0); }
+.dod-table tr.tier-row-1 td { border-left: 3px solid var(--tier-1); }
+.dod-table tr.tier-row-2 td { border-left: 3px solid var(--tier-2); }
+.dod-table tr.tier-row-3 td { border-left: 3px solid var(--tier-3); }
+.dod-table tr.tier-row-4 td { border-left: 3px solid var(--tier-4); }
+.dod-table tr.tier-row-header td { border-left: 3px solid var(--region-header); }
+
+.dod-table tr.tier-row-0 td:first-child { border-left-width: 3px; }
+.dod-table tr.tier-row-1 td:first-child { border-left-width: 3px; }
+
+/* Tier badge */
+.dod-tier-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: var(--xp-mono);
+  letter-spacing: 0.04em;
+}
+
+.dod-tier-badge.t0 { background: rgba(52, 211, 153, 0.15); color: var(--tier-0); }
+.dod-tier-badge.t1 { background: rgba(96, 165, 250, 0.15); color: var(--tier-1); }
+.dod-tier-badge.t2 { background: rgba(167, 139, 250, 0.15); color: var(--tier-2); }
+.dod-tier-badge.t3 { background: rgba(251, 191, 36, 0.15); color: var(--tier-3); }
+.dod-tier-badge.t4 { background: rgba(248, 113, 113, 0.15); color: var(--tier-4); }
+
+/* ─── Tier Distribution Bar ───────────────────────────────────────── */
+.dod-tier-bar {
+  display: flex;
+  height: 40px;
+  border-radius: var(--xp-radius-sm);
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+.dod-tier-seg {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--xp-mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: #fff;
+  transition: flex-basis 400ms ease;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.dod-tier-seg.seg-0 { background: var(--tier-0); color: #0a1624; }
+.dod-tier-seg.seg-1 { background: var(--tier-1); color: #0a1624; }
+.dod-tier-seg.seg-2 { background: var(--tier-2); color: #0a1624; }
+.dod-tier-seg.seg-3 { background: var(--tier-3); color: #0a1624; }
+.dod-tier-seg.seg-4 { background: var(--tier-4); color: #0a1624; }
+
+.dod-tier-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 12px;
+  color: var(--xp-text-muted);
+}
+
+.dod-tier-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dod-tier-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.dod-tier-dot.d0 { background: var(--tier-0); }
+.dod-tier-dot.d1 { background: var(--tier-1); }
+.dod-tier-dot.d2 { background: var(--tier-2); }
+.dod-tier-dot.d3 { background: var(--tier-3); }
+.dod-tier-dot.d4 { background: var(--tier-4); }
+
+/* ─── Bit Cost Profile Chart ──────────────────────────────────────── */
+.dod-bitcost-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.dod-bitcost-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 20px;
+}
+
+.dod-bitcost-label {
+  font-family: var(--xp-mono);
+  font-size: 10px;
+  color: var(--xp-text-dim);
+  width: 20px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.dod-bitcost-bar-wrap {
+  flex: 1;
+  height: 14px;
+  position: relative;
+}
+
+.dod-bitcost-bar {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 400ms ease;
+  min-width: 2px;
+  position: relative;
+}
+
+.dod-bitcost-bar.bc-0 { background: var(--tier-0); }
+.dod-bitcost-bar.bc-1 { background: var(--tier-1); }
+.dod-bitcost-bar.bc-2 { background: var(--tier-2); }
+.dod-bitcost-bar.bc-3 { background: var(--tier-3); }
+.dod-bitcost-bar.bc-4 { background: var(--tier-4); }
+.dod-bitcost-bar.bc-header { background: var(--region-header); }
+
+.dod-bitcost-bits {
+  font-family: var(--xp-mono);
+  font-size: 10px;
+  color: var(--xp-text-dim);
+  width: 36px;
+  text-align: left;
+  flex-shrink: 0;
+}
+
+/* ─── Jitter Story ────────────────────────────────────────────────── */
+.dod-story {
+  margin-top: 16px;
+  padding: 16px 20px;
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--xp-text-muted);
+}
+
+.dod-story strong {
+  color: var(--xp-success);
+  font-weight: 600;
+}
+
+.dod-story .warn {
+  color: var(--xp-warn);
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .dod-table {
+    min-width: 580px;
+  }
+
+  .dod-table td {
+    font-size: 11px;
+    padding: 6px 8px;
+  }
+
+  .dod-tier-seg {
+    font-size: 10px;
+  }
+
+  .dod-bitcost-row {
+    height: 16px;
+  }
+
+  .dod-bitcost-bar-wrap {
+    height: 10px;
+  }
+}

--- a/site/tsdb-engine/learn/delta-of-delta/dod-experience.css
+++ b/site/tsdb-engine/learn/delta-of-delta/dod-experience.css
@@ -24,17 +24,6 @@
 
 .dod-table-scroll {
   overflow-x: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--xp-border-strong) transparent;
-}
-
-.dod-table-scroll::-webkit-scrollbar {
-  height: 6px;
-}
-
-.dod-table-scroll::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 3px;
 }
 
 .dod-table {
@@ -83,17 +72,7 @@
 .dod-table tr.tier-row-0 td:first-child { border-left-width: 3px; }
 .dod-table tr.tier-row-1 td:first-child { border-left-width: 3px; }
 
-/* Tier badge */
-.dod-tier-badge {
-  display: inline-block;
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 10px;
-  font-weight: 600;
-  font-family: var(--xp-mono);
-  letter-spacing: 0.04em;
-}
-
+/* Tier badge — base from .xp-badge in shared.css */
 .dod-tier-badge.t0 { background: rgba(52, 211, 153, 0.15); color: var(--tier-0); }
 .dod-tier-badge.t1 { background: rgba(96, 165, 250, 0.15); color: var(--tier-1); }
 .dod-tier-badge.t2 { background: rgba(167, 139, 250, 0.15); color: var(--tier-2); }
@@ -209,16 +188,7 @@
 }
 
 /* ─── Jitter Story ────────────────────────────────────────────────── */
-.dod-story {
-  margin-top: 16px;
-  padding: 16px 20px;
-  background: var(--xp-surface);
-  border: 1px solid var(--xp-border);
-  border-radius: var(--xp-radius-sm);
-  font-size: 14px;
-  line-height: 1.6;
-  color: var(--xp-text-muted);
-}
+/* base from .xp-story in shared.css */
 
 .dod-story strong {
   color: var(--xp-success);

--- a/site/tsdb-engine/learn/delta-of-delta/dod-experience.js
+++ b/site/tsdb-engine/learn/delta-of-delta/dod-experience.js
@@ -6,7 +6,7 @@
  */
 
 import {
-  $, el, buildBreadcrumb, fmt, fmtBytes, zigzagEncode, generateSamples,
+  $, el, buildBreadcrumb, buildStat, fmt, fmtBytes, zigzagEncode, generateSamples,
 } from '../shared.js';
 
 /* ─── Constants ───────────────────────────────────────────────────── */
@@ -177,11 +177,11 @@ function renderTable() {
 
     // Tier badge
     if (row.tier >= 0) {
-      const badge = el('span', { class: `dod-tier-badge t${row.tier}` }, row.tierLabel);
+      const badge = el('span', { class: `xp-badge dod-tier-badge t${row.tier}` }, row.tierLabel);
       tr.appendChild(el('td', {}, badge));
     } else {
       const badge = el('span', {
-        class: 'dod-tier-badge',
+        class: 'xp-badge dod-tier-badge',
         style: { background: 'rgba(139, 92, 246, 0.15)', color: 'var(--region-header)' },
       }, row.tierLabel);
       tr.appendChild(el('td', {}, badge));
@@ -279,11 +279,7 @@ function renderSummary() {
   ];
 
   for (const s of stats) {
-    const stat = el('div', { class: 'xp-stat' },
-      el('div', { class: 'xp-stat-label' }, s.label),
-      el('div', { class: 'xp-stat-value' }, s.value),
-      el('div', { class: 'xp-stat-unit' }, s.unit),
-    );
+    const stat = buildStat(s.label, s.value, s.unit);
     if (s.label === 'Ratio') {
       stat.querySelector('.xp-stat-value').style.color = ratio >= 10 ? 'var(--xp-success)' : ratio >= 4 ? 'var(--xp-accent)' : 'var(--xp-warn)';
     }

--- a/site/tsdb-engine/learn/delta-of-delta/dod-experience.js
+++ b/site/tsdb-engine/learn/delta-of-delta/dod-experience.js
@@ -1,0 +1,350 @@
+/**
+ * Delta-of-Delta Timestamp Compression — Interactive Experience
+ *
+ * Demonstrates Gorilla-style timestamp encoding:
+ *   Raw ts → Delta → Delta-of-Delta → ZigZag → Tier-based variable-width encoding
+ */
+
+import {
+  $, el, buildBreadcrumb, fmt, fmtBytes, zigzagEncode, generateSamples,
+} from '../shared.js';
+
+/* ─── Constants ───────────────────────────────────────────────────── */
+
+const SAMPLE_COUNT = 24;
+
+const TIER_DEFS = [
+  { id: 0, label: '1-bit',  prefix: '0',    prefixBits: 1, dataBits: 0,  maxZZ: 0,    color: 'var(--tier-0)' },
+  { id: 1, label: '9-bit',  prefix: '10',   prefixBits: 2, dataBits: 7,  maxZZ: 127,  color: 'var(--tier-1)' },
+  { id: 2, label: '12-bit', prefix: '110',  prefixBits: 3, dataBits: 9,  maxZZ: 511,  color: 'var(--tier-2)' },
+  { id: 3, label: '16-bit', prefix: '1110', prefixBits: 4, dataBits: 12, maxZZ: 4095, color: 'var(--tier-3)' },
+  { id: 4, label: '68-bit', prefix: '1111', prefixBits: 4, dataBits: 64, maxZZ: Infinity, color: 'var(--tier-4)' },
+];
+
+const TIER_TOTAL_BITS = TIER_DEFS.map(t => t.prefixBits + t.dataBits);
+
+/* ─── State ───────────────────────────────────────────────────────── */
+
+let intervalSec = 15;
+let jitterMs = 0;
+let data = null;   // { timestamps, rows, tierCounts, totalBits, headerBits }
+
+/* ─── Algorithm ───────────────────────────────────────────────────── */
+
+function classifyTier(zzValue) {
+  const zz = Number(zzValue);
+  if (zz === 0) return 0;
+  if (zz <= 127) return 1;
+  if (zz <= 511) return 2;
+  if (zz <= 4095) return 3;
+  return 4;
+}
+
+function computeData() {
+  const intervalNs = BigInt(intervalSec) * 1_000_000_000n;
+  const { timestamps } = generateSamples('gauge', SAMPLE_COUNT, {
+    interval: intervalNs,
+    jitter: jitterMs,
+  });
+
+  const rows = [];
+  const tierCounts = [0, 0, 0, 0, 0];
+  let totalBitStreamBits = 0;
+
+  for (let i = 0; i < SAMPLE_COUNT; i++) {
+    const ts = timestamps[i];
+
+    if (i === 0) {
+      // First timestamp: stored as 8 bytes in header
+      rows.push({
+        idx: i, ts, delta: null, dod: null, zz: null,
+        tier: -1, tierLabel: 'header', prefix: '—', bits: 64,
+        note: 'stored in header',
+      });
+      continue;
+    }
+
+    const delta = ts - timestamps[i - 1];
+
+    if (i === 1) {
+      // First delta: stored raw in bit stream (14 bits with prefix to be safe,
+      // but for this visualization we treat it as a raw delta value).
+      // In Gorilla paper, first delta uses a fixed bit width. We'll show it
+      // going through the tier system like subsequent values for clarity.
+      // Actually, per the spec description in the prompt: "First delta stored as raw value"
+      // We'll represent it going through normal tier encoding for educational value,
+      // since the ΔoΔ concept starts at i=2.
+      rows.push({
+        idx: i, ts, delta, dod: null, zz: null,
+        tier: -1, tierLabel: 'Δ raw', prefix: '—', bits: 64,
+        note: 'first delta (raw)',
+      });
+      totalBitStreamBits += 64;
+      continue;
+    }
+
+    const prevDelta = timestamps[i - 1] - timestamps[i - 2];
+    const dod = delta - prevDelta;
+    const zz = zigzagEncode(dod);
+    const tier = classifyTier(zz);
+    tierCounts[tier]++;
+    const bits = TIER_TOTAL_BITS[tier];
+    totalBitStreamBits += bits;
+
+    rows.push({
+      idx: i, ts, delta, dod, zz,
+      tier,
+      tierLabel: TIER_DEFS[tier].label,
+      prefix: TIER_DEFS[tier].prefix,
+      bits,
+      note: null,
+    });
+  }
+
+  // Wire format: 10-byte header (2B count u16 BE + 8B first ts i64 BE) + bit stream
+  const headerBits = 10 * 8; // 80 bits
+  const totalBits = headerBits + totalBitStreamBits;
+
+  return { timestamps, rows, tierCounts, totalBits, headerBits, totalBitStreamBits };
+}
+
+/* ─── Formatters ──────────────────────────────────────────────────── */
+
+function fmtTimestamp(ts) {
+  const ms = Number(ts / 1_000_000n);
+  const d = new Date(ms);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  const ss = String(d.getSeconds()).padStart(2, '0');
+  const frac = String(d.getMilliseconds()).padStart(3, '0');
+  return `${hh}:${mm}:${ss}.${frac}`;
+}
+
+function fmtNs(ns) {
+  const n = Number(ns);
+  if (n === 0) return '0';
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(3)} s`;
+  if (abs >= 1_000_000) return `${(n / 1_000_000).toFixed(1)} ms`;
+  if (abs >= 1_000) return `${(n / 1_000).toFixed(1)} µs`;
+  return `${n} ns`;
+}
+
+/* ─── Render Functions ────────────────────────────────────────────── */
+
+function renderTable() {
+  const tbody = $('#dod-tbody');
+  tbody.innerHTML = '';
+
+  for (const row of data.rows) {
+    const tr = document.createElement('tr');
+
+    if (row.tier >= 0) {
+      tr.className = `tier-row-${row.tier}`;
+    } else {
+      tr.className = 'tier-row-header';
+    }
+
+    // #
+    tr.appendChild(el('td', { class: 'dod-idx' }, String(row.idx)));
+
+    // Timestamp
+    tr.appendChild(el('td', { class: 'dod-ts' }, fmtTimestamp(row.ts)));
+
+    // Delta
+    if (row.delta === null) {
+      tr.appendChild(el('td', { class: 'dod-na' }, '—'));
+    } else {
+      tr.appendChild(el('td', {}, fmtNs(Number(row.delta))));
+    }
+
+    // ΔoΔ
+    if (row.dod === null) {
+      tr.appendChild(el('td', { class: 'dod-na' }, '—'));
+    } else {
+      const dodStr = fmtNs(Number(row.dod));
+      const dodTd = el('td', {}, dodStr);
+      if (Number(row.dod) === 0) dodTd.style.color = 'var(--tier-0)';
+      tr.appendChild(dodTd);
+    }
+
+    // ZigZag
+    if (row.zz === null) {
+      tr.appendChild(el('td', { class: 'dod-na' }, '—'));
+    } else {
+      tr.appendChild(el('td', {}, String(row.zz)));
+    }
+
+    // Tier badge
+    if (row.tier >= 0) {
+      const badge = el('span', { class: `dod-tier-badge t${row.tier}` }, row.tierLabel);
+      tr.appendChild(el('td', {}, badge));
+    } else {
+      const badge = el('span', {
+        class: 'dod-tier-badge',
+        style: { background: 'rgba(139, 92, 246, 0.15)', color: 'var(--region-header)' },
+      }, row.tierLabel);
+      tr.appendChild(el('td', {}, badge));
+    }
+
+    // Prefix
+    tr.appendChild(el('td', { class: 'dod-prefix' }, row.prefix));
+
+    // Bits
+    const bitsTd = el('td', { class: 'dod-bits' }, String(row.bits));
+    if (row.tier >= 0) bitsTd.style.color = TIER_DEFS[row.tier].color;
+    else bitsTd.style.color = 'var(--region-header)';
+    tr.appendChild(bitsTd);
+
+    tbody.appendChild(tr);
+  }
+}
+
+function renderTierBar() {
+  const bar = $('#tier-bar');
+  const legend = $('#tier-legend');
+  bar.innerHTML = '';
+  legend.innerHTML = '';
+
+  // Only count tier-encoded values (skip header rows)
+  const tierTotal = data.tierCounts.reduce((a, b) => a + b, 0);
+
+  for (let t = 0; t < 5; t++) {
+    const count = data.tierCounts[t];
+    if (count === 0) continue;
+    const pct = (count / tierTotal) * 100;
+    const seg = el('div', {
+      class: `dod-tier-seg seg-${t}`,
+      style: { flexBasis: `${pct}%` },
+    }, pct >= 8 ? `${count}` : '');
+    if (pct >= 15) {
+      seg.textContent = `${count} (${Math.round(pct)}%)`;
+    }
+    bar.appendChild(seg);
+  }
+
+  // Legend
+  for (let t = 0; t < 5; t++) {
+    const def = TIER_DEFS[t];
+    const item = el('div', { class: 'dod-tier-legend-item' },
+      el('span', { class: `dod-tier-dot d${t}` }),
+      el('span', {}, `${def.label} (${TIER_TOTAL_BITS[t]}b) — ${data.tierCounts[t]}`),
+    );
+    legend.appendChild(item);
+  }
+}
+
+function renderBitCostChart() {
+  const chart = $('#bitcost-chart');
+  chart.innerHTML = '';
+
+  const maxBits = 68;
+
+  for (const row of data.rows) {
+    const barRow = el('div', { class: 'dod-bitcost-row' });
+
+    barRow.appendChild(el('div', { class: 'dod-bitcost-label' }, String(row.idx)));
+
+    const widthPct = (row.bits / maxBits) * 100;
+    const tierClass = row.tier >= 0 ? `bc-${row.tier}` : 'bc-header';
+    const barEl = el('div', { class: `dod-bitcost-bar ${tierClass}`, style: { width: `${widthPct}%` } });
+    const wrap = el('div', { class: 'dod-bitcost-bar-wrap' }, barEl);
+    barRow.appendChild(wrap);
+
+    barRow.appendChild(el('div', { class: 'dod-bitcost-bits' }, `${row.bits}b`));
+
+    chart.appendChild(barRow);
+  }
+}
+
+function renderSummary() {
+  const statsRow = $('#summary-stats');
+  statsRow.innerHTML = '';
+
+  const rawBytes = SAMPLE_COUNT * 8;
+  const compressedBits = data.totalBits;
+  const compressedBytes = Math.ceil(compressedBits / 8);
+  const ratio = rawBytes / compressedBytes;
+
+  // Average bits per timestamp for the tier-encoded portion
+  const tierTotal = data.tierCounts.reduce((a, b) => a + b, 0);
+  const tierBits = data.totalBitStreamBits - 64; // subtract first delta raw bits
+  const avgBits = tierTotal > 0 ? tierBits / tierTotal : 0;
+
+  const stats = [
+    { label: 'Raw Size', value: fmtBytes(rawBytes), unit: `${SAMPLE_COUNT} × 8 B` },
+    { label: 'Compressed', value: fmtBytes(compressedBytes), unit: `${fmt(compressedBits)} bits` },
+    { label: 'Ratio', value: `${ratio.toFixed(1)}×`, unit: 'smaller' },
+    { label: 'Avg Bits/TS', value: avgBits.toFixed(1), unit: 'bits (ΔoΔ only)' },
+  ];
+
+  for (const s of stats) {
+    const stat = el('div', { class: 'xp-stat' },
+      el('div', { class: 'xp-stat-label' }, s.label),
+      el('div', { class: 'xp-stat-value' }, s.value),
+      el('div', { class: 'xp-stat-unit' }, s.unit),
+    );
+    if (s.label === 'Ratio') {
+      stat.querySelector('.xp-stat-value').style.color = ratio >= 10 ? 'var(--xp-success)' : ratio >= 4 ? 'var(--xp-accent)' : 'var(--xp-warn)';
+    }
+    statsRow.appendChild(stat);
+  }
+
+  // Jitter story
+  const story = $('#jitter-story');
+  const t0Pct = tierTotal > 0 ? Math.round((data.tierCounts[0] / tierTotal) * 100) : 0;
+
+  if (jitterMs === 0) {
+    story.innerHTML = `With <strong>0 ms jitter</strong>, ${t0Pct}% of deltas-of-deltas are exactly zero — each costs only <strong>1 bit</strong>. The entire timestamp column compresses to <strong>${ratio.toFixed(0)}× smaller</strong> than raw 8-byte timestamps.`;
+  } else {
+    const warnClass = avgBits > 10 ? ' warn' : '';
+    story.innerHTML = `With <strong class="${warnClass}">${fmt(jitterMs)} ms jitter</strong>, only ${t0Pct}% of ΔoΔ values are zero. Average encoding cost rises to <strong class="${warnClass}">${avgBits.toFixed(1)} bits/timestamp</strong>. Compression ratio: <strong>${ratio.toFixed(1)}×</strong>.`;
+  }
+}
+
+function renderAll() {
+  data = computeData();
+  renderTable();
+  renderTierBar();
+  renderBitCostChart();
+  renderSummary();
+}
+
+/* ─── Event Wiring ────────────────────────────────────────────────── */
+
+function init() {
+  // Breadcrumb
+  $('#breadcrumb-nav').innerHTML = buildBreadcrumb('Delta‑of‑Delta');
+
+  // Interval select
+  const intervalSelect = $('#interval-select');
+  intervalSelect.addEventListener('change', () => {
+    intervalSec = Number(intervalSelect.value);
+    renderAll();
+  });
+
+  // Jitter slider — throttled to rAF
+  const jitterSlider = $('#jitter-slider');
+  const jitterDisplay = $('#jitter-value');
+  let rafPending = false;
+
+  jitterSlider.addEventListener('input', () => {
+    jitterMs = Number(jitterSlider.value);
+    jitterDisplay.textContent = `${fmt(jitterMs)} ms`;
+    if (!rafPending) {
+      rafPending = true;
+      requestAnimationFrame(() => {
+        renderAll();
+        rafPending = false;
+      });
+    }
+  });
+
+  // Regenerate button
+  $('#btn-regenerate').addEventListener('click', renderAll);
+
+  // Initial render
+  renderAll();
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/site/tsdb-engine/learn/delta-of-delta/index.html
+++ b/site/tsdb-engine/learn/delta-of-delta/index.html
@@ -110,8 +110,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/delta-of-delta/index.html
+++ b/site/tsdb-engine/learn/delta-of-delta/index.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Delta-of-Delta Timestamp Compression — Interactive Experience | o11ytsdb</title>
+    <meta name="description" content="Watch timestamps collapse from 8 bytes each to as little as 1 bit — interactively explore Gorilla-style delta-of-delta encoding." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500&display=swap" />
+    <link rel="stylesheet" href="../shared.css" />
+    <link rel="stylesheet" href="dod-experience.css" />
+  </head>
+  <body>
+    <a href="#main" class="xp-skip-link">Skip to content</a>
+    <div class="xp-ambient" aria-hidden="true"></div>
+    <div class="xp-page" id="main">
+
+      <div id="breadcrumb-nav"></div>
+
+      <div class="xp-hero">
+        <p class="xp-eyebrow">Timestamp Compression</p>
+        <h1>Delta‑of‑Delta</h1>
+        <p class="lede">
+          Metrics arrive at regular intervals — every 15 s, 30 s, 60 s.
+          Delta-of-delta exploits that regularity: perfectly spaced timestamps
+          compress to <strong>1 bit each</strong>, 64× smaller than raw.
+          Drag the jitter slider and watch compression degrade in real time.
+        </p>
+      </div>
+
+      <!-- A. Controls -->
+      <section class="xp-section" id="controls-section">
+        <h2>① Tune the Signal</h2>
+        <p>Choose an interval and add jitter to simulate real-world clock drift.</p>
+        <div class="xp-card">
+          <div class="xp-controls" id="controls-row">
+            <div class="dod-control-group">
+              <label class="xp-label" for="interval-select">Interval</label>
+              <select class="xp-select" id="interval-select">
+                <option value="10">10 s</option>
+                <option value="15" selected>15 s</option>
+                <option value="30">30 s</option>
+                <option value="60">60 s</option>
+              </select>
+            </div>
+            <div class="dod-control-group dod-slider-wide">
+              <label class="xp-label" for="jitter-slider">Jitter</label>
+              <div class="xp-slider-row">
+                <input type="range" class="xp-slider" id="jitter-slider"
+                       min="0" max="5000" step="50" value="0" />
+                <span class="xp-slider-value" id="jitter-value">0 ms</span>
+              </div>
+            </div>
+            <button class="xp-btn xp-btn-primary" id="btn-regenerate">⟳ Regenerate</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- B. Transformation Table -->
+      <section class="xp-section" id="table-section">
+        <h2>② Transformation Table</h2>
+        <p>Each row shows one timestamp flowing through the pipeline.</p>
+        <div class="xp-card dod-table-wrap">
+          <div class="dod-table-scroll">
+            <table class="xp-table dod-table" id="dod-table">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Timestamp</th>
+                  <th>Δ (delta)</th>
+                  <th>ΔoΔ</th>
+                  <th>ZigZag</th>
+                  <th>Tier</th>
+                  <th>Prefix</th>
+                  <th>Bits</th>
+                </tr>
+              </thead>
+              <tbody id="dod-tbody"></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <!-- C. Tier Distribution -->
+      <section class="xp-section" id="tier-section">
+        <h2>③ Tier Distribution</h2>
+        <p>How values spread across encoding tiers — green is cheapest.</p>
+        <div class="xp-card">
+          <div class="dod-tier-bar" id="tier-bar"></div>
+          <div class="dod-tier-legend" id="tier-legend"></div>
+        </div>
+      </section>
+
+      <!-- D. Bit Cost Profile -->
+      <section class="xp-section" id="bitcost-section">
+        <h2>④ Bit Cost Profile</h2>
+        <p>Each bar = one timestamp's encoding cost. Shorter is better.</p>
+        <div class="xp-card">
+          <div class="dod-bitcost-chart" id="bitcost-chart"></div>
+        </div>
+      </section>
+
+      <!-- E. Compression Summary -->
+      <section class="xp-section" id="summary-section">
+        <h2>⑤ Compression Summary</h2>
+        <div class="xp-stats-row" id="summary-stats"></div>
+        <div class="dod-story" id="jitter-story"></div>
+      </section>
+
+      <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
+        <p style="font-size: 13px; color: var(--xp-text-dim);">
+          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+        </p>
+      </footer>
+
+    </div>
+    <script type="module" src="dod-experience.js"></script>
+  </body>
+</html>

--- a/site/tsdb-engine/learn/delta-of-delta/index.html
+++ b/site/tsdb-engine/learn/delta-of-delta/index.html
@@ -62,7 +62,7 @@
         <h2>② Transformation Table</h2>
         <p>Each row shows one timestamp flowing through the pipeline.</p>
         <div class="xp-card dod-table-wrap">
-          <div class="dod-table-scroll">
+          <div class="dod-table-scroll xp-scroll-x">
             <table class="xp-table dod-table" id="dod-table">
               <thead>
                 <tr>
@@ -105,7 +105,7 @@
       <section class="xp-section" id="summary-section">
         <h2>⑤ Compression Summary</h2>
         <div class="xp-stats-row" id="summary-stats"></div>
-        <div class="dod-story" id="jitter-story"></div>
+        <div class="dod-story xp-story" id="jitter-story"></div>
       </section>
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">

--- a/site/tsdb-engine/learn/index.html
+++ b/site/tsdb-engine/learn/index.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Learn — How Metric Storage Works | o11ytsdb</title>
+    <meta name="description" content="Interactive experiences that teach you how a time-series database stores, compresses, and queries metric data — from bit-level encoding to query optimization." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500&display=swap" />
+    <link rel="stylesheet" href="shared.css" />
+    <style>
+      .hub-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        gap: 16px;
+        margin-top: 32px;
+      }
+      .hub-card {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 24px;
+        background: var(--xp-surface);
+        border: 1px solid var(--xp-border);
+        border-radius: var(--xp-radius);
+        text-decoration: none;
+        color: inherit;
+        transition: all 200ms;
+        position: relative;
+        overflow: hidden;
+      }
+      .hub-card:hover {
+        border-color: var(--xp-accent);
+        transform: translateY(-2px);
+        box-shadow: 0 8px 32px rgba(96, 165, 250, 0.08);
+      }
+      .hub-card::before {
+        content: '';
+        position: absolute;
+        top: 0; left: 0; right: 0;
+        height: 3px;
+        background: var(--card-accent, var(--xp-accent));
+        opacity: 0;
+        transition: opacity 200ms;
+      }
+      .hub-card:hover::before { opacity: 1; }
+      .hub-icon {
+        font-size: 28px;
+        width: 48px;
+        height: 48px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--card-glow, var(--xp-accent-glow));
+        border-radius: 12px;
+        flex-shrink: 0;
+      }
+      .hub-card h3 {
+        margin: 0;
+        font-size: 17px;
+        font-weight: 600;
+        color: #fff;
+      }
+      .hub-card p {
+        margin: 0;
+        font-size: 14px;
+        line-height: 1.5;
+        color: var(--xp-text-muted);
+      }
+      .hub-tag {
+        display: inline-block;
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        padding: 3px 8px;
+        border-radius: 999px;
+        background: var(--card-glow, var(--xp-accent-glow));
+        color: var(--card-accent, var(--xp-accent));
+        border: 1px solid var(--card-accent, var(--xp-accent));
+        opacity: 0.8;
+      }
+      .hub-intro {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 32px;
+        align-items: center;
+      }
+      .hub-intro-diagram {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        font-family: var(--xp-mono);
+        font-size: 11px;
+        color: var(--xp-text-dim);
+        padding: 16px;
+        background: var(--xp-surface);
+        border: 1px solid var(--xp-border);
+        border-radius: var(--xp-radius-sm);
+        white-space: pre;
+        line-height: 1.4;
+      }
+      @media (max-width: 700px) {
+        .hub-intro { grid-template-columns: 1fr; }
+        .hub-intro-diagram { display: none; }
+      }
+    </style>
+  </head>
+  <body>
+    <a href="#main" class="xp-skip-link">Skip to content</a>
+    <div class="xp-ambient" aria-hidden="true"></div>
+    <div class="xp-page" id="main">
+
+      <nav class="xp-topbar" aria-label="Breadcrumb">
+        <div class="xp-breadcrumb">
+          <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+          <span class="sep">›</span>
+          <span class="current">Learn</span>
+        </div>
+      </nav>
+
+      <div class="xp-hero">
+        <p class="xp-eyebrow">Learn</p>
+        <h1>How Metric Storage Works</h1>
+        <div class="hub-intro">
+          <p class="lede">
+            A time-series database takes billions of floating-point measurements and packs them into
+            a fraction of their original size — then answers queries across all of them in milliseconds.
+            <br/><br/>
+            Each experience below lets you <strong>see</strong> and <strong>interact</strong> with
+            one piece of that puzzle. Click any card to explore.
+          </p>
+          <div class="hub-intro-diagram" aria-hidden="true">Metric sample arrives
+  ↓
+┌─────────────────────────┐
+│  String Interning       │ labels → integer IDs
+│  Inverted Index         │ fast label lookup
+├─────────────────────────┤
+│  ALP / XOR-Delta        │ value compression
+│  Delta-of-Delta         │ timestamp compression
+├─────────────────────────┤
+│  Chunk Stats            │ min/max/sum/count
+│  Query Engine           │ prune → decode → agg
+└─────────────────────────┘
+  ↓
+Answer in &lt;1ms</div>
+        </div>
+      </div>
+
+      <section>
+        <h2 style="color:#fff; margin-bottom: 4px;">Compression</h2>
+        <p style="color: var(--xp-text-muted); font-size: 14px; margin-bottom: 16px;">How raw numbers become tiny bit streams</p>
+        <div class="hub-grid">
+
+          <a href="alp/" class="hub-card" style="--card-accent: #10b981; --card-glow: rgba(16, 185, 129, 0.1);">
+            <div class="hub-icon" style="--card-glow: rgba(16, 185, 129, 0.1);">📐</div>
+            <h3>ALP Compression</h3>
+            <p>Watch floating-point numbers get quantized to integers, bit-packed, and compressed to a fraction of their size — with lossless round-trip.</p>
+            <span class="hub-tag" style="--card-accent: #10b981; --card-glow: rgba(16, 185, 129, 0.1);">Values</span>
+          </a>
+
+          <a href="delta-of-delta/" class="hub-card" style="--card-accent: #06b6d4; --card-glow: rgba(6, 182, 212, 0.1);">
+            <div class="hub-icon" style="--card-glow: rgba(6, 182, 212, 0.1);">⏱️</div>
+            <h3>Delta-of-Delta</h3>
+            <p>Regular timestamps compress to almost nothing — just 1 bit per sample when the interval is constant. Watch the math unfold.</p>
+            <span class="hub-tag" style="--card-accent: #06b6d4; --card-glow: rgba(6, 182, 212, 0.1);">Timestamps</span>
+          </a>
+
+          <a href="xor-delta/" class="hub-card" style="--card-accent: #a78bfa; --card-glow: rgba(167, 139, 250, 0.1);">
+            <div class="hub-icon" style="--card-glow: rgba(167, 139, 250, 0.1);">⊕</div>
+            <h3>XOR-Delta</h3>
+            <p>Values that barely change need barely any bits. XOR two floats, find the meaningful window, and store just that.</p>
+            <span class="hub-tag" style="--card-accent: #a78bfa; --card-glow: rgba(167, 139, 250, 0.1);">Values</span>
+          </a>
+
+        </div>
+      </section>
+
+      <section style="margin-top: 40px;">
+        <h2 style="color:#fff; margin-bottom: 4px;">Storage &amp; Indexing</h2>
+        <p style="color: var(--xp-text-muted); font-size: 14px; margin-bottom: 16px;">How data is organized for fast writes and reads</p>
+        <div class="hub-grid">
+
+          <a href="string-interning/" class="hub-card" style="--card-accent: #f59e0b; --card-glow: rgba(245, 158, 11, 0.1);">
+            <div class="hub-icon" style="--card-glow: rgba(245, 158, 11, 0.1);">🏷️</div>
+            <h3>String Interning</h3>
+            <p>10,000 series × 4 labels each = 40,000 strings. Interning stores each unique string once and references it by integer ID.</p>
+            <span class="hub-tag" style="--card-accent: #f59e0b; --card-glow: rgba(245, 158, 11, 0.1);">Labels</span>
+          </a>
+
+          <a href="chunk-stats/" class="hub-card" style="--card-accent: #f87171; --card-glow: rgba(248, 113, 113, 0.1);">
+            <div class="hub-icon" style="--card-glow: rgba(248, 113, 113, 0.1);">📊</div>
+            <h3>Chunk Stats</h3>
+            <p>Each compressed chunk stores min, max, sum, and count. Queries can skip entire chunks without decompressing — often 100× faster.</p>
+            <span class="hub-tag" style="--card-accent: #f87171; --card-glow: rgba(248, 113, 113, 0.1);">Query</span>
+          </a>
+
+          <a href="query-engine/" class="hub-card" style="--card-accent: #60a5fa; --card-glow: rgba(96, 165, 250, 0.1);">
+            <div class="hub-icon" style="--card-glow: rgba(96, 165, 250, 0.1);">🔍</div>
+            <h3>Query Engine</h3>
+            <p>From label filters to aggregated answers: postings intersection, chunk pruning, step-aligned bucketing — end to end.</p>
+            <span class="hub-tag" style="--card-accent: #60a5fa;">Pipeline</span>
+          </a>
+
+        </div>
+      </section>
+
+      <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
+        <p style="font-size: 13px; color: var(--xp-text-dim);">
+          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="/o11ykit/tsdb-engine/" style="color: var(--xp-text-muted); text-decoration: none;">Back to TSDB Engine →</a>
+        </p>
+      </footer>
+
+    </div>
+  </body>
+</html>

--- a/site/tsdb-engine/learn/index.html
+++ b/site/tsdb-engine/learn/index.html
@@ -114,7 +114,7 @@
 
       <nav class="xp-topbar" aria-label="Breadcrumb">
         <div class="xp-breadcrumb">
-          <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+          <a href="../">TSDB Engine</a>
           <span class="sep">›</span>
           <span class="current">Learn</span>
         </div>

--- a/site/tsdb-engine/learn/index.html
+++ b/site/tsdb-engine/learn/index.html
@@ -208,8 +208,8 @@ Answer in &lt;1ms</div>
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/" style="color: var(--xp-text-muted); text-decoration: none;">Back to TSDB Engine →</a>
+          Part of <a href="../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">Back to TSDB Engine →</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/query-engine/index.html
+++ b/site/tsdb-engine/learn/query-engine/index.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Query Engine — Interactive Experience | o11ytsdb</title>
+    <meta name="description" content="Trace the end-to-end query flow in a TSDB: label matching, postings intersection, chunk pruning, stats skip, decode, and step-aligned aggregation." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500&display=swap" />
+    <link rel="stylesheet" href="../shared.css" />
+    <link rel="stylesheet" href="query-experience.css" />
+  </head>
+  <body>
+    <a href="#main" class="xp-skip-link">Skip to content</a>
+    <div class="xp-ambient" aria-hidden="true"></div>
+    <div class="xp-page" id="main">
+
+      <div id="breadcrumb-nav"></div>
+
+      <div class="xp-hero">
+        <p class="xp-eyebrow">Query Pipeline</p>
+        <h1>Query Engine</h1>
+        <p class="lede">
+          Trace the end-to-end journey of a TSDB query — from label matching through
+          postings intersection, chunk pruning, stats shortcuts, decoding, and
+          step-aligned aggregation. Build a query and watch it execute stage by stage.
+        </p>
+      </div>
+
+      <!-- A. Dataset Summary -->
+      <section class="xp-section" id="dataset-section">
+        <h2>① Sample Dataset</h2>
+        <p>A simulated TSDB with three metrics, multiple label dimensions, and chunked storage.</p>
+        <div class="xp-stats-row" id="dataset-stats"></div>
+        <div class="xp-card qe-dataset-card" id="dataset-detail"></div>
+      </section>
+
+      <!-- B. Pipeline -->
+      <section class="xp-section" id="pipeline-section">
+        <h2>② Query Pipeline</h2>
+        <p>Six stages transform a PromQL-like selector into aggregated results. Each stage lights up as the query executes.</p>
+        <div class="xp-pipeline" id="pipeline-bar"></div>
+      </section>
+
+      <!-- C. Query Builder -->
+      <section class="xp-section" id="query-section">
+        <h2>③ Query Builder</h2>
+        <p>Configure a query and hit Execute to watch the pipeline animate.</p>
+        <div class="xp-card qe-builder-card">
+          <div class="qe-query-preview" id="query-preview"></div>
+          <div class="qe-builder-grid">
+            <div class="qe-control-group">
+              <label class="xp-label" for="metric-select">Metric</label>
+              <select class="xp-select" id="metric-select">
+                <option value="http_requests">http_requests</option>
+                <option value="cpu_usage">cpu_usage</option>
+                <option value="memory_bytes">memory_bytes</option>
+              </select>
+            </div>
+
+            <div class="qe-control-group qe-filters-group">
+              <label class="xp-label">Label Filters</label>
+              <div id="filter-rows"></div>
+              <button type="button" class="xp-btn qe-btn-add-filter" id="btn-add-filter">+ Add Filter</button>
+            </div>
+
+            <div class="qe-control-group">
+              <label class="xp-label" for="range-select">Time Range</label>
+              <select class="xp-select" id="range-select">
+                <option value="3">Last 3 hours</option>
+                <option value="5">Last 5 hours</option>
+              </select>
+            </div>
+
+            <div class="qe-control-group">
+              <label class="xp-label" for="step-select">Step</label>
+              <select class="xp-select" id="step-select">
+                <option value="30">30 min</option>
+                <option value="60">1 hour</option>
+              </select>
+            </div>
+
+            <div class="qe-control-group">
+              <label class="xp-label" for="agg-select">Aggregation</label>
+              <select class="xp-select" id="agg-select">
+                <option value="sum">sum</option>
+                <option value="avg">avg</option>
+                <option value="max">max</option>
+                <option value="min">min</option>
+              </select>
+            </div>
+          </div>
+          <button type="button" class="xp-btn xp-btn-primary qe-btn-execute" id="btn-execute">▶ Execute Query</button>
+        </div>
+      </section>
+
+      <!-- D. Stage 1: Label Matching & Postings Intersection -->
+      <section class="xp-section" id="stage-match-section" hidden>
+        <h2>④ Label Matching &amp; Postings Intersection</h2>
+        <p id="match-description"></p>
+        <div class="xp-card qe-match-card" id="match-viz"></div>
+        <div class="qe-match-summary" id="match-summary"></div>
+      </section>
+
+      <!-- E. Stage 2: Chunk Pruning -->
+      <section class="xp-section" id="stage-prune-section" hidden>
+        <h2>⑤ Chunk Pruning</h2>
+        <p id="prune-description"></p>
+        <div class="xp-card qe-prune-card" id="prune-viz"></div>
+        <div class="qe-match-summary" id="prune-summary"></div>
+      </section>
+
+      <!-- F. Stage 3: Aggregation -->
+      <section class="xp-section" id="stage-agg-section" hidden>
+        <h2>⑥ Step-Aligned Aggregation</h2>
+        <p id="agg-description"></p>
+        <div class="xp-card qe-agg-card" id="agg-viz"></div>
+      </section>
+
+      <!-- G. Results -->
+      <section class="xp-section" id="results-section" hidden>
+        <h2>⑦ Results</h2>
+        <div class="xp-stats-row" id="result-stats"></div>
+        <div class="xp-card qe-sparkline-card">
+          <canvas id="result-sparkline" height="160"></canvas>
+        </div>
+        <div class="qe-result-table" id="result-table"></div>
+      </section>
+
+      <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
+        <p style="font-size: 13px; color: var(--xp-text-dim);">
+          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+        </p>
+      </footer>
+
+    </div>
+    <script type="module" src="query-experience.js"></script>
+  </body>
+</html>

--- a/site/tsdb-engine/learn/query-engine/index.html
+++ b/site/tsdb-engine/learn/query-engine/index.html
@@ -130,8 +130,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/query-engine/query-experience.css
+++ b/site/tsdb-engine/learn/query-engine/query-experience.css
@@ -1,0 +1,582 @@
+/* ─── Query Engine Experience ─────────────────────────────────────── */
+
+/* ─── Query Preview Bar ───────────────────────────────────────────── */
+.qe-query-preview {
+  font-family: var(--xp-mono);
+  font-size: 14px;
+  padding: 12px 16px;
+  background: var(--xp-bg);
+  border: 1px solid var(--xp-border-strong);
+  border-radius: var(--xp-radius-sm);
+  margin-bottom: 20px;
+  color: var(--xp-accent-light);
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.qe-query-preview .qp-metric {
+  color: var(--xp-success);
+  font-weight: 500;
+}
+
+.qe-query-preview .qp-label {
+  color: var(--xp-warn);
+}
+
+.qe-query-preview .qp-value {
+  color: #c4b5fd;
+}
+
+.qe-query-preview .qp-op {
+  color: var(--xp-text-dim);
+}
+
+.qe-query-preview .qp-fn {
+  color: var(--xp-accent);
+  font-weight: 600;
+}
+
+/* ─── Builder Grid ────────────────────────────────────────────────── */
+.qe-builder-card {
+  padding: 24px;
+}
+
+.qe-builder-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.qe-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.qe-filters-group {
+  grid-column: 1 / -1;
+}
+
+.qe-filter-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.qe-filter-row .xp-select {
+  flex: 1;
+  min-width: 0;
+}
+
+.qe-filter-eq {
+  color: var(--xp-text-dim);
+  font-family: var(--xp-mono);
+  font-size: 14px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.qe-btn-remove-filter {
+  background: none;
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-xs);
+  color: var(--xp-error);
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: 13px;
+  line-height: 1;
+  transition: all 150ms;
+  flex-shrink: 0;
+}
+
+.qe-btn-remove-filter:hover {
+  background: var(--xp-error-glow);
+  border-color: var(--xp-error);
+}
+
+.qe-btn-add-filter {
+  font-size: 12px;
+  padding: 4px 12px;
+  align-self: flex-start;
+}
+
+.qe-btn-execute {
+  font-size: 15px;
+  padding: 12px 28px;
+}
+
+/* ─── Dataset Card ────────────────────────────────────────────────── */
+.qe-dataset-card {
+  overflow-x: auto;
+}
+
+.qe-dataset-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.qe-dataset-table th {
+  text-align: left;
+  padding: 8px 10px;
+  font-weight: 600;
+  color: var(--xp-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 10px;
+  border-bottom: 1px solid var(--xp-border-strong);
+  white-space: nowrap;
+}
+
+.qe-dataset-table td {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--xp-border);
+  color: var(--xp-text-muted);
+  font-family: var(--xp-mono);
+  font-size: 11px;
+}
+
+.qe-dataset-table tr:hover td {
+  background: var(--xp-accent-glow);
+}
+
+.qe-dataset-table .metric-name {
+  color: var(--xp-success);
+  font-weight: 500;
+}
+
+.qe-dataset-table .label-pill {
+  display: inline-block;
+  padding: 1px 6px;
+  background: var(--xp-surface-raised);
+  border: 1px solid var(--xp-border);
+  border-radius: 99px;
+  font-size: 10px;
+  margin-right: 4px;
+  white-space: nowrap;
+}
+
+/* ─── Pipeline Bar (override) ─────────────────────────────────────── */
+#pipeline-bar .xp-pipe-stage {
+  min-width: 100px;
+  transition: all 300ms ease;
+}
+
+#pipeline-bar .xp-pipe-stage.done {
+  border-color: var(--xp-success);
+  background: var(--xp-success-glow);
+}
+
+#pipeline-bar .xp-pipe-stage.done .stage-label {
+  color: var(--xp-success);
+}
+
+#pipeline-bar .xp-pipe-stage.active {
+  animation: qe-pulse-stage 800ms ease infinite;
+}
+
+@keyframes qe-pulse-stage {
+  0%,
+  100% {
+    box-shadow: 0 0 12px rgba(96, 165, 250, 0.15);
+  }
+  50% {
+    box-shadow: 0 0 28px rgba(96, 165, 250, 0.35);
+  }
+}
+
+/* ─── Label Matching / Postings Visualization ─────────────────────── */
+.qe-match-card {
+  overflow-x: auto;
+}
+
+.qe-postings-group {
+  margin-bottom: 20px;
+}
+
+.qe-postings-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--xp-text);
+  margin-bottom: 8px;
+}
+
+.qe-postings-label .filter-text {
+  color: var(--xp-warn);
+  font-family: var(--xp-mono);
+}
+
+.qe-postings-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.qe-posting-id {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 28px;
+  font-family: var(--xp-mono);
+  font-size: 11px;
+  font-weight: 500;
+  border-radius: var(--xp-radius-xs);
+  background: var(--xp-surface-raised);
+  border: 1px solid var(--xp-border);
+  color: var(--xp-text-dim);
+  transition: all 250ms ease;
+  flex-shrink: 0;
+}
+
+.qe-posting-id.color-a {
+  background: rgba(96, 165, 250, 0.1);
+  border-color: rgba(96, 165, 250, 0.25);
+  color: var(--xp-accent);
+}
+
+.qe-posting-id.color-b {
+  background: rgba(167, 139, 250, 0.1);
+  border-color: rgba(167, 139, 250, 0.25);
+  color: var(--tier-2);
+}
+
+.qe-posting-id.match {
+  background: var(--xp-success-glow);
+  border-color: rgba(52, 211, 153, 0.5);
+  color: var(--xp-success);
+  font-weight: 700;
+  box-shadow: 0 0 10px rgba(52, 211, 153, 0.2);
+}
+
+.qe-posting-id.scanning {
+  outline: 2px solid var(--xp-accent);
+  outline-offset: 1px;
+}
+
+.qe-posting-id.dimmed {
+  opacity: 0.25;
+}
+
+.qe-intersection-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--xp-text-dim);
+  margin-top: 12px;
+  margin-bottom: 6px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.qe-intersection-label .arrow-icon {
+  color: var(--xp-success);
+}
+
+.qe-match-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.qe-match-summary .qe-summary-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-family: var(--xp-mono);
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  color: var(--xp-text-muted);
+}
+
+.qe-match-summary .qe-summary-chip strong {
+  color: var(--xp-success);
+  font-weight: 700;
+}
+
+/* ─── Chunk Pruning Visualization ─────────────────────────────────── */
+.qe-prune-card {
+  position: relative;
+  overflow-x: auto;
+}
+
+.qe-prune-timeline {
+  position: relative;
+  padding: 16px 0;
+}
+
+.qe-prune-axis {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--xp-mono);
+  font-size: 10px;
+  color: var(--xp-text-dim);
+  margin-bottom: 12px;
+  padding: 0 4px;
+}
+
+.qe-prune-series-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.qe-prune-series-label {
+  font-family: var(--xp-mono);
+  font-size: 10px;
+  color: var(--xp-text-dim);
+  width: 36px;
+  flex-shrink: 0;
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.qe-prune-chunks-bar {
+  flex: 1;
+  display: flex;
+  gap: 2px;
+  position: relative;
+  height: 20px;
+}
+
+.qe-prune-chunk {
+  flex: 1;
+  height: 100%;
+  border-radius: 3px;
+  background: var(--xp-surface-raised);
+  border: 1px solid var(--xp-border);
+  transition: all 400ms ease;
+  position: relative;
+}
+
+.qe-prune-chunk.in-range {
+  background: var(--xp-success-glow);
+  border-color: rgba(52, 211, 153, 0.4);
+}
+
+.qe-prune-chunk.pruned {
+  opacity: 0.2;
+}
+
+.qe-prune-range-overlay {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  background: rgba(96, 165, 250, 0.08);
+  border-left: 2px solid var(--xp-accent);
+  border-right: 2px solid var(--xp-accent);
+  border-radius: 3px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* ─── Step-Aligned Aggregation ────────────────────────────────────── */
+.qe-agg-card {
+  overflow: hidden;
+}
+
+.qe-agg-buckets {
+  display: flex;
+  gap: 8px;
+  padding: 8px 0;
+  overflow-x: auto;
+}
+
+.qe-agg-bucket {
+  flex: 1;
+  min-width: 100px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 8px;
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  transition: all 300ms ease;
+}
+
+.qe-agg-bucket.active {
+  border-color: var(--xp-accent);
+  background: var(--xp-accent-glow);
+}
+
+.qe-agg-bucket.done {
+  border-color: var(--xp-success);
+  background: var(--xp-success-glow);
+}
+
+.qe-bucket-label {
+  font-size: 10px;
+  color: var(--xp-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.qe-bucket-time {
+  font-family: var(--xp-mono);
+  font-size: 9px;
+  color: var(--xp-text-dim);
+}
+
+.qe-bucket-dots {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2px;
+  min-height: 24px;
+  padding: 4px 0;
+}
+
+.qe-sample-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--xp-accent);
+  opacity: 0;
+  transition: opacity 100ms ease;
+}
+
+.qe-sample-dot.visible {
+  opacity: 1;
+}
+
+.qe-bucket-accumulator {
+  font-family: var(--xp-mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: #fff;
+  min-height: 20px;
+  transition: all 200ms;
+}
+
+.qe-bucket-count {
+  font-family: var(--xp-mono);
+  font-size: 10px;
+  color: var(--xp-text-dim);
+}
+
+/* ─── Results ─────────────────────────────────────────────────────── */
+.qe-sparkline-card {
+  padding: 16px;
+}
+
+.qe-sparkline-card canvas {
+  width: 100%;
+  display: block;
+  border-radius: var(--xp-radius-sm);
+}
+
+.qe-result-table {
+  margin-top: 16px;
+  overflow-x: auto;
+}
+
+.qe-result-table table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.qe-result-table th {
+  text-align: left;
+  padding: 8px 12px;
+  font-weight: 600;
+  color: var(--xp-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 10px;
+  border-bottom: 1px solid var(--xp-border-strong);
+}
+
+.qe-result-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--xp-border);
+  color: var(--xp-text);
+  font-family: var(--xp-mono);
+  font-size: 12px;
+}
+
+.qe-result-table tr:hover td {
+  background: var(--xp-accent-glow);
+}
+
+/* ─── Flash Animations ────────────────────────────────────────────── */
+@keyframes qe-flash-green {
+  0% {
+    box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.6);
+  }
+  50% {
+    box-shadow: 0 0 16px 4px rgba(52, 211, 153, 0.3);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(52, 211, 153, 0);
+  }
+}
+
+@keyframes qe-flash-accent {
+  0% {
+    box-shadow: 0 0 0 0 rgba(96, 165, 250, 0.6);
+  }
+  50% {
+    box-shadow: 0 0 16px 4px rgba(96, 165, 250, 0.3);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(96, 165, 250, 0);
+  }
+}
+
+.qe-flash-green {
+  animation: qe-flash-green 500ms ease;
+}
+
+.qe-flash-accent {
+  animation: qe-flash-accent 500ms ease;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .qe-builder-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .qe-filter-row {
+    flex-wrap: wrap;
+  }
+
+  .qe-agg-buckets {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+
+  .qe-agg-bucket {
+    min-width: 80px;
+  }
+
+  .qe-prune-series-label {
+    width: 24px;
+    font-size: 9px;
+  }
+
+  #pipeline-bar .xp-pipe-stage {
+    min-width: 70px;
+    padding: 8px 10px;
+  }
+
+  #pipeline-bar .xp-pipe-stage .stage-label {
+    font-size: 9px;
+  }
+}

--- a/site/tsdb-engine/learn/query-engine/query-experience.js
+++ b/site/tsdb-engine/learn/query-engine/query-experience.js
@@ -6,7 +6,7 @@
  * Stats Check → Decode → Step-Aligned Aggregation
  */
 
-import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, Stepper } from "../shared.js";
+import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, revealSection, Stepper } from "../shared.js";
 
 /* ═══════════════════════════════════════════════════════════════════════
    A. DATASET GENERATION
@@ -748,7 +748,7 @@ function showResults(aggResults, matchedCount, pruneStats, aggFn, stepMinutes, q
   tableContainer.innerHTML = "";
   tableContainer.appendChild(table);
 
-  section.scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection(section);
 }
 
 /* ═══════════════════════════════════════════════════════════════════════
@@ -789,13 +789,13 @@ async function executeQuery() {
 
   const { intersection } = resolvePostings(metric, filters);
   await animateLabelMatch(metric, filters);
-  $("#stage-match-section").scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection($("#stage-match-section"));
   await sleep(600);
 
   // Stage 2: Chunk Pruning
   stepper.goto(2);
   const pruneStats = await animateChunkPruning(intersection, queryRangeHours);
-  $("#stage-prune-section").scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection($("#stage-prune-section"));
   await sleep(600);
 
   // Stage 3: Stats Check (brief pause — conceptual)
@@ -809,7 +809,7 @@ async function executeQuery() {
   // Stage 5: Aggregation
   stepper.goto(5);
   const aggResults = await animateAggregation(intersection, queryRangeHours, stepMinutes, aggFn);
-  $("#stage-agg-section").scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection($("#stage-agg-section"));
   await sleep(400);
 
   // Show results

--- a/site/tsdb-engine/learn/query-engine/query-experience.js
+++ b/site/tsdb-engine/learn/query-engine/query-experience.js
@@ -6,7 +6,7 @@
  * Stats Check → Decode → Step-Aligned Aggregation
  */
 
-import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, revealSection, Stepper } from "../shared.js";
+import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, revealSection, sleep, Stepper } from "../shared.js";
 
 /* ═══════════════════════════════════════════════════════════════════════
    A. DATASET GENERATION
@@ -823,10 +823,6 @@ async function executeQuery() {
 /* ═══════════════════════════════════════════════════════════════════════
    HELPERS
    ═══════════════════════════════════════════════════════════════════════ */
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 function fmtHour(ms) {
   const d = new Date(ms);

--- a/site/tsdb-engine/learn/query-engine/query-experience.js
+++ b/site/tsdb-engine/learn/query-engine/query-experience.js
@@ -1,0 +1,923 @@
+/**
+ * Query Engine — Interactive Experience
+ *
+ * Demonstrates the end-to-end query flow in a TSDB:
+ * Label Match → Postings Intersection → Chunk Pruning →
+ * Stats Check → Decode → Step-Aligned Aggregation
+ */
+
+import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, Stepper } from "../shared.js";
+
+/* ═══════════════════════════════════════════════════════════════════════
+   A. DATASET GENERATION
+   ═══════════════════════════════════════════════════════════════════════ */
+
+const METRICS = ["http_requests", "cpu_usage", "memory_bytes"];
+const REGIONS = ["us-east-1", "us-west-2"];
+const JOBS = ["api", "web", "worker"];
+const CHUNKS_PER_SERIES = 5;
+const SAMPLES_PER_CHUNK = 240; // 15s interval × 1 hour
+const CHUNK_DURATION_MS = 3_600_000; // 1 hour
+
+function generateDataset() {
+  const series = [];
+  let nextId = 0;
+
+  for (const metric of METRICS) {
+    for (const region of REGIONS) {
+      for (const job of JOBS) {
+        series.push({
+          id: nextId++,
+          metric,
+          labels: { region, job },
+        });
+      }
+    }
+  }
+
+  // Generate chunks for each series
+  const baseTime = Date.now() - CHUNKS_PER_SERIES * CHUNK_DURATION_MS;
+
+  for (const s of series) {
+    s.chunks = [];
+    for (let c = 0; c < CHUNKS_PER_SERIES; c++) {
+      const startTime = baseTime + c * CHUNK_DURATION_MS;
+      const endTime = startTime + CHUNK_DURATION_MS;
+      const samples = generateChunkSamples(s.metric, s.id, c);
+      const min = Math.min(...samples);
+      const max = Math.max(...samples);
+      const sum = samples.reduce((a, b) => a + b, 0);
+      s.chunks.push({
+        chunkIndex: c,
+        startTime,
+        endTime,
+        sampleCount: samples.length,
+        samples,
+        stats: { min, max, sum, count: samples.length },
+      });
+    }
+  }
+
+  return series;
+}
+
+function generateChunkSamples(metric, seriesId, chunkIdx) {
+  const samples = [];
+  const seed = seriesId * 100 + chunkIdx * 17;
+
+  for (let i = 0; i < SAMPLES_PER_CHUNK; i++) {
+    const t = i / SAMPLES_PER_CHUNK;
+    const pseudoRand = seededRand(seed + i);
+
+    switch (metric) {
+      case "http_requests":
+        samples.push(
+          Math.max(
+            0,
+            50 + seriesId * 12 + Math.sin(t * 6.28 + chunkIdx) * 30 + (pseudoRand - 0.5) * 20
+          )
+        );
+        break;
+      case "cpu_usage":
+        samples.push(
+          Math.max(
+            0,
+            Math.min(
+              100,
+              35 + seriesId * 3 + Math.sin(t * 3.14 + chunkIdx * 0.7) * 25 + (pseudoRand - 0.5) * 10
+            )
+          )
+        );
+        break;
+      case "memory_bytes":
+        samples.push(
+          Math.max(
+            0,
+            500_000_000 +
+              seriesId * 80_000_000 +
+              Math.sin(t * 2.5 + chunkIdx) * 100_000_000 +
+              (pseudoRand - 0.5) * 50_000_000
+          )
+        );
+        break;
+    }
+  }
+  return samples;
+}
+
+function seededRand(seed) {
+  const x = Math.sin(seed) * 10000;
+  return x - Math.floor(x);
+}
+
+const DATASET = generateDataset();
+
+/* ─── Postings index: label→value → sorted series IDs ─────────────── */
+const POSTINGS = new Map();
+
+function buildPostingsIndex() {
+  for (const s of DATASET) {
+    // metric name as __name__
+    addPosting("__name__", s.metric, s.id);
+    for (const [k, v] of Object.entries(s.labels)) {
+      addPosting(k, v, s.id);
+    }
+  }
+}
+
+function addPosting(label, value, seriesId) {
+  const key = `${label}=${value}`;
+  if (!POSTINGS.has(key)) POSTINGS.set(key, []);
+  const list = POSTINGS.get(key);
+  if (!list.includes(seriesId)) list.push(seriesId);
+  list.sort((a, b) => a - b);
+}
+
+buildPostingsIndex();
+
+/* ═══════════════════════════════════════════════════════════════════════
+   B. PIPELINE STAGES
+   ═══════════════════════════════════════════════════════════════════════ */
+
+const STAGES = [
+  { icon: "🏷", label: "Label Match" },
+  { icon: "∩", label: "Postings" },
+  { icon: "✂", label: "Prune Chunks" },
+  { icon: "📊", label: "Stats Check" },
+  { icon: "📦", label: "Decode" },
+  { icon: "Σ", label: "Aggregate" },
+];
+
+let stepper;
+
+function buildPipeline() {
+  const bar = $("#pipeline-bar");
+  bar.innerHTML = "";
+
+  STAGES.forEach((stage, i) => {
+    if (i > 0) {
+      bar.appendChild(el("span", { class: "xp-pipe-arrow", "aria-hidden": "true" }, "→"));
+    }
+    const stageEl = el(
+      "div",
+      { class: "xp-pipe-stage", "data-stage": String(i) },
+      el("span", { class: "stage-icon" }, stage.icon),
+      el("span", { class: "stage-label" }, stage.label)
+    );
+    bar.appendChild(stageEl);
+  });
+
+  stepper = new Stepper(STAGES.length, (current) => {
+    $$(".xp-pipe-stage", bar).forEach((el, i) => {
+      el.classList.remove("active", "done");
+      if (i < current) el.classList.add("done");
+      else if (i === current) el.classList.add("active");
+    });
+  });
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   C. QUERY BUILDER
+   ═══════════════════════════════════════════════════════════════════════ */
+
+const filters = [{ label: "region", value: "us-west-2" }];
+
+function getAvailableLabels() {
+  return ["region", "job"];
+}
+
+function getValuesForLabel(label) {
+  if (label === "region") return REGIONS;
+  if (label === "job") return JOBS;
+  return [];
+}
+
+function renderFilterRows() {
+  const container = $("#filter-rows");
+  container.innerHTML = "";
+
+  filters.forEach((f, i) => {
+    const labelSelect = el("select", {
+      class: "xp-select",
+      "data-filter-idx": String(i),
+      "data-field": "label",
+    });
+    for (const lab of getAvailableLabels()) {
+      const opt = el("option", { value: lab }, lab);
+      if (lab === f.label) opt.selected = true;
+      labelSelect.appendChild(opt);
+    }
+
+    const valSelect = el("select", {
+      class: "xp-select",
+      "data-filter-idx": String(i),
+      "data-field": "value",
+    });
+    for (const val of getValuesForLabel(f.label)) {
+      const opt = el("option", { value: val }, val);
+      if (val === f.value) opt.selected = true;
+      valSelect.appendChild(opt);
+    }
+
+    const removeBtn = el(
+      "button",
+      { class: "qe-btn-remove-filter", "data-filter-idx": String(i) },
+      "×"
+    );
+
+    const row = el(
+      "div",
+      { class: "qe-filter-row" },
+      labelSelect,
+      el("span", { class: "qe-filter-eq" }, "="),
+      valSelect,
+      removeBtn
+    );
+    container.appendChild(row);
+
+    labelSelect.addEventListener("change", () => {
+      filters[i].label = labelSelect.value;
+      filters[i].value = getValuesForLabel(labelSelect.value)[0] || "";
+      renderFilterRows();
+      updateQueryPreview();
+    });
+
+    valSelect.addEventListener("change", () => {
+      filters[i].value = valSelect.value;
+      updateQueryPreview();
+    });
+
+    removeBtn.addEventListener("click", () => {
+      filters.splice(i, 1);
+      renderFilterRows();
+      updateQueryPreview();
+    });
+  });
+}
+
+function updateQueryPreview() {
+  const metric = $("#metric-select").value;
+  const agg = $("#agg-select").value;
+  const step = $("#step-select").value;
+  const range = $("#range-select").value;
+
+  let filterStr = "";
+  if (filters.length > 0) {
+    const parts = filters.map(
+      (f) =>
+        `<span class="qp-label">${f.label}</span><span class="qp-op">=</span><span class="qp-value">"${f.value}"</span>`
+    );
+    filterStr = `{${parts.join('<span class="qp-op">, </span>')}}`;
+  }
+
+  const preview = $("#query-preview");
+  preview.innerHTML = `<span class="qp-fn">${agg}</span>(<span class="qp-metric">${metric}</span>${filterStr}[<span class="qp-value">${range}h</span>:<span class="qp-value">${step}m</span>])`;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   D. STAGE 1 — LABEL MATCHING & POSTINGS INTERSECTION
+   ═══════════════════════════════════════════════════════════════════════ */
+
+function intersectSorted(a, b) {
+  const result = [];
+  let i = 0,
+    j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      result.push(a[i]);
+      i++;
+      j++;
+    } else if (a[i] < b[j]) i++;
+    else j++;
+  }
+  return result;
+}
+
+function resolvePostings(metric, labelFilters) {
+  // Start with the metric postings
+  const metricKey = `__name__=${metric}`;
+  let current = POSTINGS.get(metricKey) || [];
+  const lists = [{ key: metricKey, ids: [...current] }];
+
+  for (const f of labelFilters) {
+    const key = `${f.label}=${f.value}`;
+    const plist = POSTINGS.get(key) || [];
+    lists.push({ key, ids: [...plist] });
+    current = intersectSorted(current, plist);
+  }
+
+  return { lists, intersection: current };
+}
+
+async function animateLabelMatch(metric, labelFilters) {
+  const section = $("#stage-match-section");
+  section.hidden = false;
+
+  const { lists, intersection } = resolvePostings(metric, labelFilters);
+  const vizContainer = $("#match-viz");
+  vizContainer.innerHTML = "";
+
+  // Only show filter-level postings (skip __name__ for visual clarity if there are filters)
+  const displayLists = lists.length > 1 ? lists.slice(1) : lists;
+  const colors = ["color-a", "color-b"];
+
+  // Description
+  const desc = $("#match-description");
+  desc.textContent = `Each label filter maps to a sorted postings list. We intersect them using galloping search.`;
+
+  // Render postings lists
+  const postingsGroups = [];
+  displayLists.forEach((pl, idx) => {
+    const group = el("div", { class: "qe-postings-group" });
+    const label = el(
+      "div",
+      { class: "qe-postings-label" },
+      `Postings for `,
+      el("span", { class: "filter-text" }, pl.key),
+      ` (${pl.ids.length} series)`
+    );
+    group.appendChild(label);
+
+    const row = el("div", { class: "qe-postings-row" });
+    const idEls = pl.ids.map((id) => {
+      const idEl = el("div", { class: `qe-posting-id ${colors[idx % 2]}` }, String(id));
+      row.appendChild(idEl);
+      return { id, el: idEl };
+    });
+    group.appendChild(row);
+    vizContainer.appendChild(group);
+    postingsGroups.push({ ids: pl.ids, idEls, key: pl.key });
+  });
+
+  // Intersection result row
+  const intLabel = el(
+    "div",
+    { class: "qe-intersection-label" },
+    el("span", { class: "arrow-icon" }, "↓"),
+    " Intersection Result"
+  );
+  vizContainer.appendChild(intLabel);
+
+  const intRow = el("div", { class: "qe-postings-row" });
+  vizContainer.appendChild(intRow);
+
+  // Animate the intersection
+  if (displayLists.length >= 2) {
+    await animateGallopingIntersection(postingsGroups, intersection, intRow);
+  } else {
+    // Single list = all match
+    for (const id of displayLists[0]?.ids || intersection) {
+      const idEl = el("div", { class: "qe-posting-id match" }, String(id));
+      intRow.appendChild(idEl);
+    }
+  }
+
+  // Summary
+  const summary = $("#match-summary");
+  summary.innerHTML = "";
+  for (const pl of displayLists) {
+    summary.appendChild(
+      el(
+        "div",
+        { class: "qe-summary-chip" },
+        el("strong", {}, String(pl.ids.length)),
+        ` match ${pl.key}`
+      )
+    );
+  }
+  summary.appendChild(
+    el(
+      "div",
+      { class: "qe-summary-chip" },
+      "→ ",
+      el("strong", {}, String(intersection.length)),
+      " in intersection"
+    )
+  );
+}
+
+async function animateGallopingIntersection(groups, intersection, resultRow) {
+  // We animate through the first two lists
+  const listA = groups[0];
+  const listB = groups[1];
+  let i = 0,
+    j = 0;
+
+  const _interSet = new Set(intersection);
+
+  while (i < listA.ids.length && j < listB.ids.length) {
+    // Highlight current scanning position
+    listA.idEls[i].el.classList.add("scanning");
+    listB.idEls[j].el.classList.add("scanning");
+
+    await sleep(80);
+
+    if (listA.ids[i] === listB.ids[j]) {
+      // Match
+      listA.idEls[i].el.classList.remove("scanning");
+      listA.idEls[i].el.classList.add("match");
+      listB.idEls[j].el.classList.remove("scanning");
+      listB.idEls[j].el.classList.add("match");
+
+      const matchEl = el(
+        "div",
+        { class: "qe-posting-id match qe-flash-green" },
+        String(listA.ids[i])
+      );
+      resultRow.appendChild(matchEl);
+
+      i++;
+      j++;
+    } else if (listA.ids[i] < listB.ids[j]) {
+      listA.idEls[i].el.classList.remove("scanning");
+      listA.idEls[i].el.classList.add("dimmed");
+      i++;
+    } else {
+      listB.idEls[j].el.classList.remove("scanning");
+      listB.idEls[j].el.classList.add("dimmed");
+      j++;
+    }
+
+    await sleep(50);
+  }
+
+  // Dim remaining
+  while (i < listA.ids.length) {
+    listA.idEls[i].el.classList.add("dimmed");
+    i++;
+  }
+  while (j < listB.ids.length) {
+    listB.idEls[j].el.classList.add("dimmed");
+    j++;
+  }
+
+  // If more than 2 filters, apply further intersection (non-animated)
+  if (groups.length > 2) {
+    const resultIds = [...resultRow.children].map((c) => Number(c.textContent));
+    for (let g = 2; g < groups.length; g++) {
+      const filtered = intersectSorted(resultIds, groups[g].ids);
+      const filteredSet = new Set(filtered);
+      for (const child of [...resultRow.children]) {
+        if (!filteredSet.has(Number(child.textContent))) {
+          child.classList.remove("match");
+          child.classList.add("dimmed");
+        }
+      }
+    }
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   E. STAGE 2 — CHUNK PRUNING
+   ═══════════════════════════════════════════════════════════════════════ */
+
+async function animateChunkPruning(matchedSeriesIds, queryRangeHours) {
+  const section = $("#stage-prune-section");
+  section.hidden = false;
+
+  const vizContainer = $("#prune-viz");
+  vizContainer.innerHTML = "";
+
+  const now = Date.now();
+  const rangeStart = now - queryRangeHours * CHUNK_DURATION_MS;
+  const rangeEnd = now;
+
+  // We'll show a subset of matched series (max 6 for readability)
+  const displayIds = matchedSeriesIds.slice(0, 6);
+  const matchedSeries = displayIds.map((id) => DATASET[id]);
+
+  // Time axis min/max (full range across all chunks)
+  const allStart = Math.min(...matchedSeries.flatMap((s) => s.chunks.map((c) => c.startTime)));
+  const allEnd = Math.max(...matchedSeries.flatMap((s) => s.chunks.map((c) => c.endTime)));
+
+  const desc = $("#prune-description");
+  desc.textContent = `Binary-search each series' chunk list to find chunks overlapping the query time range [${fmtHour(rangeStart)} – ${fmtHour(rangeEnd)}].`;
+
+  const timeline = el("div", { class: "qe-prune-timeline" });
+
+  // Time axis labels
+  const axisRow = el("div", { class: "qe-prune-axis" });
+  for (let h = 0; h <= CHUNKS_PER_SERIES; h++) {
+    const t = allStart + (h / CHUNKS_PER_SERIES) * (allEnd - allStart);
+    axisRow.appendChild(el("span", {}, fmtHour(t)));
+  }
+  timeline.appendChild(axisRow);
+
+  let totalChunks = 0;
+  let inRangeCount = 0;
+  let prunedCount = 0;
+  const allChunkEls = [];
+
+  // Series rows
+  for (const s of matchedSeries) {
+    const row = el("div", { class: "qe-prune-series-row" });
+    const label = el("div", { class: "qe-prune-series-label" }, `S${s.id}`);
+    row.appendChild(label);
+
+    const chunksBar = el("div", { class: "qe-prune-chunks-bar" });
+
+    for (const chunk of s.chunks) {
+      totalChunks++;
+      const overlaps = chunk.endTime > rangeStart && chunk.startTime < rangeEnd;
+      const chunkEl = el("div", { class: "qe-prune-chunk" });
+      chunksBar.appendChild(chunkEl);
+      allChunkEls.push({ el: chunkEl, overlaps });
+
+      if (overlaps) inRangeCount++;
+      else prunedCount++;
+    }
+
+    row.appendChild(chunksBar);
+    timeline.appendChild(row);
+  }
+
+  vizContainer.appendChild(timeline);
+
+  // Animate chunks lighting up / dimming
+  for (const item of allChunkEls) {
+    if (item.overlaps) {
+      item.el.classList.add("in-range");
+    } else {
+      item.el.classList.add("pruned");
+    }
+    await sleep(30);
+  }
+
+  // Summary
+  const summary = $("#prune-summary");
+  summary.innerHTML = "";
+  summary.appendChild(
+    el("div", { class: "qe-summary-chip" }, el("strong", {}, String(totalChunks)), " chunks total")
+  );
+  summary.appendChild(
+    el("div", { class: "qe-summary-chip" }, el("strong", {}, String(inRangeCount)), " in range")
+  );
+  summary.appendChild(
+    el("div", { class: "qe-summary-chip" }, el("strong", {}, String(prunedCount)), " pruned")
+  );
+
+  return { totalChunks, inRangeCount, prunedCount };
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   F. STAGE 3 — STEP-ALIGNED AGGREGATION
+   ═══════════════════════════════════════════════════════════════════════ */
+
+async function animateAggregation(matchedSeriesIds, queryRangeHours, stepMinutes, aggFn) {
+  const section = $("#stage-agg-section");
+  section.hidden = false;
+
+  const vizContainer = $("#agg-viz");
+  vizContainer.innerHTML = "";
+
+  const now = Date.now();
+  const rangeStart = now - queryRangeHours * CHUNK_DURATION_MS;
+  const rangeEnd = now;
+  const stepMs = stepMinutes * 60_000;
+  const numBuckets = Math.ceil((rangeEnd - rangeStart) / stepMs);
+
+  const desc = $("#agg-description");
+  desc.textContent = `Dividing the ${queryRangeHours}h range into ${numBuckets} buckets of ${stepMinutes}min each. Folding samples with ${aggFn}().`;
+
+  // Collect all samples in range from matched series
+  const matchedSeries = matchedSeriesIds.map((id) => DATASET[id]);
+  const bucketSamples = Array.from({ length: numBuckets }, () => []);
+
+  for (const s of matchedSeries) {
+    for (const chunk of s.chunks) {
+      if (chunk.endTime <= rangeStart || chunk.startTime >= rangeEnd) continue;
+      const sampleInterval = CHUNK_DURATION_MS / chunk.sampleCount;
+      for (let i = 0; i < chunk.sampleCount; i++) {
+        const t = chunk.startTime + i * sampleInterval;
+        if (t >= rangeStart && t < rangeEnd) {
+          const bucketIdx = Math.min(Math.floor((t - rangeStart) / stepMs), numBuckets - 1);
+          bucketSamples[bucketIdx].push(chunk.samples[i]);
+        }
+      }
+    }
+  }
+
+  // Build bucket elements
+  const bucketsRow = el("div", { class: "qe-agg-buckets" });
+  const bucketEls = [];
+
+  for (let b = 0; b < numBuckets; b++) {
+    const bucketStart = rangeStart + b * stepMs;
+    const bucket = el(
+      "div",
+      { class: "qe-agg-bucket" },
+      el("span", { class: "qe-bucket-label" }, `Bucket ${b}`),
+      el("span", { class: "qe-bucket-time" }, fmtHour(bucketStart))
+    );
+
+    // Sample dots (max 20 shown for visual clarity)
+    const dotCount = Math.min(bucketSamples[b].length, 20);
+    const dotsContainer = el("div", { class: "qe-bucket-dots" });
+    const dots = [];
+    for (let d = 0; d < dotCount; d++) {
+      const dot = el("div", { class: "qe-sample-dot" });
+      dotsContainer.appendChild(dot);
+      dots.push(dot);
+    }
+    bucket.appendChild(dotsContainer);
+
+    const accEl = el("span", { class: "qe-bucket-accumulator" }, "—");
+    bucket.appendChild(accEl);
+
+    const countEl = el("span", { class: "qe-bucket-count" }, "");
+    bucket.appendChild(countEl);
+
+    bucketsRow.appendChild(bucket);
+    bucketEls.push({ el: bucket, dots, accEl, countEl, samples: bucketSamples[b] });
+  }
+
+  vizContainer.appendChild(bucketsRow);
+
+  // Animate bucket by bucket
+  const results = [];
+  for (let b = 0; b < bucketEls.length; b++) {
+    const be = bucketEls[b];
+    be.el.classList.add("active");
+
+    // Animate dots appearing
+    for (const dot of be.dots) {
+      dot.classList.add("visible");
+      await sleep(15);
+    }
+
+    // Compute aggregation
+    const val = computeAgg(be.samples, aggFn);
+    results.push(val);
+
+    be.accEl.textContent = formatAggValue(val, aggFn);
+    be.countEl.textContent = `n=${fmt(be.samples.length)}`;
+    be.el.classList.remove("active");
+    be.el.classList.add("done");
+
+    await sleep(120);
+  }
+
+  return results;
+}
+
+function computeAgg(samples, fn) {
+  if (samples.length === 0) return 0;
+  switch (fn) {
+    case "sum":
+      return samples.reduce((a, b) => a + b, 0);
+    case "avg":
+      return samples.reduce((a, b) => a + b, 0) / samples.length;
+    case "max":
+      return Math.max(...samples);
+    case "min":
+      return Math.min(...samples);
+    default:
+      return 0;
+  }
+}
+
+function formatAggValue(val, fn) {
+  if (fn === "sum") return fmt(val, 1);
+  if (fn === "avg") return val.toFixed(2);
+  if (fn === "max" || fn === "min") return val.toFixed(2);
+  return val.toFixed(2);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   G. RESULTS
+   ═══════════════════════════════════════════════════════════════════════ */
+
+function showResults(aggResults, matchedCount, pruneStats, aggFn, stepMinutes, queryRangeHours) {
+  const section = $("#results-section");
+  section.hidden = false;
+
+  // Stats
+  const _totalSamples = matchedCount * CHUNKS_PER_SERIES * SAMPLES_PER_CHUNK;
+  const decodedChunks = pruneStats.inRangeCount;
+
+  const statsRow = $("#result-stats");
+  statsRow.innerHTML = [
+    { label: "Series Scanned", value: String(matchedCount), color: "var(--xp-accent)" },
+    { label: "Chunks Decoded", value: String(decodedChunks), color: "var(--xp-success)" },
+    { label: "Chunks Pruned", value: String(pruneStats.prunedCount), color: "var(--xp-text-dim)" },
+    { label: "Output Buckets", value: String(aggResults.length), color: "var(--xp-warn)" },
+  ]
+    .map(
+      (s) => `
+    <div class="xp-stat">
+      <span class="xp-stat-label">${s.label}</span>
+      <span class="xp-stat-value" style="color:${s.color}">${s.value}</span>
+    </div>
+  `
+    )
+    .join("");
+
+  // Sparkline
+  drawSparkline($("#result-sparkline"), aggResults, {
+    color: "#34d399",
+    fillAlpha: 0.15,
+    lineWidth: 2,
+  });
+
+  // Results table
+  const now = Date.now();
+  const rangeStart = now - queryRangeHours * CHUNK_DURATION_MS;
+  const stepMs = stepMinutes * 60_000;
+
+  const tableContainer = $("#result-table");
+  const table = el("table");
+  const thead = el("thead");
+  thead.appendChild(
+    el("tr", {}, el("th", {}, "Bucket"), el("th", {}, "Time"), el("th", {}, `${aggFn}()`))
+  );
+  table.appendChild(thead);
+
+  const tbody = el("tbody");
+  aggResults.forEach((val, i) => {
+    const t = rangeStart + i * stepMs;
+    const row = el(
+      "tr",
+      {},
+      el("td", {}, String(i)),
+      el("td", {}, fmtHour(t)),
+      el("td", {}, formatAggValue(val, aggFn))
+    );
+    tbody.appendChild(row);
+  });
+  table.appendChild(tbody);
+  tableContainer.innerHTML = "";
+  tableContainer.appendChild(table);
+
+  section.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   QUERY EXECUTION ORCHESTRATOR
+   ═══════════════════════════════════════════════════════════════════════ */
+
+let _running = false;
+
+async function executeQuery() {
+  if (_running) return;
+  _running = true;
+
+  const btn = $("#btn-execute");
+  btn.disabled = true;
+  btn.textContent = "⏳ Running…";
+
+  // Hide previous results
+  for (const id of [
+    "stage-match-section",
+    "stage-prune-section",
+    "stage-agg-section",
+    "results-section",
+  ]) {
+    $(` #${id}`).hidden = true;
+  }
+
+  const metric = $("#metric-select").value;
+  const queryRangeHours = Number($("#range-select").value);
+  const stepMinutes = Number($("#step-select").value);
+  const aggFn = $("#agg-select").value;
+
+  stepper.reset();
+
+  // Stage 0 & 1: Label Match + Postings Intersection
+  stepper.goto(0);
+  await sleep(400);
+  stepper.goto(1);
+
+  const { intersection } = resolvePostings(metric, filters);
+  await animateLabelMatch(metric, filters);
+  $("#stage-match-section").scrollIntoView({ behavior: "smooth", block: "start" });
+  await sleep(600);
+
+  // Stage 2: Chunk Pruning
+  stepper.goto(2);
+  const pruneStats = await animateChunkPruning(intersection, queryRangeHours);
+  $("#stage-prune-section").scrollIntoView({ behavior: "smooth", block: "start" });
+  await sleep(600);
+
+  // Stage 3: Stats Check (brief pause — conceptual)
+  stepper.goto(3);
+  await sleep(500);
+
+  // Stage 4: Decode (brief pause — conceptual)
+  stepper.goto(4);
+  await sleep(500);
+
+  // Stage 5: Aggregation
+  stepper.goto(5);
+  const aggResults = await animateAggregation(intersection, queryRangeHours, stepMinutes, aggFn);
+  $("#stage-agg-section").scrollIntoView({ behavior: "smooth", block: "start" });
+  await sleep(400);
+
+  // Show results
+  showResults(aggResults, intersection.length, pruneStats, aggFn, stepMinutes, queryRangeHours);
+
+  btn.disabled = false;
+  btn.textContent = "▶ Execute Query";
+  _running = false;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   HELPERS
+   ═══════════════════════════════════════════════════════════════════════ */
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function fmtHour(ms) {
+  const d = new Date(ms);
+  return d.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   DATASET SUMMARY
+   ═══════════════════════════════════════════════════════════════════════ */
+
+function renderDatasetSummary() {
+  const totalSeries = DATASET.length;
+  const totalChunks = totalSeries * CHUNKS_PER_SERIES;
+  const totalSamples = totalChunks * SAMPLES_PER_CHUNK;
+
+  const statsRow = $("#dataset-stats");
+  statsRow.innerHTML = [
+    { label: "Metrics", value: String(METRICS.length) },
+    { label: "Series", value: String(totalSeries) },
+    { label: "Chunks", value: fmt(totalChunks) },
+    { label: "Samples", value: fmt(totalSamples) },
+  ]
+    .map(
+      (s) => `
+    <div class="xp-stat">
+      <span class="xp-stat-label">${s.label}</span>
+      <span class="xp-stat-value">${s.value}</span>
+    </div>
+  `
+    )
+    .join("");
+
+  // Compact dataset table
+  const detail = $("#dataset-detail");
+
+  // Group by metric
+  const rows = DATASET.map((s) => {
+    const labelPills = Object.entries(s.labels)
+      .map(([k, v]) => `<span class="label-pill">${k}=${v}</span>`)
+      .join(" ");
+    return `<tr>
+      <td><span class="metric-name">${s.metric}</span></td>
+      <td>${labelPills}</td>
+      <td>S${s.id}</td>
+      <td>${s.chunks.length}</td>
+      <td>${fmt(s.chunks.reduce((a, c) => a + c.sampleCount, 0))}</td>
+    </tr>`;
+  }).join("");
+
+  detail.innerHTML = `
+    <table class="qe-dataset-table">
+      <thead>
+        <tr><th>Metric</th><th>Labels</th><th>ID</th><th>Chunks</th><th>Samples</th></tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   INIT
+   ═══════════════════════════════════════════════════════════════════════ */
+
+function init() {
+  // Breadcrumb
+  $("#breadcrumb-nav").innerHTML = buildBreadcrumb("Query Engine");
+
+  // Dataset
+  renderDatasetSummary();
+
+  // Pipeline
+  buildPipeline();
+
+  // Query builder
+  renderFilterRows();
+  updateQueryPreview();
+
+  // Event listeners
+  $("#btn-add-filter").addEventListener("click", () => {
+    const usedLabels = new Set(filters.map((f) => f.label));
+    const available = getAvailableLabels().filter((l) => !usedLabels.has(l));
+    const nextLabel = available[0] || getAvailableLabels()[0];
+    filters.push({ label: nextLabel, value: getValuesForLabel(nextLabel)[0] });
+    renderFilterRows();
+    updateQueryPreview();
+  });
+
+  for (const id of ["metric-select", "range-select", "step-select", "agg-select"]) {
+    $(`#${id}`).addEventListener("change", updateQueryPreview);
+  }
+
+  $("#btn-execute").addEventListener("click", executeQuery);
+}
+
+init();

--- a/site/tsdb-engine/learn/shared.css
+++ b/site/tsdb-engine/learn/shared.css
@@ -1,0 +1,550 @@
+/* ─── Learn Experiences — Shared Styles ──────────────────────────── */
+
+:root {
+  /* Experience palette */
+  --xp-bg: #0a1624;
+  --xp-surface: #0f1f33;
+  --xp-surface-raised: #162a42;
+  --xp-surface-hover: #1a3350;
+  --xp-border: rgba(96, 165, 250, 0.12);
+  --xp-border-strong: rgba(96, 165, 250, 0.25);
+  --xp-text: #e2e8f0;
+  --xp-text-muted: #94a3b8;
+  --xp-text-dim: #64748b;
+  --xp-accent: #60a5fa;
+  --xp-accent-light: #93c5fd;
+  --xp-accent-glow: rgba(96, 165, 250, 0.15);
+  --xp-success: #34d399;
+  --xp-success-glow: rgba(52, 211, 153, 0.12);
+  --xp-warn: #fbbf24;
+  --xp-warn-glow: rgba(251, 191, 36, 0.12);
+  --xp-error: #f87171;
+  --xp-error-glow: rgba(248, 113, 113, 0.12);
+
+  /* Tier colors for encoding */
+  --tier-0: #34d399;   /* best compression */
+  --tier-1: #60a5fa;   /* good */
+  --tier-2: #a78bfa;   /* moderate */
+  --tier-3: #fbbf24;   /* poor */
+  --tier-4: #f87171;   /* worst / raw */
+
+  /* Region colors (from byte explorer) */
+  --region-header: #8b5cf6;
+  --region-timestamps: #06b6d4;
+  --region-values: #10b981;
+  --region-exceptions: #f59e0b;
+
+  /* Fonts */
+  --xp-font: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
+  --xp-mono: "IBM Plex Mono", "Fira Code", monospace;
+
+  /* Sizing */
+  --xp-max-width: 960px;
+  --xp-radius: 16px;
+  --xp-radius-sm: 8px;
+  --xp-radius-xs: 4px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--xp-bg);
+  color: var(--xp-text);
+  font-family: var(--xp-font);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ─── Ambient Background ──────────────────────────────────────────── */
+.xp-ambient {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(600px 400px at 10% -5%, rgba(96, 165, 250, 0.08), transparent 60%),
+    radial-gradient(500px 400px at 90% 10%, rgba(139, 92, 246, 0.06), transparent 55%),
+    radial-gradient(700px 500px at 50% 105%, rgba(52, 211, 153, 0.05), transparent 65%);
+}
+
+/* ─── Page Layout ─────────────────────────────────────────────────── */
+.xp-page {
+  position: relative;
+  z-index: 1;
+  max-width: var(--xp-max-width);
+  margin: 0 auto;
+  padding: 0 20px 64px;
+}
+
+/* ─── Top Navigation ──────────────────────────────────────────────── */
+.xp-topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--xp-border);
+  margin-bottom: 40px;
+}
+
+.xp-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--xp-text-dim);
+}
+
+.xp-breadcrumb a {
+  color: var(--xp-text-muted);
+  text-decoration: none;
+  transition: color 150ms;
+}
+
+.xp-breadcrumb a:hover {
+  color: var(--xp-accent);
+}
+
+.xp-breadcrumb .sep {
+  color: var(--xp-text-dim);
+  font-size: 10px;
+}
+
+.xp-breadcrumb .current {
+  color: var(--xp-text);
+  font-weight: 500;
+}
+
+/* ─── Hero Section ────────────────────────────────────────────────── */
+.xp-hero {
+  margin-bottom: 48px;
+}
+
+.xp-eyebrow {
+  display: inline-block;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--xp-accent);
+  margin: 0 0 8px;
+  padding: 4px 10px;
+  background: var(--xp-accent-glow);
+  border-radius: 999px;
+  border: 1px solid rgba(96, 165, 250, 0.2);
+}
+
+.xp-hero h1 {
+  margin: 0 0 16px;
+  font-size: clamp(28px, 4.5vw, 44px);
+  line-height: 1.1;
+  letter-spacing: -0.025em;
+  font-weight: 700;
+  color: #fff;
+}
+
+.xp-hero .lede {
+  margin: 0;
+  font-size: 17px;
+  line-height: 1.55;
+  color: var(--xp-text-muted);
+  max-width: 65ch;
+}
+
+/* ─── Sections ────────────────────────────────────────────────────── */
+.xp-section {
+  margin-bottom: 48px;
+}
+
+.xp-section h2 {
+  font-size: 22px;
+  font-weight: 600;
+  color: #fff;
+  margin: 0 0 8px;
+  letter-spacing: -0.01em;
+}
+
+.xp-section h3 {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--xp-text);
+  margin: 0 0 6px;
+}
+
+.xp-section p {
+  margin: 0 0 16px;
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--xp-text-muted);
+  max-width: 65ch;
+}
+
+/* ─── Cards / Panels ──────────────────────────────────────────────── */
+.xp-card {
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius);
+  padding: 24px;
+  margin-bottom: 20px;
+}
+
+.xp-card-raised {
+  background: var(--xp-surface-raised);
+  border-color: var(--xp-border-strong);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+}
+
+/* ─── Interactive Controls ────────────────────────────────────────── */
+.xp-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.xp-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--xp-font);
+  color: var(--xp-text);
+  background: var(--xp-surface-raised);
+  border: 1px solid var(--xp-border-strong);
+  border-radius: var(--xp-radius-sm);
+  cursor: pointer;
+  transition: all 150ms;
+}
+
+.xp-btn:hover {
+  background: var(--xp-surface-hover);
+  border-color: var(--xp-accent);
+}
+
+.xp-btn.active, .xp-btn[aria-pressed="true"] {
+  background: var(--xp-accent-glow);
+  border-color: var(--xp-accent);
+  color: var(--xp-accent-light);
+}
+
+.xp-btn-primary {
+  background: var(--xp-accent);
+  color: #0a1624;
+  border-color: var(--xp-accent);
+  font-weight: 600;
+}
+
+.xp-btn-primary:hover {
+  background: var(--xp-accent-light);
+}
+
+.xp-select {
+  padding: 8px 12px;
+  font-size: 13px;
+  font-family: var(--xp-font);
+  color: var(--xp-text);
+  background: var(--xp-surface-raised);
+  border: 1px solid var(--xp-border-strong);
+  border-radius: var(--xp-radius-sm);
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='10' height='6' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%2394a3b8' stroke-width='1.5' fill='none'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 28px;
+}
+
+.xp-select:focus {
+  outline: 2px solid var(--xp-accent);
+  outline-offset: 1px;
+}
+
+.xp-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--xp-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ─── Slider ──────────────────────────────────────────────────────── */
+.xp-slider-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.xp-slider-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.xp-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 160px;
+  height: 4px;
+  background: var(--xp-surface-raised);
+  border-radius: 2px;
+  outline: none;
+}
+
+.xp-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  background: var(--xp-accent);
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid var(--xp-bg);
+}
+
+.xp-slider-value {
+  font-family: var(--xp-mono);
+  font-size: 13px;
+  color: var(--xp-accent);
+  min-width: 40px;
+  text-align: right;
+}
+
+/* ─── Data Table ──────────────────────────────────────────────────── */
+.xp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.xp-table th {
+  text-align: left;
+  padding: 8px 12px;
+  font-weight: 600;
+  color: var(--xp-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 11px;
+  border-bottom: 1px solid var(--xp-border-strong);
+}
+
+.xp-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--xp-border);
+  color: var(--xp-text);
+}
+
+.xp-table tr:hover td {
+  background: var(--xp-accent-glow);
+}
+
+/* ─── Stat Badges ─────────────────────────────────────────────────── */
+.xp-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 16px;
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  min-width: 100px;
+}
+
+.xp-stat-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--xp-text-dim);
+}
+
+.xp-stat-value {
+  font-family: var(--xp-mono);
+  font-size: 20px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.xp-stat-unit {
+  font-size: 12px;
+  color: var(--xp-text-muted);
+  font-weight: 400;
+}
+
+.xp-stats-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+/* ─── Pipeline Visualization ──────────────────────────────────────── */
+.xp-pipeline {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  overflow-x: auto;
+  padding: 4px 0;
+  margin-bottom: 20px;
+}
+
+.xp-pipe-stage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 12px 16px;
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  min-width: 80px;
+  text-align: center;
+  transition: all 200ms;
+  cursor: default;
+  flex-shrink: 0;
+}
+
+.xp-pipe-stage.active {
+  border-color: var(--xp-accent);
+  background: var(--xp-accent-glow);
+  box-shadow: 0 0 20px rgba(96, 165, 250, 0.1);
+}
+
+.xp-pipe-stage .stage-icon {
+  font-size: 20px;
+}
+
+.xp-pipe-stage .stage-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--xp-text-muted);
+}
+
+.xp-pipe-arrow {
+  color: var(--xp-text-dim);
+  font-size: 16px;
+  padding: 0 4px;
+  flex-shrink: 0;
+}
+
+/* ─── Bit Grid ────────────────────────────────────────────────────── */
+.xp-bit-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  font-family: var(--xp-mono);
+  font-size: 11px;
+}
+
+.xp-bit {
+  width: 18px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  transition: all 120ms;
+  cursor: default;
+}
+
+.xp-bit[data-v="0"] {
+  background: var(--xp-surface);
+  color: var(--xp-text-dim);
+}
+
+.xp-bit[data-v="1"] {
+  background: var(--xp-surface-raised);
+  color: var(--xp-text);
+}
+
+.xp-bit.highlight {
+  outline: 2px solid var(--xp-accent);
+  outline-offset: -1px;
+}
+
+/* ─── Meter / Progress ────────────────────────────────────────────── */
+.xp-meter {
+  height: 8px;
+  background: var(--xp-surface-raised);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.xp-meter-fill {
+  height: 100%;
+  border-radius: 4px;
+  background: linear-gradient(90deg, var(--xp-accent), var(--xp-success));
+  transition: width 400ms ease;
+}
+
+/* ─── Code / Mono Text ────────────────────────────────────────────── */
+.xp-mono {
+  font-family: var(--xp-mono);
+}
+
+.xp-code {
+  font-family: var(--xp-mono);
+  font-size: 12px;
+  padding: 2px 6px;
+  background: var(--xp-surface-raised);
+  border-radius: var(--xp-radius-xs);
+  color: var(--xp-accent-light);
+}
+
+/* ─── Tier Color Utilities ────────────────────────────────────────── */
+.tier-0 { color: var(--tier-0); }
+.tier-1 { color: var(--tier-1); }
+.tier-2 { color: var(--tier-2); }
+.tier-3 { color: var(--tier-3); }
+.tier-4 { color: var(--tier-4); }
+
+.tier-0-bg { background: rgba(52, 211, 153, 0.12); border-color: rgba(52, 211, 153, 0.3); }
+.tier-1-bg { background: rgba(96, 165, 250, 0.12); border-color: rgba(96, 165, 250, 0.3); }
+.tier-2-bg { background: rgba(167, 139, 250, 0.12); border-color: rgba(167, 139, 250, 0.3); }
+.tier-3-bg { background: rgba(251, 191, 36, 0.12); border-color: rgba(251, 191, 36, 0.3); }
+.tier-4-bg { background: rgba(248, 113, 113, 0.12); border-color: rgba(248, 113, 113, 0.3); }
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .xp-page { padding: 0 14px 40px; }
+  .xp-card { padding: 16px; }
+  .xp-hero h1 { font-size: 26px; }
+  .xp-pipeline { gap: 0; }
+  .xp-stats-row { gap: 8px; }
+  .xp-stat { min-width: 80px; padding: 10px 12px; }
+}
+
+/* ─── Animations ──────────────────────────────────────────────────── */
+@keyframes xp-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes xp-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.xp-animate-in {
+  animation: xp-fade-in 400ms ease both;
+}
+
+/* Skip link */
+.xp-skip-link {
+  position: absolute;
+  left: -999px;
+  top: 8px;
+  z-index: 100;
+  padding: 8px 16px;
+  background: var(--xp-accent);
+  color: var(--xp-bg);
+  border-radius: var(--xp-radius-sm);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.xp-skip-link:focus {
+  left: 16px;
+}

--- a/site/tsdb-engine/learn/shared.css
+++ b/site/tsdb-engine/learn/shared.css
@@ -557,3 +557,66 @@ body {
   100% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0); }
 }
 .xp-reveal { animation: xp-reveal-pulse 0.6s ease-out; }
+
+/* ─── Scrollable Container Utilities ─────────────────────────────── */
+
+/* Horizontal scroll with thin themed scrollbar */
+.xp-scroll-x {
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--xp-border-strong) transparent;
+}
+
+.xp-scroll-x::-webkit-scrollbar {
+  height: 6px;
+}
+
+.xp-scroll-x::-webkit-scrollbar-thumb {
+  background: var(--xp-border-strong);
+  border-radius: 3px;
+}
+
+/* Vertical scroll with thin themed scrollbar */
+.xp-scroll-y {
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--xp-border-strong) transparent;
+}
+
+.xp-scroll-y::-webkit-scrollbar {
+  width: 4px;
+}
+
+.xp-scroll-y::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.xp-scroll-y::-webkit-scrollbar-thumb {
+  background: var(--xp-border-strong);
+  border-radius: 2px;
+}
+
+/* ─── Narrative Story Box ─────────────────────────────────────────── */
+
+.xp-story {
+  margin-top: 16px;
+  padding: 16px 20px;
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--xp-text-muted);
+}
+
+/* ─── Pill Badge ──────────────────────────────────────────────────── */
+
+.xp-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: var(--xp-mono);
+  letter-spacing: 0.04em;
+}

--- a/site/tsdb-engine/learn/shared.css
+++ b/site/tsdb-engine/learn/shared.css
@@ -548,3 +548,12 @@ body {
 .xp-skip-link:focus {
   left: 16px;
 }
+
+/* ─── Reveal pulse (gentle attention without forced scroll) ─────── */
+
+@keyframes xp-reveal-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.4); }
+  70% { box-shadow: 0 0 0 8px rgba(99, 102, 241, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0); }
+}
+.xp-reveal { animation: xp-reveal-pulse 0.6s ease-out; }

--- a/site/tsdb-engine/learn/shared.js
+++ b/site/tsdb-engine/learn/shared.js
@@ -197,13 +197,24 @@ export function buildBreadcrumb(title) {
   return `
     <nav class="xp-topbar" aria-label="Breadcrumb">
       <div class="xp-breadcrumb">
-        <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+        <a href="../../">TSDB Engine</a>
         <span class="sep">›</span>
-        <a href="/o11ykit/tsdb-engine/learn/">Learn</a>
+        <a href="../">Learn</a>
         <span class="sep">›</span>
         <span class="current">${title}</span>
       </div>
     </nav>`;
+}
+
+/** Gently reveal a section — only scrolls if not already visible, adds a brief highlight pulse. */
+export function revealSection(el) {
+  const rect = el.getBoundingClientRect();
+  const inView = rect.top >= 0 && rect.bottom <= window.innerHeight;
+  if (!inView) {
+    el.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }
+  el.classList.add("xp-reveal");
+  el.addEventListener("animationend", () => el.classList.remove("xp-reveal"), { once: true });
 }
 
 /** Render a sparkline to a canvas element. */

--- a/site/tsdb-engine/learn/shared.js
+++ b/site/tsdb-engine/learn/shared.js
@@ -252,3 +252,32 @@ export function drawSparkline(canvas, values, opts = {}) {
   ctx.fillStyle = color.replace(')', `, ${fillAlpha})`).replace('rgb', 'rgba');
   ctx.fill();
 }
+
+/* ─── Stat Card Builder ───────────────────────────────────────────── */
+
+/**
+ * Build a standard `.xp-stat` card element.
+ * @param {string} label
+ * @param {string|number} value
+ * @param {string} [unit]
+ * @param {object} [opts]  – opts.cls (extra class on value), opts.color (inline color on value)
+ * @returns {HTMLElement}
+ */
+export function buildStat(label, value, unit = '', opts = {}) {
+  const valueEl = el('div', {
+    class: ['xp-stat-value', opts.cls].filter(Boolean).join(' '),
+    ...(opts.color ? { style: { color: opts.color } } : {}),
+  }, String(value));
+  return el('div', { class: 'xp-stat' },
+    el('div', { class: 'xp-stat-label' }, label),
+    valueEl,
+    unit ? el('div', { class: 'xp-stat-unit' }, unit) : null,
+  );
+}
+
+/* ─── Async Helpers ───────────────────────────────────────────────── */
+
+/** Promise-based sleep. */
+export function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/site/tsdb-engine/learn/shared.js
+++ b/site/tsdb-engine/learn/shared.js
@@ -1,0 +1,243 @@
+/**
+ * Shared utilities for Learn experiences.
+ * Pure functions + lightweight animation helpers — no DOM side effects on import.
+ */
+
+/** Format a number with locale-aware thousands separators. */
+export function fmt(n, decimals = 0) {
+  return Number(n).toLocaleString('en-US', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
+/** Format bytes as human-readable string. */
+export function fmtBytes(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+/** Format bits as human-readable string. */
+export function fmtBits(bits) {
+  if (bits < 8) return `${bits} bits`;
+  if (bits < 8192) return `${(bits / 8).toFixed(1)} B`;
+  return fmtBytes(bits / 8);
+}
+
+/** Convert a float64 to its IEEE 754 bit string (64 chars of 0/1). */
+export function float64ToBits(value) {
+  const buf = new ArrayBuffer(8);
+  new Float64Array(buf)[0] = value;
+  const bytes = new Uint8Array(buf);
+  let bits = '';
+  for (let i = 7; i >= 0; i--) {
+    bits += bytes[i].toString(2).padStart(8, '0');
+  }
+  return bits;
+}
+
+/** Convert a BigInt (int64) to its bit string (64 chars). */
+export function int64ToBits(value) {
+  const big = BigInt(value);
+  let s = '';
+  for (let i = 63; i >= 0; i--) {
+    s += (big >> BigInt(i)) & 1n ? '1' : '0';
+  }
+  return s;
+}
+
+/** ZigZag encode a signed value. */
+export function zigzagEncode(n) {
+  const big = BigInt(n);
+  return big >= 0n ? big * 2n : (-big) * 2n - 1n;
+}
+
+/** ZigZag decode an unsigned value. */
+export function zigzagDecode(n) {
+  const big = BigInt(n);
+  return (big & 1n) ? -(big >> 1n) - 1n : big >> 1n;
+}
+
+/** Count leading zero bits in a 64-bit value. */
+export function clz64(value) {
+  const big = BigInt(value);
+  if (big === 0n) return 64;
+  let count = 0;
+  for (let i = 63; i >= 0; i--) {
+    if ((big >> BigInt(i)) & 1n) break;
+    count++;
+  }
+  return count;
+}
+
+/** Count trailing zero bits in a 64-bit value. */
+export function ctz64(value) {
+  const big = BigInt(value);
+  if (big === 0n) return 64;
+  let count = 0;
+  for (let i = 0; i <= 63; i++) {
+    if ((big >> BigInt(i)) & 1n) break;
+    count++;
+  }
+  return count;
+}
+
+/**
+ * Generate sample time-series data.
+ * @param {'gauge'|'counter'|'percentage'|'temperature'|'sine'|'random'} pattern
+ * @param {number} count
+ * @param {object} opts
+ * @returns {{ timestamps: BigInt64Array, values: Float64Array }}
+ */
+export function generateSamples(pattern, count, opts = {}) {
+  const { interval = 15_000_000_000n, jitter = 0, base = 100, noise = 0.02 } = opts;
+  const timestamps = new BigInt64Array(count);
+  const values = new Float64Array(count);
+  const now = BigInt(Date.now()) * 1_000_000n;
+
+  for (let i = 0; i < count; i++) {
+    const jitterNs = jitter ? BigInt(Math.round((Math.random() - 0.5) * 2 * jitter * 1e6)) : 0n;
+    timestamps[i] = now - BigInt(count - i) * interval + jitterNs;
+
+    switch (pattern) {
+      case 'gauge':
+        values[i] = base + Math.sin(i * 0.05) * 20 + (Math.random() - 0.5) * noise * base;
+        break;
+      case 'counter':
+        values[i] = i === 0 ? base : values[i - 1] + Math.random() * 5 + 1;
+        break;
+      case 'percentage':
+        values[i] = Math.round(Math.max(0, Math.min(100, 50 + Math.sin(i * 0.08) * 30 + (Math.random() - 0.5) * 10)) * 10) / 10;
+        break;
+      case 'temperature':
+        values[i] = Math.round((20 + Math.sin(i * 0.03) * 8 + (Math.random() - 0.5) * 2) * 100) / 100;
+        break;
+      case 'sine':
+        values[i] = Math.sin(i * 0.1) * base;
+        break;
+      case 'random':
+        values[i] = Math.random() * base * 2;
+        break;
+      default:
+        values[i] = base + (Math.random() - 0.5) * noise * base;
+    }
+  }
+  return { timestamps, values };
+}
+
+/* ─── Animation Helpers ───────────────────────────────────────────── */
+
+/** Animate a numeric value from `from` to `to` over `duration` ms, calling `cb(current)`. */
+export function animateValue(from, to, duration, cb) {
+  const start = performance.now();
+  function tick(now) {
+    const t = Math.min(1, (now - start) / duration);
+    const eased = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+    cb(from + (to - from) * eased);
+    if (t < 1) requestAnimationFrame(tick);
+  }
+  requestAnimationFrame(tick);
+}
+
+/** Step-through controller for pipeline animations. */
+export class Stepper {
+  constructor(totalSteps, onStep) {
+    this.total = totalSteps;
+    this.current = -1;
+    this.onStep = onStep;
+    this._timer = null;
+  }
+
+  goto(step) {
+    this.current = Math.max(-1, Math.min(step, this.total - 1));
+    this.onStep(this.current);
+  }
+
+  next() { if (this.current < this.total - 1) this.goto(this.current + 1); }
+  prev() { if (this.current > -1) this.goto(this.current - 1); }
+  reset() { this.goto(-1); }
+
+  play(intervalMs = 1200) {
+    this.stop();
+    this.reset();
+    this._timer = setInterval(() => {
+      if (this.current >= this.total - 1) { this.stop(); return; }
+      this.next();
+    }, intervalMs);
+  }
+
+  stop() {
+    if (this._timer) { clearInterval(this._timer); this._timer = null; }
+  }
+}
+
+/** Shorthand DOM query. */
+export const $ = (sel, root = document) => root.querySelector(sel);
+export const $$ = (sel, root = document) => [...root.querySelectorAll(sel)];
+
+/** Create an element with attributes and children. */
+export function el(tag, attrs = {}, ...children) {
+  const e = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) {
+    if (k === 'class') e.className = v;
+    else if (k === 'style' && typeof v === 'object') Object.assign(e.style, v);
+    else if (k.startsWith('on')) e.addEventListener(k.slice(2).toLowerCase(), v);
+    else e.setAttribute(k, v);
+  }
+  for (const c of children) {
+    if (typeof c === 'string') e.appendChild(document.createTextNode(c));
+    else if (c) e.appendChild(c);
+  }
+  return e;
+}
+
+/** Build standard breadcrumb nav for an experience page. */
+export function buildBreadcrumb(title) {
+  return `
+    <nav class="xp-topbar" aria-label="Breadcrumb">
+      <div class="xp-breadcrumb">
+        <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+        <span class="sep">›</span>
+        <a href="/o11ykit/tsdb-engine/learn/">Learn</a>
+        <span class="sep">›</span>
+        <span class="current">${title}</span>
+      </div>
+    </nav>`;
+}
+
+/** Render a sparkline to a canvas element. */
+export function drawSparkline(canvas, values, opts = {}) {
+  const { color = '#60a5fa', fillAlpha = 0.1, lineWidth = 1.5 } = opts;
+  const ctx = canvas.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+  const w = canvas.clientWidth;
+  const h = canvas.clientHeight;
+  canvas.width = w * dpr;
+  canvas.height = h * dpr;
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, w, h);
+
+  if (values.length < 2) return;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const pad = 2;
+
+  ctx.beginPath();
+  for (let i = 0; i < values.length; i++) {
+    const x = (i / (values.length - 1)) * w;
+    const y = pad + (1 - (values[i] - min) / range) * (h - 2 * pad);
+    i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+  }
+  ctx.strokeStyle = color;
+  ctx.lineWidth = lineWidth;
+  ctx.stroke();
+
+  // fill
+  ctx.lineTo(w, h);
+  ctx.lineTo(0, h);
+  ctx.closePath();
+  ctx.fillStyle = color.replace(')', `, ${fillAlpha})`).replace('rgb', 'rgba');
+  ctx.fill();
+}

--- a/site/tsdb-engine/learn/string-interning/index.html
+++ b/site/tsdb-engine/learn/string-interning/index.html
@@ -132,8 +132,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/string-interning/index.html
+++ b/site/tsdb-engine/learn/string-interning/index.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>String Interning — Interactive Experience | o11ytsdb</title>
+    <meta name="description" content="See how TSDB engines store label strings once and reference them by integer ID — interactively explore FNV-1a hashing, open-addressing, and memory savings." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500&display=swap" />
+    <link rel="stylesheet" href="../shared.css" />
+    <link rel="stylesheet" href="intern-experience.css" />
+  </head>
+  <body>
+    <a href="#main" class="xp-skip-link">Skip to content</a>
+    <div class="xp-ambient" aria-hidden="true"></div>
+    <div class="xp-page" id="main">
+
+      <div id="breadcrumb-nav"></div>
+
+      <div class="xp-hero">
+        <p class="xp-eyebrow">Label Storage</p>
+        <h1>String Interning</h1>
+        <p class="lede">
+          Instead of storing <code class="xp-code">"region=us-west-2"</code> in every series,
+          store it <strong>once</strong> in a byte buffer and reference it by a 4-byte integer ID.
+          Generate Kubernetes-style metrics and watch memory usage collapse as strings are reused.
+        </p>
+      </div>
+
+      <!-- A. Series Generator -->
+      <section class="xp-section" id="generator-section">
+        <h2>① Generate Series</h2>
+        <p>Create realistic Kubernetes metric series with shared labels. Adjust the count and hit Generate.</p>
+        <div class="xp-card">
+          <div class="xp-controls" id="gen-controls">
+            <div class="xp-slider-group">
+              <label class="xp-label" for="series-slider">Series count</label>
+              <div class="xp-slider-row">
+                <input type="range" class="xp-slider" id="series-slider"
+                       min="10" max="500" step="10" value="100" style="width:200px" />
+                <span class="xp-slider-value" id="series-count-display">100</span>
+              </div>
+            </div>
+            <button type="button" class="xp-btn xp-btn-primary" id="btn-generate">⟳ Generate</button>
+          </div>
+          <div class="intern-gen-summary" id="gen-summary"></div>
+        </div>
+      </section>
+
+      <!-- F. Stats Row (placed near top for visibility) -->
+      <section class="xp-section" id="stats-section">
+        <h2>② At a Glance</h2>
+        <div class="xp-stats-row" id="stats-row"></div>
+      </section>
+
+      <!-- B. Naive vs Interned Split View -->
+      <section class="xp-section" id="split-section">
+        <h2>③ Naive vs Interned</h2>
+        <p>Side-by-side: every series stores full strings (left) vs. integer IDs into a shared buffer (right).</p>
+        <div class="intern-split">
+          <div class="xp-card intern-panel" id="naive-panel">
+            <h3>Naive Storage</h3>
+            <div class="intern-panel-body" id="naive-body"></div>
+            <div class="intern-panel-footer" id="naive-footer"></div>
+          </div>
+          <div class="xp-card intern-panel" id="interned-panel">
+            <h3>Interned Storage</h3>
+            <div class="intern-string-buffer-wrap">
+              <span class="xp-label">String Buffer (unique strings, packed)</span>
+              <div class="intern-tape" id="string-buffer-tape"></div>
+            </div>
+            <div class="intern-id-table-wrap">
+              <span class="xp-label">ID Table</span>
+              <div class="intern-id-table" id="id-table"></div>
+            </div>
+            <div class="intern-refs-wrap">
+              <span class="xp-label">Series References</span>
+              <div class="intern-panel-body" id="interned-body"></div>
+            </div>
+            <div class="intern-panel-footer" id="interned-footer"></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- C. Memory Comparison Bar Chart -->
+      <section class="xp-section" id="memory-section">
+        <h2>④ Memory Comparison</h2>
+        <p>How much space does interning actually save?</p>
+        <div class="xp-card" id="memory-bars"></div>
+      </section>
+
+      <!-- D. Intern Animation -->
+      <section class="xp-section" id="animation-section">
+        <h2>⑤ Intern a String</h2>
+        <p>Step through the FNV-1a hash → open-addressing → store-or-reuse pipeline.</p>
+        <div class="xp-card xp-card-raised">
+          <div class="xp-controls">
+            <div class="xp-slider-group">
+              <label class="xp-label" for="anim-string-select">String to intern</label>
+              <select class="xp-select" id="anim-string-select"></select>
+            </div>
+            <button type="button" class="xp-btn" id="btn-anim-prev">← Prev</button>
+            <button type="button" class="xp-btn xp-btn-primary" id="btn-anim-next">Next →</button>
+            <button type="button" class="xp-btn" id="btn-anim-play">▶ Play</button>
+            <button type="button" class="xp-btn" id="btn-anim-reset">Reset</button>
+          </div>
+
+          <!-- Animation pipeline stages -->
+          <div class="xp-pipeline" id="anim-pipeline"></div>
+
+          <!-- Animation detail area -->
+          <div class="intern-anim-detail" id="anim-detail"></div>
+
+          <!-- Hash table visualization -->
+          <div class="intern-hash-table-wrap">
+            <span class="xp-label">Hash Table (open addressing)</span>
+            <div class="intern-hash-grid" id="hash-grid"></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- E. Cardinality Impact -->
+      <section class="xp-section" id="cardinality-section">
+        <h2>⑥ Cardinality Impact</h2>
+        <p>Memory grows differently for naive vs interned as the number of unique strings changes.</p>
+        <div class="xp-card">
+          <canvas id="cardinality-canvas" width="900" height="300" style="width:100%;height:280px;"></canvas>
+          <div class="intern-chart-legend" id="cardinality-legend"></div>
+        </div>
+      </section>
+
+      <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
+        <p style="font-size: 13px; color: var(--xp-text-dim);">
+          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+        </p>
+      </footer>
+
+    </div>
+    <script type="module" src="intern-experience.js"></script>
+  </body>
+</html>

--- a/site/tsdb-engine/learn/string-interning/index.html
+++ b/site/tsdb-engine/learn/string-interning/index.html
@@ -61,7 +61,7 @@
         <div class="intern-split">
           <div class="xp-card intern-panel" id="naive-panel">
             <h3>Naive Storage</h3>
-            <div class="intern-panel-body" id="naive-body"></div>
+            <div class="intern-panel-body xp-scroll-y" id="naive-body"></div>
             <div class="intern-panel-footer" id="naive-footer"></div>
           </div>
           <div class="xp-card intern-panel" id="interned-panel">
@@ -72,11 +72,11 @@
             </div>
             <div class="intern-id-table-wrap">
               <span class="xp-label">ID Table</span>
-              <div class="intern-id-table" id="id-table"></div>
+              <div class="intern-id-table xp-scroll-y" id="id-table"></div>
             </div>
             <div class="intern-refs-wrap">
               <span class="xp-label">Series References</span>
-              <div class="intern-panel-body" id="interned-body"></div>
+              <div class="intern-panel-body xp-scroll-y" id="interned-body"></div>
             </div>
             <div class="intern-panel-footer" id="interned-footer"></div>
           </div>

--- a/site/tsdb-engine/learn/string-interning/intern-experience.css
+++ b/site/tsdb-engine/learn/string-interning/intern-experience.css
@@ -64,19 +64,6 @@
   min-height: 0;
 }
 
-.intern-panel-body::-webkit-scrollbar {
-  width: 4px;
-}
-
-.intern-panel-body::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.intern-panel-body::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 2px;
-}
-
 .intern-panel-footer {
   padding-top: 10px;
   border-top: 1px solid var(--xp-border);
@@ -176,15 +163,6 @@
   max-height: 120px;
   overflow-y: auto;
   padding-right: 4px;
-}
-
-.intern-id-table::-webkit-scrollbar {
-  width: 4px;
-}
-
-.intern-id-table::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 2px;
 }
 
 .intern-id-entry {

--- a/site/tsdb-engine/learn/string-interning/intern-experience.css
+++ b/site/tsdb-engine/learn/string-interning/intern-experience.css
@@ -1,0 +1,454 @@
+/* ─── String Interning Experience ─────────────────────────────────── */
+
+/* Palette for string coloring — 12 distinct hues */
+:root {
+  --str-0: #34d399;
+  --str-1: #60a5fa;
+  --str-2: #a78bfa;
+  --str-3: #fbbf24;
+  --str-4: #f87171;
+  --str-5: #2dd4bf;
+  --str-6: #f472b6;
+  --str-7: #fb923c;
+  --str-8: #818cf8;
+  --str-9: #4ade80;
+  --str-10: #38bdf8;
+  --str-11: #e879f9;
+}
+
+/* ─── Generator Summary ──────────────────────────────────────────── */
+.intern-gen-summary {
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--xp-text-muted);
+  font-family: var(--xp-mono);
+}
+
+/* ─── Split View ─────────────────────────────────────────────────── */
+.intern-split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 780px) {
+  .intern-split {
+    grid-template-columns: 1fr;
+  }
+}
+
+.intern-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 520px;
+  overflow: hidden;
+}
+
+.intern-panel h3 {
+  margin: 0 0 4px;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--xp-text-muted);
+}
+
+.intern-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-right: 4px;
+  min-height: 0;
+}
+
+.intern-panel-body::-webkit-scrollbar {
+  width: 4px;
+}
+
+.intern-panel-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.intern-panel-body::-webkit-scrollbar-thumb {
+  background: var(--xp-border-strong);
+  border-radius: 2px;
+}
+
+.intern-panel-footer {
+  padding-top: 10px;
+  border-top: 1px solid var(--xp-border);
+  font-family: var(--xp-mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+}
+
+/* ─── Naive series row ───────────────────────────────────────────── */
+.intern-naive-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.intern-str-block {
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 5px;
+  border-radius: 3px;
+  font-family: var(--xp-mono);
+  font-size: 10px;
+  white-space: nowrap;
+  color: var(--xp-bg);
+  font-weight: 500;
+  line-height: 1;
+}
+
+/* ─── Interned reference chips ───────────────────────────────────── */
+.intern-ref-row {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-wrap: wrap;
+}
+
+.intern-ref-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 18px;
+  border-radius: 3px;
+  font-family: var(--xp-mono);
+  font-size: 9px;
+  font-weight: 600;
+  color: #fff;
+  opacity: 0.85;
+}
+
+/* ─── String Buffer Tape ─────────────────────────────────────────── */
+.intern-string-buffer-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.intern-tape {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1px;
+  padding: 6px;
+  background: var(--xp-surface-raised);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  min-height: 32px;
+}
+
+.intern-tape-seg {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 4px;
+  border-radius: 2px;
+  font-family: var(--xp-mono);
+  font-size: 9px;
+  white-space: nowrap;
+  color: var(--xp-bg);
+  font-weight: 500;
+  line-height: 1;
+}
+
+/* ─── ID Table ───────────────────────────────────────────────────── */
+.intern-id-table-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.intern-id-table {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 3px;
+  max-height: 120px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.intern-id-table::-webkit-scrollbar {
+  width: 4px;
+}
+
+.intern-id-table::-webkit-scrollbar-thumb {
+  background: var(--xp-border-strong);
+  border-radius: 2px;
+}
+
+.intern-id-entry {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 6px;
+  background: var(--xp-surface-raised);
+  border-radius: 3px;
+  font-family: var(--xp-mono);
+  font-size: 10px;
+  color: var(--xp-text-muted);
+}
+
+.intern-id-entry .id-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 3px;
+  font-size: 9px;
+  font-weight: 700;
+  color: #fff;
+}
+
+.intern-id-entry .id-meta {
+  color: var(--xp-text-dim);
+  font-size: 9px;
+}
+
+/* ─── Series References ──────────────────────────────────────────── */
+.intern-refs-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* ─── Memory Bars ────────────────────────────────────────────────── */
+.intern-mem-bar-row {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.intern-mem-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.intern-mem-bar-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--xp-text);
+}
+
+.intern-mem-bar-label .bytes {
+  font-family: var(--xp-mono);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.intern-mem-bar-track {
+  height: 28px;
+  background: var(--xp-surface-raised);
+  border-radius: var(--xp-radius-xs);
+  overflow: hidden;
+  position: relative;
+}
+
+.intern-mem-bar-fill {
+  height: 100%;
+  border-radius: var(--xp-radius-xs);
+  transition: width 600ms cubic-bezier(0.22, 1, 0.36, 1);
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  font-family: var(--xp-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--xp-bg);
+  white-space: nowrap;
+}
+
+.intern-mem-bar-fill.naive {
+  background: linear-gradient(90deg, var(--xp-error), #fca5a5);
+}
+
+.intern-mem-bar-fill.interned {
+  background: linear-gradient(90deg, var(--xp-success), #6ee7b7);
+}
+
+.intern-savings-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+  padding: 6px 14px;
+  background: var(--xp-success-glow);
+  border: 1px solid rgba(52, 211, 153, 0.3);
+  border-radius: 999px;
+  font-family: var(--xp-mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--xp-success);
+}
+
+/* ─── Intern Animation ───────────────────────────────────────────── */
+.intern-anim-detail {
+  min-height: 120px;
+  padding: 16px;
+  margin-bottom: 16px;
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  font-family: var(--xp-mono);
+  font-size: 13px;
+  color: var(--xp-text);
+  line-height: 1.7;
+}
+
+.intern-anim-detail .anim-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--xp-text-dim);
+  margin-bottom: 4px;
+}
+
+.intern-anim-detail .anim-value {
+  color: var(--xp-accent-light);
+  font-weight: 500;
+}
+
+.intern-anim-detail .anim-highlight {
+  color: var(--xp-success);
+  font-weight: 600;
+}
+
+.intern-anim-detail .anim-warn {
+  color: var(--xp-warn);
+  font-weight: 600;
+}
+
+.intern-char-grid {
+  display: flex;
+  gap: 2px;
+  flex-wrap: wrap;
+  margin: 6px 0;
+}
+
+.intern-char-cell {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 28px;
+  background: var(--xp-surface-raised);
+  border: 1px solid var(--xp-border);
+  border-radius: 3px;
+  font-family: var(--xp-mono);
+  font-size: 12px;
+  color: var(--xp-accent-light);
+  transition: all 200ms;
+}
+
+.intern-char-cell.active {
+  background: var(--xp-accent-glow);
+  border-color: var(--xp-accent);
+  color: #fff;
+}
+
+/* ─── Hash Table Grid ────────────────────────────────────────────── */
+.intern-hash-table-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.intern-hash-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(40px, 1fr));
+  gap: 3px;
+}
+
+.intern-hash-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  border-radius: var(--xp-radius-xs);
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  font-family: var(--xp-mono);
+  font-size: 9px;
+  color: var(--xp-text-dim);
+  transition: all 200ms;
+  position: relative;
+  overflow: hidden;
+}
+
+.intern-hash-cell.occupied {
+  border-color: var(--xp-border-strong);
+  color: #fff;
+  font-weight: 500;
+}
+
+.intern-hash-cell.probe-target {
+  outline: 2px solid var(--xp-accent);
+  outline-offset: -1px;
+  z-index: 1;
+}
+
+.intern-hash-cell.probe-collision {
+  outline: 2px solid var(--xp-warn);
+  outline-offset: -1px;
+  z-index: 1;
+}
+
+.intern-hash-cell.probe-found {
+  outline: 2px solid var(--xp-success);
+  outline-offset: -1px;
+  z-index: 1;
+}
+
+/* ─── Cardinality Chart ──────────────────────────────────────────── */
+.intern-chart-legend {
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--xp-text-muted);
+}
+
+.intern-chart-legend .legend-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .intern-split {
+    grid-template-columns: 1fr;
+  }
+
+  .intern-id-table {
+    grid-template-columns: 1fr;
+  }
+
+  .intern-hash-grid {
+    grid-template-columns: repeat(auto-fill, minmax(32px, 1fr));
+  }
+}

--- a/site/tsdb-engine/learn/string-interning/intern-experience.js
+++ b/site/tsdb-engine/learn/string-interning/intern-experience.js
@@ -1,0 +1,830 @@
+/**
+ * String Interning — Interactive Experience
+ * Demonstrates how TSDB engines store label strings once and reference them by ID.
+ */
+import { $, $$, buildBreadcrumb, el, fmt, fmtBytes, Stepper } from "../shared.js";
+
+/* ─── Constants ──────────────────────────────────────────────────── */
+
+const LABEL_DEFS = {
+  __name__: [
+    "http_requests_total",
+    "cpu_usage_percent",
+    "memory_bytes",
+    "disk_io_bytes",
+    "gc_pause_seconds",
+  ],
+  region: ["us-east-1", "us-west-2", "eu-west-1", "ap-south-1"],
+  job: ["api-server", "web-frontend", "worker", "scheduler"],
+  instance: Array.from({ length: 10 }, (_, i) => `pod-${String(i + 1).padStart(3, "0")}`),
+};
+
+const HASH_TABLE_SIZE = 64;
+
+const STRING_COLORS = [
+  "#34d399",
+  "#60a5fa",
+  "#a78bfa",
+  "#fbbf24",
+  "#f87171",
+  "#2dd4bf",
+  "#f472b6",
+  "#fb923c",
+  "#818cf8",
+  "#4ade80",
+  "#38bdf8",
+  "#e879f9",
+];
+
+/* ─── FNV-1a Hash ────────────────────────────────────────────────── */
+
+const FNV_OFFSET = 0x811c9dc5;
+const FNV_PRIME = 0x01000193;
+
+function fnv1a(str) {
+  let h = FNV_OFFSET;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, FNV_PRIME) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/* ─── String Interning Engine ────────────────────────────────────── */
+
+class StringInterner {
+  constructor(tableSize = HASH_TABLE_SIZE) {
+    this.tableSize = tableSize;
+    this.table = new Array(tableSize).fill(null); // { id, str }
+    this.strings = []; // ordered unique strings
+    this.buffer = []; // byte buffer segments: { str, offset, len }
+    this.nextId = 0;
+    this.bufferOffset = 0;
+    this.colorMap = new Map();
+  }
+
+  intern(str) {
+    const hash = fnv1a(str);
+    let idx = hash % this.tableSize;
+    const probeSteps = [];
+
+    for (let i = 0; i < this.tableSize; i++) {
+      const slot = this.table[idx];
+      if (slot === null) {
+        const id = this.nextId++;
+        const byteLen = new TextEncoder().encode(str).length;
+        this.table[idx] = { id, str };
+        this.strings.push(str);
+        this.buffer.push({ str, offset: this.bufferOffset, len: byteLen });
+        this.bufferOffset += byteLen;
+        this.colorMap.set(str, STRING_COLORS[id % STRING_COLORS.length]);
+        return {
+          id,
+          isNew: true,
+          hash,
+          bucketIdx: hash % this.tableSize,
+          probeSteps,
+          finalIdx: idx,
+        };
+      }
+      if (slot.str === str) {
+        return {
+          id: slot.id,
+          isNew: false,
+          hash,
+          bucketIdx: hash % this.tableSize,
+          probeSteps,
+          finalIdx: idx,
+        };
+      }
+      probeSteps.push(idx);
+      idx = (idx + 1) % this.tableSize;
+    }
+    throw new Error("Hash table full");
+  }
+
+  getColor(str) {
+    return this.colorMap.get(str) || "#64748b";
+  }
+
+  getId(str) {
+    for (const entry of this.table) {
+      if (entry && entry.str === str) return entry.id;
+    }
+    return -1;
+  }
+}
+
+/* ─── State ──────────────────────────────────────────────────────── */
+
+let series = [];
+let interner = new StringInterner();
+let animInterner = new StringInterner();
+let stepper = null;
+
+/* ─── Series Generation ──────────────────────────────────────────── */
+
+function generateSeries(count) {
+  const keys = Object.keys(LABEL_DEFS);
+  const result = [];
+  for (let i = 0; i < count; i++) {
+    const labels = {};
+    for (const k of keys) {
+      const pool = LABEL_DEFS[k];
+      labels[k] = pool[Math.floor(Math.random() * pool.length)];
+    }
+    result.push(labels);
+  }
+  return result;
+}
+
+function labelStrings(labels) {
+  return Object.entries(labels).map(([k, v]) => `${k}=${v}`);
+}
+
+/* ─── Stats Calculation ──────────────────────────────────────────── */
+
+function computeStats(seriesList) {
+  interner = new StringInterner();
+  let totalRefs = 0;
+  const allLabels = [];
+
+  for (const s of seriesList) {
+    const strs = labelStrings(s);
+    for (const str of strs) {
+      interner.intern(str);
+      totalRefs++;
+    }
+    allLabels.push(strs);
+  }
+
+  const avgLen =
+    interner.buffer.reduce((s, b) => s + b.len, 0) / Math.max(interner.strings.length, 1);
+  const _naiveBytes =
+    totalRefs *
+    Math.round(
+      avgLen > 0 ? interner.buffer.reduce((s, b) => s + b.len, 0) / interner.strings.length : 15
+    );
+
+  let naiveTotal = 0;
+  for (const strs of allLabels) {
+    for (const str of strs) {
+      naiveTotal += new TextEncoder().encode(str).length;
+    }
+  }
+
+  const internedBufferBytes = interner.bufferOffset;
+  const internedIdBytes = totalRefs * 4;
+  const internedTotal = internedBufferBytes + internedIdBytes;
+
+  return {
+    totalSeries: seriesList.length,
+    uniqueStrings: interner.strings.length,
+    totalRefs,
+    naiveBytes: naiveTotal,
+    internedBytes: internedTotal,
+    internedBufferBytes,
+    internedIdBytes,
+    ratio: naiveTotal / Math.max(internedTotal, 1),
+    allLabels,
+  };
+}
+
+/* ─── Render: Stats Row ──────────────────────────────────────────── */
+
+function renderStats(stats) {
+  const row = $("#stats-row");
+  row.innerHTML = "";
+  const items = [
+    ["Total Series", fmt(stats.totalSeries), ""],
+    ["Unique Strings", fmt(stats.uniqueStrings), ""],
+    ["Total Refs", fmt(stats.totalRefs), ""],
+    ["Naive Memory", fmtBytes(stats.naiveBytes), ""],
+    ["Interned Memory", fmtBytes(stats.internedBytes), ""],
+    ["Savings", `${stats.ratio.toFixed(1)}×`, ""],
+  ];
+  for (const [label, value, unit] of items) {
+    row.appendChild(
+      el(
+        "div",
+        { class: "xp-stat" },
+        el("span", { class: "xp-stat-label" }, label),
+        el("span", { class: "xp-stat-value" }, value, el("span", { class: "xp-stat-unit" }, unit))
+      )
+    );
+  }
+}
+
+/* ─── Render: Generator Summary ──────────────────────────────────── */
+
+function renderGenSummary(stats) {
+  $("#gen-summary").textContent =
+    `${fmt(stats.totalSeries)} series × ${Object.keys(LABEL_DEFS).length} labels = ${fmt(stats.totalRefs)} label references`;
+}
+
+/* ─── Render: Naive Panel ────────────────────────────────────────── */
+
+function renderNaivePanel(stats) {
+  const body = $("#naive-body");
+  body.innerHTML = "";
+  const max = Math.min(stats.allLabels.length, 60);
+
+  for (let i = 0; i < max; i++) {
+    const row = el("div", { class: "intern-naive-row" });
+    for (const str of stats.allLabels[i]) {
+      const color = interner.getColor(str);
+      const block = el("span", { class: "intern-str-block" }, str);
+      block.style.background = color;
+      const byteLen = new TextEncoder().encode(str).length;
+      block.style.minWidth = `${Math.max(byteLen * 3.5, 40)}px`;
+      row.appendChild(block);
+    }
+    body.appendChild(row);
+  }
+  if (stats.allLabels.length > max) {
+    body.appendChild(
+      el(
+        "div",
+        { style: { color: "var(--xp-text-dim)", fontSize: "11px", padding: "4px 0" } },
+        `… and ${fmt(stats.allLabels.length - max)} more series`
+      )
+    );
+  }
+
+  $("#naive-footer").innerHTML =
+    `Total: <span style="color:var(--xp-error)">${fmtBytes(stats.naiveBytes)}</span>`;
+}
+
+/* ─── Render: Interned Panel ─────────────────────────────────────── */
+
+function renderInternedPanel(stats) {
+  // String buffer tape
+  const tape = $("#string-buffer-tape");
+  tape.innerHTML = "";
+  for (const entry of interner.buffer) {
+    const seg = el(
+      "span",
+      {
+        class: "intern-tape-seg",
+        title: `ID ${interner.getId(entry.str)} | offset ${entry.offset} | ${entry.len} bytes`,
+      },
+      entry.str
+    );
+    seg.style.background = interner.getColor(entry.str);
+    tape.appendChild(seg);
+  }
+
+  // ID table
+  const table = $("#id-table");
+  table.innerHTML = "";
+  for (const entry of interner.buffer) {
+    const id = interner.getId(entry.str);
+    const color = interner.getColor(entry.str);
+    const badge = el("span", { class: "id-badge" }, `${id}`);
+    badge.style.background = color;
+    const row = el(
+      "div",
+      { class: "intern-id-entry" },
+      badge,
+      el("span", {}, truncStr(entry.str, 18)),
+      el("span", { class: "id-meta" }, `@${entry.offset}+${entry.len}`)
+    );
+    table.appendChild(row);
+  }
+
+  // References
+  const body = $("#interned-body");
+  body.innerHTML = "";
+  const max = Math.min(stats.allLabels.length, 60);
+
+  for (let i = 0; i < max; i++) {
+    const row = el("div", { class: "intern-ref-row" });
+    for (const str of stats.allLabels[i]) {
+      const id = interner.getId(str);
+      const color = interner.getColor(str);
+      const chip = el("span", { class: "intern-ref-chip", title: str }, `${id}`);
+      chip.style.background = color;
+      row.appendChild(chip);
+    }
+    body.appendChild(row);
+  }
+  if (stats.allLabels.length > max) {
+    body.appendChild(
+      el(
+        "div",
+        { style: { color: "var(--xp-text-dim)", fontSize: "11px", padding: "4px 0" } },
+        `… and ${fmt(stats.allLabels.length - max)} more series`
+      )
+    );
+  }
+
+  $("#interned-footer").innerHTML =
+    `Total: <span style="color:var(--xp-success)">${fmtBytes(stats.internedBytes)}</span> ` +
+    `<span style="font-size:11px;color:var(--xp-text-dim)">(buffer ${fmtBytes(stats.internedBufferBytes)} + IDs ${fmtBytes(stats.internedIdBytes)})</span>`;
+}
+
+/* ─── Render: Memory Bars ────────────────────────────────────────── */
+
+function renderMemoryBars(stats) {
+  const wrap = $("#memory-bars");
+  wrap.innerHTML = "";
+  const container = el("div", { class: "intern-mem-bar-row" });
+
+  // Naive bar
+  const naiveBar = el("div", { class: "intern-mem-bar" });
+  naiveBar.innerHTML = `
+    <div class="intern-mem-bar-label">
+      <span>Naive Storage</span>
+      <span class="bytes">${fmtBytes(stats.naiveBytes)}</span>
+    </div>
+    <div class="intern-mem-bar-track">
+      <div class="intern-mem-bar-fill naive" id="naive-bar-fill" style="width:0%">
+        ${fmtBytes(stats.naiveBytes)}
+      </div>
+    </div>`;
+  container.appendChild(naiveBar);
+
+  // Interned bar
+  const internedBar = el("div", { class: "intern-mem-bar" });
+  const pct = Math.max(2, (stats.internedBytes / stats.naiveBytes) * 100);
+  internedBar.innerHTML = `
+    <div class="intern-mem-bar-label">
+      <span>Interned Storage</span>
+      <span class="bytes">${fmtBytes(stats.internedBytes)}</span>
+    </div>
+    <div class="intern-mem-bar-track">
+      <div class="intern-mem-bar-fill interned" id="interned-bar-fill" style="width:0%">
+        ${fmtBytes(stats.internedBytes)}
+      </div>
+    </div>`;
+  container.appendChild(internedBar);
+
+  const badge = el(
+    "div",
+    { class: "intern-savings-badge" },
+    `🎯 ${stats.ratio.toFixed(1)}× smaller with interning`
+  );
+  container.appendChild(badge);
+
+  wrap.appendChild(container);
+
+  // Animate bars
+  requestAnimationFrame(() => {
+    $("#naive-bar-fill").style.width = "100%";
+    $("#interned-bar-fill").style.width = `${pct.toFixed(1)}%`;
+  });
+}
+
+/* ─── Render: Intern Animation ───────────────────────────────────── */
+
+function setupAnimation() {
+  const select = $("#anim-string-select");
+  select.innerHTML = "";
+
+  // Collect some sample strings
+  const samples = [];
+  for (const [k, vals] of Object.entries(LABEL_DEFS)) {
+    for (const v of vals.slice(0, 3)) {
+      samples.push(`${k}=${v}`);
+    }
+  }
+  for (const s of samples) {
+    select.appendChild(el("option", { value: s }, s));
+  }
+
+  setupAnimPipeline();
+  setupHashGrid();
+  resetAnimation();
+}
+
+function setupAnimPipeline() {
+  const pipeline = $("#anim-pipeline");
+  pipeline.innerHTML = "";
+  const stages = [
+    ["📝", "Input"],
+    ["#️⃣", "Hash"],
+    ["🎯", "Bucket"],
+    ["🔍", "Probe"],
+    ["💾", "Result"],
+  ];
+  stages.forEach(([icon, label], i) => {
+    if (i > 0) pipeline.appendChild(el("span", { class: "xp-pipe-arrow" }, "→"));
+    const stage = el(
+      "div",
+      {
+        class: "xp-pipe-stage",
+        "data-stage": `${i}`,
+      },
+      el("span", { class: "stage-icon" }, icon),
+      el("span", { class: "stage-label" }, label)
+    );
+    pipeline.appendChild(stage);
+  });
+}
+
+function setupHashGrid() {
+  const grid = $("#hash-grid");
+  grid.innerHTML = "";
+  animInterner = new StringInterner();
+  for (let i = 0; i < HASH_TABLE_SIZE; i++) {
+    const cell = el(
+      "div",
+      {
+        class: "intern-hash-cell",
+        "data-idx": `${i}`,
+      },
+      `${i}`
+    );
+    grid.appendChild(cell);
+  }
+}
+
+function resetAnimation() {
+  const detail = $("#anim-detail");
+  detail.innerHTML =
+    '<span style="color:var(--xp-text-dim)">Select a string and click <strong>Next →</strong> to begin the interning pipeline.</span>';
+  $$(".xp-pipe-stage", $("#anim-pipeline")).forEach((s) => {
+    s.classList.remove("active");
+  });
+  clearHashGridHighlights();
+  if (stepper) stepper.stop();
+}
+
+function clearHashGridHighlights() {
+  $$(".intern-hash-cell", $("#hash-grid")).forEach((c) => {
+    c.classList.remove("probe-target", "probe-collision", "probe-found");
+  });
+}
+
+function runInternAnimation() {
+  const str = $("#anim-string-select").value;
+  if (!str) return;
+
+  const hash = fnv1a(str);
+  const bucketIdx = hash % HASH_TABLE_SIZE;
+
+  // Pre-compute what will happen
+  const probeSteps = [];
+  let finalIdx = bucketIdx;
+  let isNew = true;
+  let _existingId = -1;
+
+  // Simulate probing
+  for (let i = 0; i < HASH_TABLE_SIZE; i++) {
+    const idx = (bucketIdx + i) % HASH_TABLE_SIZE;
+    const slot = animInterner.table[idx];
+    if (slot === null) {
+      finalIdx = idx;
+      isNew = true;
+      break;
+    }
+    if (slot.str === str) {
+      finalIdx = idx;
+      isNew = false;
+      _existingId = slot.id;
+      break;
+    }
+    probeSteps.push(idx);
+  }
+
+  const totalSteps = probeSteps.length > 0 ? 5 : isNew ? 5 : 5;
+
+  if (stepper) stepper.stop();
+
+  stepper = new Stepper(totalSteps, (step) => {
+    const detail = $("#anim-detail");
+    const pipeline = $$(".xp-pipe-stage", $("#anim-pipeline"));
+    pipeline.forEach((s, i) => {
+      s.classList.toggle("active", i <= step);
+    });
+    clearHashGridHighlights();
+
+    switch (step) {
+      case 0: {
+        // Step 0: Show input string as character grid
+        const bytes = new TextEncoder().encode(str);
+        let charHtml = '<div class="anim-label">Input String</div>';
+        charHtml += `<div><span class="anim-value">"${str}"</span> — ${bytes.length} UTF-8 bytes</div>`;
+        charHtml += '<div class="intern-char-grid">';
+        for (let i = 0; i < str.length; i++) {
+          charHtml += `<span class="intern-char-cell">${escHtml(str[i])}</span>`;
+        }
+        charHtml += "</div>";
+        detail.innerHTML = charHtml;
+        break;
+      }
+      case 1: {
+        // Step 1: Compute FNV-1a hash
+        let html = '<div class="anim-label">FNV-1a Hash</div>';
+        html += '<div class="intern-char-grid">';
+        for (let i = 0; i < str.length; i++) {
+          html += `<span class="intern-char-cell active">${escHtml(str[i])}</span>`;
+        }
+        html += "</div>";
+        html += `<div style="margin-top:8px">hash = <span class="anim-value">0x${hash.toString(16).padStart(8, "0")}</span>`;
+        html += ` (${fmt(hash)})</div>`;
+        html +=
+          '<div style="margin-top:4px;font-size:11px;color:var(--xp-text-dim)">XOR each byte → multiply by FNV prime 0x01000193</div>';
+        detail.innerHTML = html;
+        break;
+      }
+      case 2: {
+        // Step 2: Bucket index
+        let html = '<div class="anim-label">Bucket Index</div>';
+        html += `<div>hash % ${HASH_TABLE_SIZE} = <span class="anim-value">0x${hash.toString(16).padStart(8, "0")}</span> % ${HASH_TABLE_SIZE} = <span class="anim-highlight">${bucketIdx}</span></div>`;
+        detail.innerHTML = html;
+        // Highlight bucket in grid
+        const cell = $(`.intern-hash-cell[data-idx="${bucketIdx}"]`, $("#hash-grid"));
+        if (cell) cell.classList.add("probe-target");
+        break;
+      }
+      case 3: {
+        // Step 3: Probe
+        let html = '<div class="anim-label">Linear Probe</div>';
+        if (probeSteps.length === 0 && isNew) {
+          html += `<div>Bucket <span class="anim-highlight">${bucketIdx}</span> is <span class="anim-highlight">empty</span> — no collision!</div>`;
+          const cell = $(`.intern-hash-cell[data-idx="${bucketIdx}"]`, $("#hash-grid"));
+          if (cell) cell.classList.add("probe-target");
+        } else if (!isNew) {
+          if (probeSteps.length === 0) {
+            html += `<div>Bucket <span class="anim-highlight">${bucketIdx}</span> contains <span class="anim-value">"${str}"</span> — <span class="anim-highlight">match found!</span></div>`;
+          } else {
+            html += `<div>Probed ${probeSteps.length} slot(s) before finding existing <span class="anim-value">"${str}"</span></div>`;
+            html += `<div style="margin-top:4px;font-size:11px">Probe path: ${probeSteps.map((i) => `<span class="anim-warn">${i}</span>`).join(" → ")} → <span class="anim-highlight">${finalIdx}</span></div>`;
+          }
+          for (const idx of probeSteps) {
+            const cell = $(`.intern-hash-cell[data-idx="${idx}"]`, $("#hash-grid"));
+            if (cell) cell.classList.add("probe-collision");
+          }
+          const cell = $(`.intern-hash-cell[data-idx="${finalIdx}"]`, $("#hash-grid"));
+          if (cell) cell.classList.add("probe-found");
+        } else {
+          html += `<div>Collision! Probed ${probeSteps.length} occupied slot(s):</div>`;
+          html += `<div style="margin-top:4px;font-size:11px">Probe path: ${probeSteps.map((i) => `<span class="anim-warn">${i}</span>`).join(" → ")} → <span class="anim-highlight">${finalIdx}</span> (empty)</div>`;
+          for (const idx of probeSteps) {
+            const cell = $(`.intern-hash-cell[data-idx="${idx}"]`, $("#hash-grid"));
+            if (cell) cell.classList.add("probe-collision");
+          }
+          const cell = $(`.intern-hash-cell[data-idx="${finalIdx}"]`, $("#hash-grid"));
+          if (cell) cell.classList.add("probe-target");
+        }
+        detail.innerHTML = html;
+        break;
+      }
+      case 4: {
+        // Step 4: Result — actually perform the intern
+        const result = animInterner.intern(str);
+        let _html = '<div class="anim-label">Result</div>';
+        if (result.isNew) {
+          _html += `<div><span class="anim-highlight">NEW</span> — stored in buffer, assigned ID <span class="anim-value">${result.id}</span></div>`;
+          _html += `<div style="margin-top:4px;font-size:12px">Buffer offset: ${animInterner.buffer[result.id].offset}, length: ${animInterner.buffer[result.id].len} bytes</div>`;
+        } else {
+          _html += `<div><span class="anim-value">REUSE</span> — already interned as ID <span class="anim-value">${result.id}</span></div>`;
+          _html += `<div style="margin-top:4px;font-size:12px;color:var(--xp-success)">Zero new storage needed — just return the existing 4-byte ID</div>`;
+        }
+        // Update hash grid to show occupied cells
+        updateHashGridDisplay();
+        break;
+      }
+    }
+  });
+
+  stepper.next();
+}
+
+function updateHashGridDisplay() {
+  const grid = $("#hash-grid");
+  for (let i = 0; i < HASH_TABLE_SIZE; i++) {
+    const cell = $(`.intern-hash-cell[data-idx="${i}"]`, grid);
+    const slot = animInterner.table[i];
+    if (slot) {
+      cell.classList.add("occupied");
+      cell.style.background = animInterner.getColor(slot.str);
+      cell.style.borderColor = animInterner.getColor(slot.str);
+      cell.textContent = `${slot.id}`;
+      cell.title = `ID ${slot.id}: ${slot.str}`;
+    }
+  }
+}
+
+/* ─── Render: Cardinality Chart ──────────────────────────────────── */
+
+function renderCardinalityChart() {
+  const canvas = $("#cardinality-canvas");
+  const ctx = canvas.getContext("2d");
+  const dpr = window.devicePixelRatio || 1;
+  const w = canvas.clientWidth;
+  const h = canvas.clientHeight;
+  canvas.width = w * dpr;
+  canvas.height = h * dpr;
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, w, h);
+
+  const totalRefs = 40000;
+  const avgLen = 15;
+  const uniqueCounts = [10, 25, 50, 100, 200, 500, 1000];
+
+  const naivePoints = uniqueCounts.map(() => totalRefs * avgLen);
+  const internedPoints = uniqueCounts.map((u) => u * avgLen + totalRefs * 4);
+
+  const maxVal = Math.max(...naivePoints, ...internedPoints);
+  const padL = 70,
+    padR = 20,
+    padT = 20,
+    padB = 40;
+  const plotW = w - padL - padR;
+  const plotH = h - padT - padB;
+
+  // Grid lines
+  ctx.strokeStyle = "rgba(96, 165, 250, 0.08)";
+  ctx.lineWidth = 1;
+  for (let i = 0; i <= 4; i++) {
+    const y = padT + (plotH / 4) * i;
+    ctx.beginPath();
+    ctx.moveTo(padL, y);
+    ctx.lineTo(w - padR, y);
+    ctx.stroke();
+  }
+
+  // Y-axis labels
+  ctx.font = "10px IBM Plex Mono, monospace";
+  ctx.fillStyle = "#64748b";
+  ctx.textAlign = "right";
+  for (let i = 0; i <= 4; i++) {
+    const y = padT + (plotH / 4) * i;
+    const val = maxVal - (maxVal / 4) * i;
+    ctx.fillText(formatKB(val), padL - 8, y + 3);
+  }
+
+  // X-axis labels
+  ctx.textAlign = "center";
+  uniqueCounts.forEach((u, i) => {
+    const x = padL + (i / (uniqueCounts.length - 1)) * plotW;
+    ctx.fillText(`${u}`, x, h - padB + 18);
+  });
+
+  // X-axis title
+  ctx.fillStyle = "#94a3b8";
+  ctx.font = "11px Space Grotesk, sans-serif";
+  ctx.fillText("Unique Strings", padL + plotW / 2, h - 4);
+
+  // Draw naive line (flat — always the same)
+  ctx.beginPath();
+  ctx.strokeStyle = "#f87171";
+  ctx.lineWidth = 2;
+  uniqueCounts.forEach((_, i) => {
+    const x = padL + (i / (uniqueCounts.length - 1)) * plotW;
+    const y = padT + plotH * (1 - naivePoints[i] / maxVal);
+    i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+  });
+  ctx.stroke();
+
+  // Naive fill
+  ctx.lineTo(padL + plotW, padT + plotH);
+  ctx.lineTo(padL, padT + plotH);
+  ctx.closePath();
+  ctx.fillStyle = "rgba(248, 113, 113, 0.06)";
+  ctx.fill();
+
+  // Draw interned line
+  ctx.beginPath();
+  ctx.strokeStyle = "#34d399";
+  ctx.lineWidth = 2;
+  uniqueCounts.forEach((_, i) => {
+    const x = padL + (i / (uniqueCounts.length - 1)) * plotW;
+    const y = padT + plotH * (1 - internedPoints[i] / maxVal);
+    i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+  });
+  ctx.stroke();
+
+  // Interned fill
+  ctx.lineTo(padL + plotW, padT + plotH);
+  ctx.lineTo(padL, padT + plotH);
+  ctx.closePath();
+  ctx.fillStyle = "rgba(52, 211, 153, 0.06)";
+  ctx.fill();
+
+  // Draw data points
+  uniqueCounts.forEach((_, i) => {
+    const x = padL + (i / (uniqueCounts.length - 1)) * plotW;
+    // Naive dot
+    const ny = padT + plotH * (1 - naivePoints[i] / maxVal);
+    ctx.beginPath();
+    ctx.arc(x, ny, 3, 0, Math.PI * 2);
+    ctx.fillStyle = "#f87171";
+    ctx.fill();
+
+    // Interned dot
+    const iy = padT + plotH * (1 - internedPoints[i] / maxVal);
+    ctx.beginPath();
+    ctx.arc(x, iy, 3, 0, Math.PI * 2);
+    ctx.fillStyle = "#34d399";
+    ctx.fill();
+  });
+
+  // Draw savings annotations at a few points
+  [1, 3, 5].forEach((i) => {
+    const x = padL + (i / (uniqueCounts.length - 1)) * plotW;
+    const ny = padT + plotH * (1 - naivePoints[i] / maxVal);
+    const iy = padT + plotH * (1 - internedPoints[i] / maxVal);
+    const ratio = (naivePoints[i] / internedPoints[i]).toFixed(1);
+
+    ctx.fillStyle = "rgba(52, 211, 153, 0.8)";
+    ctx.font = "10px IBM Plex Mono, monospace";
+    ctx.textAlign = "center";
+    ctx.fillText(`${ratio}×`, x + 18, (ny + iy) / 2 + 3);
+  });
+
+  // Legend
+  const legend = $("#cardinality-legend");
+  legend.innerHTML = `
+    <span><span class="legend-swatch" style="background:#f87171"></span>Naive (40K refs × 15 B each)</span>
+    <span><span class="legend-swatch" style="background:#34d399"></span>Interned (unique × 15 B + 40K × 4 B IDs)</span>
+  `;
+}
+
+/* ─── Helpers ────────────────────────────────────────────────────── */
+
+function truncStr(s, max) {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
+function escHtml(s) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function formatKB(bytes) {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${bytes} B`;
+}
+
+/* ─── Orchestration ──────────────────────────────────────────────── */
+
+function refresh() {
+  const count = Number($("#series-slider").value);
+  series = generateSeries(count);
+  const stats = computeStats(series);
+
+  renderGenSummary(stats);
+  renderStats(stats);
+  renderNaivePanel(stats);
+  renderInternedPanel(stats);
+  renderMemoryBars(stats);
+  renderCardinalityChart();
+}
+
+/* ─── Init ───────────────────────────────────────────────────────── */
+
+function init() {
+  // Breadcrumb
+  $("#breadcrumb-nav").innerHTML = buildBreadcrumb("String Interning");
+
+  // Slider live update
+  const slider = $("#series-slider");
+  const display = $("#series-count-display");
+  slider.addEventListener("input", () => {
+    display.textContent = slider.value;
+  });
+
+  // Generate button
+  $("#btn-generate").addEventListener("click", refresh);
+
+  // Animation controls
+  $("#btn-anim-next").addEventListener("click", () => {
+    if (!stepper || stepper.current >= stepper.total - 1) {
+      runInternAnimation();
+    } else {
+      stepper.next();
+    }
+  });
+  $("#btn-anim-prev").addEventListener("click", () => stepper?.prev());
+  $("#btn-anim-play").addEventListener("click", () => {
+    runInternAnimation();
+    if (stepper) {
+      // Auto-advance after first step
+      setTimeout(() => stepper?.play(1400), 200);
+    }
+  });
+  $("#btn-anim-reset").addEventListener("click", () => {
+    setupHashGrid();
+    resetAnimation();
+  });
+
+  // String select change resets animation state
+  $("#anim-string-select").addEventListener("change", () => {
+    clearHashGridHighlights();
+    if (stepper) stepper.stop();
+    stepper = null;
+    resetAnimation();
+  });
+
+  // Initial render
+  setupAnimation();
+  refresh();
+
+  // Resize handler for canvas
+  window.addEventListener("resize", () => renderCardinalityChart());
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/site/tsdb-engine/learn/string-interning/intern-experience.js
+++ b/site/tsdb-engine/learn/string-interning/intern-experience.js
@@ -2,7 +2,7 @@
  * String Interning — Interactive Experience
  * Demonstrates how TSDB engines store label strings once and reference them by ID.
  */
-import { $, $$, buildBreadcrumb, el, fmt, fmtBytes, Stepper } from "../shared.js";
+import { $, $$, buildBreadcrumb, buildStat, el, fmt, fmtBytes, Stepper } from "../shared.js";
 
 /* ─── Constants ──────────────────────────────────────────────────── */
 
@@ -204,14 +204,7 @@ function renderStats(stats) {
     ["Savings", `${stats.ratio.toFixed(1)}×`, ""],
   ];
   for (const [label, value, unit] of items) {
-    row.appendChild(
-      el(
-        "div",
-        { class: "xp-stat" },
-        el("span", { class: "xp-stat-label" }, label),
-        el("span", { class: "xp-stat-value" }, value, el("span", { class: "xp-stat-unit" }, unit))
-      )
-    );
+    row.appendChild(buildStat(label, value, unit));
   }
 }
 

--- a/site/tsdb-engine/learn/xor-delta/index.html
+++ b/site/tsdb-engine/learn/xor-delta/index.html
@@ -51,7 +51,7 @@
         <h2>③ XOR Visualization Table</h2>
         <p>Each row shows a value XOR'd with its predecessor. Click any row to expand bit-level detail.</p>
         <div class="xp-card xor-table-wrap">
-          <div class="xor-table-scroll">
+          <div class="xor-table-scroll xp-scroll-x">
             <table class="xp-table xor-table" id="xor-table">
               <thead>
                 <tr>
@@ -85,7 +85,7 @@
         <h2>⑤ Compression Summary</h2>
         <div class="xp-stats-row" id="summary-stats"></div>
         <div class="xor-encoding-bar" id="encoding-bar"></div>
-        <div class="xor-story" id="compression-story"></div>
+        <div class="xor-story xp-story" id="compression-story"></div>
       </section>
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">

--- a/site/tsdb-engine/learn/xor-delta/index.html
+++ b/site/tsdb-engine/learn/xor-delta/index.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>XOR-Delta Value Compression — Interactive Experience | o11ytsdb</title>
+    <meta name="description" content="See how Gorilla-style XOR encoding compresses float64 values by exploiting temporal locality — interactively explore leading/trailing zeros, window reuse, and bit-level encoding." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500&display=swap" />
+    <link rel="stylesheet" href="../shared.css" />
+    <link rel="stylesheet" href="xor-experience.css" />
+  </head>
+  <body>
+    <a href="#main" class="xp-skip-link">Skip to content</a>
+    <div class="xp-ambient" aria-hidden="true"></div>
+    <div class="xp-page" id="main">
+
+      <div id="breadcrumb-nav"></div>
+
+      <div class="xp-hero">
+        <p class="xp-eyebrow">Value Compression</p>
+        <h1>XOR‑Delta</h1>
+        <p class="lede">
+          Metrics that change slowly — temperature, CPU&nbsp;%, latency — produce nearly
+          identical IEEE&nbsp;754 bit patterns. XOR‑Delta exploits this: XOR consecutive
+          values, and most bits cancel out. The remaining handful of
+          <strong>meaningful bits</strong> is all you need to store.
+        </p>
+      </div>
+
+      <!-- A. Signal Pattern Picker -->
+      <section class="xp-section" id="signal-section">
+        <h2>① Choose a Signal</h2>
+        <p>Pick a pattern and watch how temporal locality affects compression.</p>
+        <div class="xp-card">
+          <div class="xp-controls" id="pattern-controls"></div>
+          <canvas id="sparkline-canvas" height="64"></canvas>
+        </div>
+      </section>
+
+      <!-- D. Encoding Decision Tree -->
+      <section class="xp-section" id="tree-section">
+        <h2>② Encoding Decision Tree</h2>
+        <p>Every value follows this flowchart. Click a table row below to highlight the path taken.</p>
+        <div class="xp-card" id="decision-tree"></div>
+      </section>
+
+      <!-- B. XOR Visualization Table -->
+      <section class="xp-section" id="table-section">
+        <h2>③ XOR Visualization Table</h2>
+        <p>Each row shows a value XOR'd with its predecessor. Click any row to expand bit-level detail.</p>
+        <div class="xp-card xor-table-wrap">
+          <div class="xor-table-scroll">
+            <table class="xp-table xor-table" id="xor-table">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Value</th>
+                  <th>XOR with prev</th>
+                  <th>Lead 0s</th>
+                  <th>Trail 0s</th>
+                  <th>Meaningful</th>
+                  <th>Encoding</th>
+                  <th>Cost</th>
+                </tr>
+              </thead>
+              <tbody id="xor-tbody"></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <!-- E. Compression Cost Profile -->
+      <section class="xp-section" id="cost-section">
+        <h2>④ Bit Cost Profile</h2>
+        <p>Each bar shows one value's encoding cost. Green = identical (1 bit), blue = window reuse, yellow = new window.</p>
+        <div class="xp-card">
+          <canvas id="cost-canvas" height="220"></canvas>
+        </div>
+      </section>
+
+      <!-- F. Pattern Comparison Summary -->
+      <section class="xp-section" id="summary-section">
+        <h2>⑤ Compression Summary</h2>
+        <div class="xp-stats-row" id="summary-stats"></div>
+        <div class="xor-encoding-bar" id="encoding-bar"></div>
+        <div class="xor-story" id="compression-story"></div>
+      </section>
+
+      <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
+        <p style="font-size: 13px; color: var(--xp-text-dim);">
+          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+        </p>
+      </footer>
+
+    </div>
+    <script type="module" src="xor-experience.js"></script>
+  </body>
+</html>

--- a/site/tsdb-engine/learn/xor-delta/index.html
+++ b/site/tsdb-engine/learn/xor-delta/index.html
@@ -90,8 +90,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/xor-delta/xor-experience.css
+++ b/site/tsdb-engine/learn/xor-delta/xor-experience.css
@@ -16,17 +16,6 @@
 
 .xor-table-scroll {
   overflow-x: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--xp-border-strong) transparent;
-}
-
-.xor-table-scroll::-webkit-scrollbar {
-  height: 6px;
-}
-
-.xor-table-scroll::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 3px;
 }
 
 .xor-table {
@@ -117,13 +106,8 @@
 }
 
 /* ─── Encoding Badges ─────────────────────────────────────────────── */
+/* Encoding badge — base from .xp-badge in shared.css */
 .xor-enc-badge {
-  display: inline-block;
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 10px;
-  font-weight: 600;
-  font-family: var(--xp-mono);
   letter-spacing: 0.02em;
 }
 
@@ -485,16 +469,7 @@
 }
 
 /* ─── Story Box ───────────────────────────────────────────────────── */
-.xor-story {
-  margin-top: 16px;
-  padding: 16px 20px;
-  background: var(--xp-surface);
-  border: 1px solid var(--xp-border);
-  border-radius: var(--xp-radius-sm);
-  font-size: 14px;
-  line-height: 1.6;
-  color: var(--xp-text-muted);
-}
+/* base from .xp-story in shared.css */
 
 .xor-story strong {
   color: var(--xp-text);

--- a/site/tsdb-engine/learn/xor-delta/xor-experience.css
+++ b/site/tsdb-engine/learn/xor-delta/xor-experience.css
@@ -1,0 +1,544 @@
+/* ─── XOR-Delta Experience ────────────────────────────────────────── */
+
+/* ─── Sparkline Canvas ────────────────────────────────────────────── */
+#sparkline-canvas {
+  width: 100%;
+  height: 64px;
+  display: block;
+  margin-top: 12px;
+}
+
+/* ─── Table ───────────────────────────────────────────────────────── */
+.xor-table-wrap {
+  padding: 0;
+  overflow: hidden;
+}
+
+.xor-table-scroll {
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--xp-border-strong) transparent;
+}
+
+.xor-table-scroll::-webkit-scrollbar {
+  height: 6px;
+}
+
+.xor-table-scroll::-webkit-scrollbar-thumb {
+  background: var(--xp-border-strong);
+  border-radius: 3px;
+}
+
+.xor-table {
+  min-width: 820px;
+}
+
+.xor-table td {
+  font-family: var(--xp-mono);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.xor-table td.xor-idx {
+  color: var(--xp-text-dim);
+  font-weight: 600;
+  width: 32px;
+}
+
+.xor-table td.xor-val {
+  color: var(--xp-text);
+}
+
+.xor-table td.xor-na {
+  color: var(--xp-text-dim);
+  font-style: italic;
+  font-family: var(--xp-font);
+}
+
+.xor-table td.xor-num {
+  text-align: center;
+  color: var(--xp-text-muted);
+}
+
+.xor-table td.xor-cost {
+  font-weight: 600;
+}
+
+/* Row encoding left-border accent */
+.xor-table tr.xor-enc-first td:first-child {
+  border-left: 3px solid var(--region-header);
+}
+.xor-table tr.xor-enc-identical td:first-child {
+  border-left: 3px solid var(--tier-0);
+}
+.xor-table tr.xor-enc-reuse td:first-child {
+  border-left: 3px solid var(--tier-1);
+}
+.xor-table tr.xor-enc-new td:first-child {
+  border-left: 3px solid var(--tier-3);
+}
+
+.xor-table tr.xor-row {
+  cursor: pointer;
+  transition: background 120ms;
+}
+
+.xor-table tr.xor-row:hover td {
+  background: var(--xp-accent-glow);
+}
+
+.xor-table tr.xor-selected td {
+  background: rgba(96, 165, 250, 0.12);
+}
+
+/* ─── Mini XOR bits in table cell ─────────────────────────────────── */
+.xor-mini-bits {
+  display: inline-flex;
+  gap: 0;
+  font-family: var(--xp-mono);
+  font-size: 8px;
+  line-height: 1;
+  letter-spacing: -0.5px;
+}
+
+.xor-mini-bit {
+  width: 7px;
+  text-align: center;
+  transition: opacity 120ms;
+}
+
+.xor-mini-bit.xor-zero {
+  opacity: 0.15;
+}
+
+.xor-mini-bit.xor-meaningful {
+  color: var(--xp-accent-light);
+  font-weight: 600;
+}
+
+/* ─── Encoding Badges ─────────────────────────────────────────────── */
+.xor-enc-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: var(--xp-mono);
+  letter-spacing: 0.02em;
+}
+
+.xor-enc-badge.enc-first {
+  background: rgba(139, 92, 246, 0.15);
+  color: var(--region-header);
+}
+.xor-enc-badge.enc-identical {
+  background: rgba(52, 211, 153, 0.15);
+  color: var(--tier-0);
+}
+.xor-enc-badge.enc-reuse {
+  background: rgba(96, 165, 250, 0.15);
+  color: var(--tier-1);
+}
+.xor-enc-badge.enc-new {
+  background: rgba(251, 191, 36, 0.15);
+  color: var(--tier-3);
+}
+
+/* ─── Detail Panel (expanded row) ─────────────────────────────────── */
+.xor-table tr.xor-detail-row > td {
+  padding: 0;
+  border-bottom: 1px solid var(--xp-border-strong);
+  background: var(--xp-surface);
+}
+
+.xor-table tr.xor-detail-row:hover > td {
+  background: var(--xp-surface);
+}
+
+.xor-detail-panel {
+  padding: 20px 16px;
+}
+
+.xor-detail-panel h3 {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--xp-text);
+  margin: 0 0 16px;
+}
+
+/* ─── 64-Bit Grid ─────────────────────────────────────────────────── */
+.xor-bitgrid-wrap {
+  margin-bottom: 14px;
+}
+
+.xor-bitgrid-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--xp-text-dim);
+  margin-bottom: 4px;
+}
+
+.xor-bitgrid {
+  overflow-x: auto;
+  flex-wrap: nowrap;
+}
+
+.xor-bitgrid .xp-bit {
+  width: 18px;
+  height: 22px;
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.xor-bitgrid .xp-bit.xor-bit-faded {
+  opacity: 0.15;
+}
+
+.xor-bitgrid .xp-bit.xor-bit-meaningful {
+  background: rgba(96, 165, 250, 0.22);
+  color: var(--xp-accent-light);
+  font-weight: 600;
+  outline: 1px solid rgba(96, 165, 250, 0.35);
+  outline-offset: -1px;
+}
+
+.xor-bitgrid .xp-bit.xor-bit-window {
+  background: rgba(96, 165, 250, 0.1);
+  color: var(--xp-text-muted);
+}
+
+/* ─── Bit Grid Markers ────────────────────────────────────────────── */
+.xor-bitgrid-markers {
+  position: relative;
+  height: 18px;
+  margin-top: 2px;
+  font-size: 9px;
+  font-family: var(--xp-mono);
+}
+
+.xor-marker {
+  position: absolute;
+  text-align: center;
+  color: var(--xp-text-dim);
+  padding-top: 2px;
+  border-top: 1px solid rgba(100, 116, 139, 0.3);
+}
+
+/* ─── Encoded Bits Section ────────────────────────────────────────── */
+.xor-encoded-section {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--xp-border);
+}
+
+.xor-encoded-bits {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  margin: 8px 0;
+}
+
+.xor-enc-bit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 22px;
+  font-family: var(--xp-mono);
+  font-size: 11px;
+  border-radius: 3px;
+  font-weight: 500;
+}
+
+.xor-enc-bit.enc-ctrl {
+  background: rgba(248, 113, 113, 0.2);
+  color: var(--xp-error);
+  border: 1px solid rgba(248, 113, 113, 0.3);
+}
+
+.xor-enc-bit.enc-meta {
+  background: rgba(139, 92, 246, 0.2);
+  color: #a78bfa;
+  border: 1px solid rgba(139, 92, 246, 0.3);
+}
+
+.xor-enc-bit.enc-meta2 {
+  background: rgba(6, 182, 212, 0.2);
+  color: #22d3ee;
+  border: 1px solid rgba(6, 182, 212, 0.3);
+}
+
+.xor-enc-bit.enc-data {
+  background: rgba(96, 165, 250, 0.2);
+  color: var(--xp-accent-light);
+  border: 1px solid rgba(96, 165, 250, 0.3);
+}
+
+.xor-enc-bit.enc-raw {
+  background: var(--xp-surface-raised);
+  color: var(--xp-text-muted);
+}
+
+.xor-enc-annotation {
+  font-size: 12px;
+  color: var(--xp-text-muted);
+  line-height: 1.6;
+  margin-top: 4px;
+}
+
+/* Legend row under encoded bits */
+.xor-enc-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 10px;
+  font-size: 11px;
+  color: var(--xp-text-dim);
+}
+
+.xor-enc-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.xor-enc-legend-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+/* ─── Decision Tree ───────────────────────────────────────────────── */
+.dt-flow {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 8px 0;
+}
+
+.dt-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.dt-node {
+  padding: 10px 16px;
+  background: var(--xp-surface-raised);
+  border: 1px solid var(--xp-border-strong);
+  border-radius: var(--xp-radius-sm);
+  font-size: 13px;
+  color: var(--xp-text);
+  transition: all 200ms;
+  min-width: 120px;
+}
+
+.dt-node code {
+  font-family: var(--xp-mono);
+  background: rgba(96, 165, 250, 0.15);
+  padding: 1px 5px;
+  border-radius: 3px;
+  color: var(--xp-accent-light);
+  font-size: 12px;
+}
+
+.dt-node .dt-label {
+  display: block;
+  font-weight: 600;
+}
+
+.dt-node .dt-cost {
+  display: block;
+  font-size: 11px;
+  color: var(--xp-text-muted);
+  font-family: var(--xp-mono);
+  margin-top: 2px;
+}
+
+.dt-node.dt-active {
+  border-color: var(--xp-accent);
+  background: var(--xp-accent-glow);
+  box-shadow: 0 0 20px rgba(96, 165, 250, 0.15);
+}
+
+.dt-node.dt-active-green {
+  border-color: var(--xp-success);
+  background: var(--xp-success-glow);
+  box-shadow: 0 0 20px rgba(52, 211, 153, 0.15);
+}
+
+.dt-node.dt-active-yellow {
+  border-color: var(--xp-warn);
+  background: var(--xp-warn-glow);
+  box-shadow: 0 0 20px rgba(251, 191, 36, 0.15);
+}
+
+.dt-node.dt-dim {
+  opacity: 0.25;
+}
+
+.dt-arrow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--xp-text-dim);
+  font-size: 13px;
+  font-family: var(--xp-mono);
+  transition: opacity 200ms;
+}
+
+.dt-arrow .dt-lbl {
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.dt-arrow .dt-lbl-yes {
+  color: var(--xp-success);
+}
+.dt-arrow .dt-lbl-no {
+  color: var(--xp-error);
+}
+
+.dt-arrow .dt-arrow-line {
+  font-size: 18px;
+  color: var(--xp-text-dim);
+}
+
+.dt-arrow.dt-active .dt-arrow-line {
+  color: var(--xp-accent);
+}
+
+.dt-arrow.dt-dim {
+  opacity: 0.25;
+}
+
+.dt-vert {
+  padding: 4px 0 4px 40px;
+  font-size: 12px;
+  color: var(--xp-text-dim);
+  font-family: var(--xp-mono);
+  transition: opacity 200ms;
+}
+
+.dt-vert.dt-active {
+  color: var(--xp-accent);
+}
+
+.dt-vert.dt-dim {
+  opacity: 0.25;
+}
+
+/* ─── Cost Profile Canvas ─────────────────────────────────────────── */
+#cost-canvas {
+  width: 100%;
+  display: block;
+}
+
+/* ─── Encoding Distribution Bar ───────────────────────────────────── */
+.xor-dist-bar {
+  display: flex;
+  height: 36px;
+  border-radius: var(--xp-radius-sm);
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+
+.xor-dist-seg {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--xp-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: #0a1624;
+  transition: flex-basis 400ms ease;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  padding: 0 8px;
+}
+
+.xor-dist-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 12px;
+  color: var(--xp-text-muted);
+  margin-top: 8px;
+}
+
+.xor-dist-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.xor-dist-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+/* ─── Story Box ───────────────────────────────────────────────────── */
+.xor-story {
+  margin-top: 16px;
+  padding: 16px 20px;
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--xp-text-muted);
+}
+
+.xor-story strong {
+  color: var(--xp-text);
+  font-weight: 600;
+}
+
+.xor-story .success {
+  color: var(--xp-success);
+}
+
+.xor-story .warn {
+  color: var(--xp-warn);
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .xor-table {
+    min-width: 700px;
+  }
+
+  .xor-table td {
+    font-size: 11px;
+    padding: 6px 8px;
+  }
+
+  .dt-row {
+    gap: 8px;
+  }
+
+  .dt-node {
+    padding: 8px 12px;
+    font-size: 12px;
+    min-width: 100px;
+  }
+
+  .xor-bitgrid .xp-bit {
+    width: 14px;
+    height: 18px;
+    font-size: 9px;
+  }
+
+  .xor-enc-bit {
+    width: 14px;
+    height: 18px;
+    font-size: 9px;
+  }
+}

--- a/site/tsdb-engine/learn/xor-delta/xor-experience.js
+++ b/site/tsdb-engine/learn/xor-delta/xor-experience.js
@@ -1,0 +1,898 @@
+/**
+ * XOR-Delta Value Compression — Interactive Experience
+ *
+ * Demonstrates Gorilla-style XOR value encoding:
+ *   Raw float64 → XOR with previous → leading/trailing zero analysis
+ *   → identical (1 bit) / reuse window (2+M bits) / new window (14+M bits)
+ */
+
+import {
+  $,
+  $$,
+  buildBreadcrumb,
+  clz64,
+  ctz64,
+  drawSparkline,
+  el,
+  float64ToBits,
+  fmt,
+  fmtBytes,
+} from "../shared.js";
+
+/* ─── Constants ───────────────────────────────────────────────────── */
+
+const SAMPLE_COUNT = 20;
+
+const PATTERNS = [
+  { id: "slow-sine", label: "Slow Sine", icon: "〜" },
+  { id: "temperature", label: "Temperature", icon: "🌡" },
+  { id: "random", label: "Random", icon: "🎲" },
+  { id: "constant", label: "Constant", icon: "═" },
+];
+
+const ENC_COLORS = {
+  first: "#8b5cf6",
+  identical: "#34d399",
+  reuse: "#60a5fa",
+  new: "#fbbf24",
+};
+
+const ENC_LABELS = {
+  first: "raw",
+  identical: "identical",
+  reuse: "reuse window",
+  new: "new window",
+};
+
+/* ─── State ───────────────────────────────────────────────────────── */
+
+let activePattern = "slow-sine";
+let values = [];
+let rows = [];
+let selectedRow = -1;
+
+/* ─── Signal Generation ───────────────────────────────────────────── */
+
+function generateValues(pattern, count) {
+  const vals = new Float64Array(count);
+  switch (pattern) {
+    case "slow-sine":
+      for (let i = 0; i < count; i++) {
+        vals[i] = Math.round(50 + Math.sin(i * 0.2) * 5);
+      }
+      break;
+    case "temperature":
+      for (let i = 0; i < count; i++) {
+        vals[i] = Math.round((22 + Math.sin(i * 0.15) * 3 + (Math.random() - 0.5) * 0.5) * 10) / 10;
+      }
+      break;
+    case "random":
+      for (let i = 0; i < count; i++) {
+        vals[i] = Math.random() * 200;
+      }
+      break;
+    case "constant":
+      for (let i = 0; i < count; i++) {
+        vals[i] = 42.5;
+      }
+      break;
+  }
+  return vals;
+}
+
+/* ─── IEEE 754 → BigInt ───────────────────────────────────────────── */
+
+function float64ToUint64(value) {
+  const buf = new ArrayBuffer(8);
+  new Float64Array(buf)[0] = value;
+  const bytes = new Uint8Array(buf);
+  let result = 0n;
+  for (let i = 7; i >= 0; i--) {
+    result = (result << 8n) | BigInt(bytes[i]);
+  }
+  return result;
+}
+
+function bigIntToBitString(n) {
+  let s = "";
+  for (let i = 63; i >= 0; i--) {
+    s += (n >> BigInt(i)) & 1n ? "1" : "0";
+  }
+  return s;
+}
+
+/* ─── XOR-Delta Encoding ──────────────────────────────────────────── */
+
+function computeRows(vals) {
+  const result = [];
+  // Sentinel: no window established yet — forces "new window" for first XOR≠0
+  let prevLeading = 255;
+  let prevTrailing = 0;
+
+  for (let i = 0; i < vals.length; i++) {
+    const value = vals[i];
+    const bits = float64ToBits(value);
+    const uint64 = float64ToUint64(value);
+
+    if (i === 0) {
+      result.push({
+        idx: 0,
+        value,
+        bits,
+        uint64,
+        xorBits: null,
+        xorUint64: null,
+        leadingZeros: null,
+        trailingZeros: null,
+        meaningfulBits: null,
+        encoding: "first",
+        cost: 64,
+        windowLeading: null,
+        windowTrailing: null,
+        windowMeaningful: null,
+      });
+      continue;
+    }
+
+    const prevUint64 = float64ToUint64(vals[i - 1]);
+    const xorUint64 = prevUint64 ^ uint64;
+    const xorBits = bigIntToBitString(xorUint64);
+
+    const lz = clz64(xorUint64);
+    const tz = ctz64(xorUint64);
+    const meaningful = xorUint64 === 0n ? 0 : 64 - lz - tz;
+
+    let encoding, cost, windowLeading, windowTrailing, windowMeaningful;
+
+    if (xorUint64 === 0n) {
+      encoding = "identical";
+      cost = 1;
+      windowLeading = prevLeading;
+      windowTrailing = prevTrailing;
+      windowMeaningful = prevLeading === 255 ? 0 : 64 - prevLeading - prevTrailing;
+    } else if (prevLeading !== 255 && lz >= prevLeading && tz >= prevTrailing) {
+      encoding = "reuse";
+      windowLeading = prevLeading;
+      windowTrailing = prevTrailing;
+      windowMeaningful = 64 - prevLeading - prevTrailing;
+      cost = 2 + windowMeaningful;
+    } else {
+      encoding = "new";
+      windowLeading = lz;
+      windowTrailing = tz;
+      windowMeaningful = meaningful;
+      cost = 2 + 6 + 6 + meaningful; // 14 + M control/metadata overhead
+      prevLeading = lz;
+      prevTrailing = tz;
+    }
+
+    result.push({
+      idx: i,
+      value,
+      bits,
+      uint64,
+      xorBits,
+      xorUint64,
+      leadingZeros: lz,
+      trailingZeros: tz,
+      meaningfulBits: meaningful,
+      encoding,
+      cost,
+      windowLeading,
+      windowTrailing,
+      windowMeaningful,
+    });
+  }
+
+  return result;
+}
+
+/* ─── Render: Pattern Picker ──────────────────────────────────────── */
+
+function renderPatternPicker() {
+  const container = $("#pattern-controls");
+  container.innerHTML = "";
+
+  for (const p of PATTERNS) {
+    const btn = el(
+      "button",
+      {
+        class: `xp-btn${p.id === activePattern ? " active" : ""}`,
+        "data-pattern": p.id,
+        onClick: () => {
+          activePattern = p.id;
+          selectedRow = -1;
+          recompute();
+        },
+      },
+      `${p.icon} ${p.label}`
+    );
+    container.appendChild(btn);
+  }
+}
+
+function updatePatternButtons() {
+  for (const btn of $$(".xp-btn[data-pattern]")) {
+    btn.classList.toggle("active", btn.dataset.pattern === activePattern);
+  }
+}
+
+/* ─── Render: Sparkline ───────────────────────────────────────────── */
+
+function renderSparkline() {
+  const canvas = $("#sparkline-canvas");
+  canvas.style.width = "100%";
+  drawSparkline(canvas, Array.from(values), {
+    color: "rgb(96, 165, 250)",
+    fillAlpha: 0.08,
+    lineWidth: 2,
+  });
+}
+
+/* ─── Render: Decision Tree ───────────────────────────────────────── */
+
+function renderDecisionTree() {
+  const container = $("#decision-tree");
+  const row = selectedRow >= 0 ? rows[selectedRow] : null;
+  const enc = row ? row.encoding : null;
+
+  // Determine which nodes/arrows are on the active path
+  const isFirst = enc === "first";
+  const isIdentical = enc === "identical";
+  const isReuse = enc === "reuse";
+  const isNew = enc === "new";
+  const hasPath = enc && !isFirst;
+
+  function nc(nodeId) {
+    if (!hasPath) return "dt-node";
+    switch (nodeId) {
+      case "xor-q":
+        return hasPath ? "dt-node dt-active" : "dt-node dt-dim";
+      case "identical":
+        return isIdentical ? "dt-node dt-active-green" : "dt-node dt-dim";
+      case "window-q":
+        return isReuse || isNew ? "dt-node dt-active" : "dt-node dt-dim";
+      case "reuse":
+        return isReuse ? "dt-node dt-active" : "dt-node dt-dim";
+      case "new":
+        return isNew ? "dt-node dt-active-yellow" : "dt-node dt-dim";
+      default:
+        return "dt-node";
+    }
+  }
+
+  function ac(arrowId) {
+    if (!hasPath) return "dt-arrow";
+    switch (arrowId) {
+      case "xor-yes":
+        return isIdentical ? "dt-arrow dt-active" : "dt-arrow dt-dim";
+      case "xor-no":
+        return isReuse || isNew ? "dt-arrow dt-active" : "dt-arrow dt-dim";
+      case "win-yes":
+        return isReuse ? "dt-arrow dt-active" : "dt-arrow dt-dim";
+      case "win-no":
+        return isNew ? "dt-arrow dt-active" : "dt-arrow dt-dim";
+      default:
+        return "dt-arrow";
+    }
+  }
+
+  function vc(vertId) {
+    if (!hasPath) return "dt-vert";
+    switch (vertId) {
+      case "v1":
+        return isReuse || isNew ? "dt-vert dt-active" : "dt-vert dt-dim";
+      case "v2":
+        return isNew ? "dt-vert dt-active" : "dt-vert dt-dim";
+      default:
+        return "dt-vert";
+    }
+  }
+
+  // Cost annotation for the active leaf
+  let costNote = "";
+  if (row && hasPath) {
+    costNote = ` → ${row.cost} bits`;
+  }
+
+  container.innerHTML = `
+    <div class="dt-flow">
+      <div class="dt-row">
+        <div class="${nc("xor-q")}">
+          <span class="dt-label">XOR = 0 ?</span>
+        </div>
+        <div class="${ac("xor-yes")}">
+          <span class="dt-lbl dt-lbl-yes">yes</span>
+          <span class="dt-arrow-line">→</span>
+        </div>
+        <div class="${nc("identical")}">
+          <span class="dt-label">Write "<code>0</code>"</span>
+          <span class="dt-cost">1 bit${isIdentical ? costNote : ""}</span>
+        </div>
+      </div>
+
+      <div class="${vc("v1")}">
+        <span>no ↓</span>
+      </div>
+
+      <div class="dt-row">
+        <div class="${nc("window-q")}">
+          <span class="dt-label">Window fits ?</span>
+          <span class="dt-cost">lead ≥ prev_lead &amp;&amp; trail ≥ prev_trail</span>
+        </div>
+        <div class="${ac("win-yes")}">
+          <span class="dt-lbl dt-lbl-yes">yes</span>
+          <span class="dt-arrow-line">→</span>
+        </div>
+        <div class="${nc("reuse")}">
+          <span class="dt-label">Write "<code>10</code>" + meaningful</span>
+          <span class="dt-cost">2 + M bits${isReuse ? costNote : ""}</span>
+        </div>
+      </div>
+
+      <div class="${vc("v2")}">
+        <span>no ↓</span>
+      </div>
+
+      <div class="dt-row">
+        <div class="${nc("new")}">
+          <span class="dt-label">Write "<code>11</code>" + 6‑bit lead + 6‑bit len + meaningful</span>
+          <span class="dt-cost">14 + M bits${isNew ? costNote : ""}</span>
+        </div>
+      </div>
+    </div>`;
+}
+
+/* ─── Mini XOR bits for table cell ────────────────────────────────── */
+
+function buildMiniXorBits(row) {
+  const container = el("div", { class: "xor-mini-bits" });
+  const { xorBits, leadingZeros: lz, trailingZeros: tz } = row;
+
+  for (let i = 0; i < 64; i++) {
+    const bit = xorBits[i];
+    let cls = "xor-mini-bit";
+    if (i < lz || i >= 64 - tz) {
+      cls += " xor-zero";
+    } else {
+      cls += " xor-meaningful";
+    }
+    container.appendChild(el("span", { class: cls }, bit));
+  }
+  return container;
+}
+
+/* ─── Build 64-bit grid ───────────────────────────────────────────── */
+
+function buildBitGrid(bits, options = {}) {
+  const {
+    leadingZeros = 0,
+    trailingZeros = 0,
+    highlightMeaningful = false,
+    windowLeading,
+    windowTrailing,
+    label = "",
+  } = options;
+
+  const wrap = el("div", { class: "xor-bitgrid-wrap" });
+  if (label) {
+    wrap.appendChild(el("div", { class: "xor-bitgrid-label" }, label));
+  }
+
+  const grid = el("div", { class: "xp-bit-grid xor-bitgrid" });
+  const hasWindow = windowLeading !== undefined;
+  const wl = hasWindow ? windowLeading : leadingZeros;
+  const wt = hasWindow ? windowTrailing : trailingZeros;
+
+  for (let i = 0; i < 64; i++) {
+    const bit = bits[i];
+    let cls = "xp-bit";
+
+    if (highlightMeaningful) {
+      const inWindow = i >= wl && i < 64 - wt;
+      const isActualMeaningful = i >= leadingZeros && i < 64 - trailingZeros;
+
+      if (isActualMeaningful) {
+        cls += " xor-bit-meaningful";
+      } else if (inWindow) {
+        cls += " xor-bit-window";
+      } else {
+        cls += " xor-bit-faded";
+      }
+    }
+
+    const cell = el("div", { class: cls, "data-v": bit });
+    cell.textContent = bit;
+    grid.appendChild(cell);
+  }
+  wrap.appendChild(grid);
+
+  // Position markers
+  if (highlightMeaningful && (leadingZeros > 0 || trailingZeros > 0)) {
+    const markers = el("div", { class: "xor-bitgrid-markers" });
+    if (leadingZeros > 0) {
+      markers.appendChild(
+        el(
+          "span",
+          {
+            class: "xor-marker",
+            style: { left: "0", width: `${(leadingZeros / 64) * 100}%` },
+          },
+          `${leadingZeros} leading`
+        )
+      );
+    }
+    if (trailingZeros > 0) {
+      markers.appendChild(
+        el(
+          "span",
+          {
+            class: "xor-marker",
+            style: { right: "0", width: `${(trailingZeros / 64) * 100}%`, textAlign: "right" },
+          },
+          `${trailingZeros} trailing`
+        )
+      );
+    }
+    wrap.appendChild(markers);
+  }
+
+  return wrap;
+}
+
+/* ─── Detail Panel — first value ──────────────────────────────────── */
+
+function buildFirstValueDetail(row) {
+  const panel = el("div", { class: "xor-detail-panel xp-animate-in" });
+  panel.appendChild(el("h3", {}, `Value #${row.idx}: ${row.value} — stored as raw 64 bits`));
+  panel.appendChild(buildBitGrid(row.bits, { label: "IEEE 754 bits" }));
+
+  const encSection = el("div", { class: "xor-encoded-section" });
+  encSection.appendChild(el("div", { class: "xor-bitgrid-label" }, "Encoded output"));
+  const encGrid = el("div", { class: "xor-encoded-bits" });
+  for (let i = 0; i < 64; i++) {
+    encGrid.appendChild(el("span", { class: "xor-enc-bit enc-raw" }, row.bits[i]));
+  }
+  encSection.appendChild(encGrid);
+  encSection.appendChild(
+    el("div", { class: "xor-enc-annotation" }, "64 raw bits — first value stored uncompressed")
+  );
+  panel.appendChild(encSection);
+  return panel;
+}
+
+/* ─── Detail Panel — subsequent values ────────────────────────────── */
+
+function buildDetailPanel(row) {
+  const panel = el("div", { class: "xor-detail-panel xp-animate-in" });
+  const prevRow = rows[row.idx - 1];
+
+  panel.appendChild(el("h3", {}, `Value #${row.idx}: ${row.value}`));
+
+  // Previous & current bit grids
+  panel.appendChild(
+    buildBitGrid(prevRow.bits, { label: `Previous (#${prevRow.idx}): ${prevRow.value}` })
+  );
+  panel.appendChild(buildBitGrid(row.bits, { label: `Current (#${row.idx}): ${row.value}` }));
+
+  // XOR result with meaningful highlighting
+  if (row.encoding === "identical") {
+    panel.appendChild(
+      buildBitGrid(row.xorBits, {
+        label: "XOR result — all zeros (identical)",
+        leadingZeros: 64,
+        trailingZeros: 0,
+        highlightMeaningful: true,
+      })
+    );
+  } else {
+    panel.appendChild(
+      buildBitGrid(row.xorBits, {
+        label: "XOR result",
+        leadingZeros: row.leadingZeros,
+        trailingZeros: row.trailingZeros,
+        highlightMeaningful: true,
+        windowLeading: row.windowLeading,
+        windowTrailing: row.windowTrailing,
+      })
+    );
+  }
+
+  // Encoded bits with colored annotations
+  const encSection = el("div", { class: "xor-encoded-section" });
+  encSection.appendChild(el("div", { class: "xor-bitgrid-label" }, "Encoded output"));
+
+  const encGrid = el("div", { class: "xor-encoded-bits" });
+
+  if (row.encoding === "identical") {
+    encGrid.appendChild(el("span", { class: "xor-enc-bit enc-ctrl" }, "0"));
+    encSection.appendChild(encGrid);
+    encSection.appendChild(
+      el("div", { class: "xor-enc-annotation" }, '"0" → values are identical. Total: 1 bit.')
+    );
+  } else if (row.encoding === "reuse") {
+    // Control: "10"
+    encGrid.appendChild(el("span", { class: "xor-enc-bit enc-ctrl" }, "1"));
+    encGrid.appendChild(el("span", { class: "xor-enc-bit enc-ctrl" }, "0"));
+
+    // Data: meaningful bits within previous window
+    const wl = row.windowLeading;
+    const wt = row.windowTrailing;
+    for (let i = wl; i < 64 - wt; i++) {
+      encGrid.appendChild(el("span", { class: "xor-enc-bit enc-data" }, row.xorBits[i]));
+    }
+    encSection.appendChild(encGrid);
+    encSection.appendChild(
+      el(
+        "div",
+        { class: "xor-enc-annotation" },
+        `"1" (not identical) + "0" (reuse window) + ${row.windowMeaningful} bits in window [${wl}…${63 - wt}] = ${row.cost} bits total`
+      )
+    );
+
+    // Legend
+    const legend = el("div", { class: "xor-enc-legend" });
+    legend.appendChild(makeLegendItem("rgba(248, 113, 113, 0.3)", "Control bits"));
+    legend.appendChild(makeLegendItem("rgba(96, 165, 250, 0.3)", "Data (within prev window)"));
+    encSection.appendChild(legend);
+  } else if (row.encoding === "new") {
+    // Control: "11"
+    encGrid.appendChild(el("span", { class: "xor-enc-bit enc-ctrl" }, "1"));
+    encGrid.appendChild(el("span", { class: "xor-enc-bit enc-ctrl" }, "1"));
+
+    // 6-bit leading zero count
+    const lzBin = row.leadingZeros.toString(2).padStart(6, "0");
+    for (const b of lzBin) {
+      encGrid.appendChild(el("span", { class: "xor-enc-bit enc-meta" }, b));
+    }
+
+    // 6-bit meaningful length
+    const mlBin = row.meaningfulBits.toString(2).padStart(6, "0");
+    for (const b of mlBin) {
+      encGrid.appendChild(el("span", { class: "xor-enc-bit enc-meta2" }, b));
+    }
+
+    // Meaningful data bits
+    const lz = row.leadingZeros;
+    const tz = row.trailingZeros;
+    for (let i = lz; i < 64 - tz; i++) {
+      encGrid.appendChild(el("span", { class: "xor-enc-bit enc-data" }, row.xorBits[i]));
+    }
+    encSection.appendChild(encGrid);
+    encSection.appendChild(
+      el(
+        "div",
+        { class: "xor-enc-annotation" },
+        `"11" (new window) + ${lzBin} (leading=${row.leadingZeros}) + ${mlBin} (meaningful=${row.meaningfulBits}) + ${row.meaningfulBits} data bits = ${row.cost} bits total`
+      )
+    );
+
+    // Legend
+    const legend = el("div", { class: "xor-enc-legend" });
+    legend.appendChild(makeLegendItem("rgba(248, 113, 113, 0.3)", "Control"));
+    legend.appendChild(makeLegendItem("rgba(139, 92, 246, 0.3)", "Leading zeros (6 bits)"));
+    legend.appendChild(makeLegendItem("rgba(6, 182, 212, 0.3)", "Meaningful len (6 bits)"));
+    legend.appendChild(makeLegendItem("rgba(96, 165, 250, 0.3)", "Data bits"));
+    encSection.appendChild(legend);
+  }
+
+  panel.appendChild(encSection);
+  return panel;
+}
+
+function makeLegendItem(bg, text) {
+  return el(
+    "div",
+    { class: "xor-enc-legend-item" },
+    el("span", { class: "xor-enc-legend-swatch", style: { background: bg } }),
+    el("span", {}, text)
+  );
+}
+
+/* ─── Render: XOR Table ───────────────────────────────────────────── */
+
+function renderTable() {
+  const tbody = $("#xor-tbody");
+  tbody.innerHTML = "";
+
+  for (const row of rows) {
+    const tr = el("tr", {
+      class: `xor-row xor-enc-${row.encoding}${selectedRow === row.idx ? " xor-selected" : ""}`,
+      onClick: () => {
+        selectedRow = selectedRow === row.idx ? -1 : row.idx;
+        renderTable();
+        renderDecisionTree();
+      },
+    });
+
+    // #
+    tr.appendChild(el("td", { class: "xor-idx" }, String(row.idx)));
+
+    // Value
+    tr.appendChild(
+      el(
+        "td",
+        { class: "xor-val" },
+        Number.isInteger(row.value) ? String(row.value) : row.value.toFixed(4)
+      )
+    );
+
+    // XOR bits (compact in table)
+    if (row.xorBits === null) {
+      tr.appendChild(el("td", { class: "xor-na" }, "— first value"));
+    } else if (row.xorUint64 === 0n) {
+      tr.appendChild(
+        el("td", { class: "xor-na", style: { color: "var(--tier-0)" } }, "= 0 (identical)")
+      );
+    } else {
+      const cell = el("td", { class: "xor-bits-cell" });
+      cell.appendChild(buildMiniXorBits(row));
+      tr.appendChild(cell);
+    }
+
+    // Leading zeros
+    tr.appendChild(
+      el("td", { class: "xor-num" }, row.leadingZeros !== null ? String(row.leadingZeros) : "—")
+    );
+
+    // Trailing zeros
+    tr.appendChild(
+      el("td", { class: "xor-num" }, row.trailingZeros !== null ? String(row.trailingZeros) : "—")
+    );
+
+    // Meaningful bits
+    tr.appendChild(
+      el("td", { class: "xor-num" }, row.meaningfulBits !== null ? String(row.meaningfulBits) : "—")
+    );
+
+    // Encoding badge
+    const badge = el(
+      "span",
+      { class: `xor-enc-badge enc-${row.encoding}` },
+      ENC_LABELS[row.encoding]
+    );
+    tr.appendChild(el("td", {}, badge));
+
+    // Cost
+    const costTd = el("td", { class: "xor-cost" }, `${row.cost}b`);
+    costTd.style.color = ENC_COLORS[row.encoding];
+    tr.appendChild(costTd);
+
+    tbody.appendChild(tr);
+
+    // Expanded detail panel on click
+    if (selectedRow === row.idx) {
+      const detailTr = el("tr", { class: "xor-detail-row" });
+      const detailTd = el("td", { colspan: "8" });
+      detailTd.appendChild(
+        row.encoding === "first" ? buildFirstValueDetail(row) : buildDetailPanel(row)
+      );
+      detailTr.appendChild(detailTd);
+      tbody.appendChild(detailTr);
+    }
+  }
+}
+
+/* ─── Render: Cost Profile (Canvas) ───────────────────────────────── */
+
+function renderCostProfile() {
+  const canvas = $("#cost-canvas");
+  canvas.style.width = "100%";
+
+  const ctx = canvas.getContext("2d");
+  const dpr = window.devicePixelRatio || 1;
+  const w = canvas.clientWidth;
+  const h = canvas.clientHeight;
+  canvas.width = w * dpr;
+  canvas.height = h * dpr;
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, w, h);
+
+  const n = rows.length;
+  if (n === 0) return;
+
+  const maxCost = 64;
+  const pad = { top: 24, bottom: 28, left: 36, right: 12 };
+  const available = w - pad.left - pad.right;
+  const barW = Math.max(6, Math.min(28, available / n - 4));
+  const gap = (available - barW * n) / (n + 1);
+  const chartH = h - pad.top - pad.bottom;
+
+  // Y axis grid
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
+  for (const yVal of [0, 16, 32, 48, 64]) {
+    const y = pad.top + chartH * (1 - yVal / maxCost);
+    ctx.fillStyle = "#4b5563";
+    ctx.font = `10px "IBM Plex Mono", monospace`;
+    ctx.fillText(`${yVal}`, pad.left - 8, y);
+    ctx.strokeStyle = "rgba(96, 165, 250, 0.05)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(pad.left, y);
+    ctx.lineTo(w - pad.right, y);
+    ctx.stroke();
+  }
+
+  // Bars
+  for (let i = 0; i < n; i++) {
+    const row = rows[i];
+    const x = pad.left + gap + i * (barW + gap);
+    const barH = Math.max(2, (row.cost / maxCost) * chartH);
+    const y = pad.top + chartH - barH;
+
+    // Bar fill
+    ctx.fillStyle = ENC_COLORS[row.encoding];
+    const r = Math.min(3, barW / 2);
+    ctx.beginPath();
+    ctx.moveTo(x, y + r);
+    ctx.arcTo(x, y, x + barW, y, r);
+    ctx.arcTo(x + barW, y, x + barW, y + barH, r);
+    ctx.lineTo(x + barW, pad.top + chartH);
+    ctx.lineTo(x, pad.top + chartH);
+    ctx.closePath();
+    ctx.fill();
+
+    // Highlight selected
+    if (selectedRow === i) {
+      ctx.strokeStyle = "#fff";
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    }
+
+    // Cost label
+    ctx.fillStyle = "#94a3b8";
+    ctx.font = `9px "IBM Plex Mono", monospace`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "bottom";
+    ctx.fillText(`${row.cost}`, x + barW / 2, y - 3);
+
+    // X label
+    ctx.fillStyle = "#4b5563";
+    ctx.textBaseline = "top";
+    ctx.fillText(`${i}`, x + barW / 2, pad.top + chartH + 6);
+  }
+}
+
+/* ─── Render: Summary Stats ───────────────────────────────────────── */
+
+function renderSummary() {
+  const statsRow = $("#summary-stats");
+  statsRow.innerHTML = "";
+
+  const rawBits = rows.length * 64;
+  const compressedBits = rows.reduce((sum, r) => sum + r.cost, 0);
+  const rawBytes = rawBits / 8;
+  const compressedBytes = Math.ceil(compressedBits / 8);
+  const ratio = rawBytes / compressedBytes;
+  const avgBits = compressedBits / rows.length;
+
+  const encoded = rows.length - 1;
+  const identicalCount = rows.filter((r) => r.encoding === "identical").length;
+  const reuseCount = rows.filter((r) => r.encoding === "reuse").length;
+  const newCount = rows.filter((r) => r.encoding === "new").length;
+
+  const stats = [
+    { label: "Raw Size", value: fmtBytes(rawBytes), unit: `${rows.length} × 8 B` },
+    { label: "Compressed", value: fmtBytes(compressedBytes), unit: `${fmt(compressedBits)} bits` },
+    { label: "Ratio", value: `${ratio.toFixed(1)}×`, unit: "smaller" },
+    { label: "Avg bits/val", value: avgBits.toFixed(1), unit: "bits" },
+  ];
+
+  for (const s of stats) {
+    const stat = el(
+      "div",
+      { class: "xp-stat" },
+      el("div", { class: "xp-stat-label" }, s.label),
+      el("div", { class: "xp-stat-value" }, s.value),
+      el("div", { class: "xp-stat-unit" }, s.unit)
+    );
+    if (s.label === "Ratio") {
+      const valEl = stat.querySelector(".xp-stat-value");
+      valEl.style.color =
+        ratio >= 10 ? "var(--xp-success)" : ratio >= 4 ? "var(--xp-accent)" : "var(--xp-warn)";
+    }
+    statsRow.appendChild(stat);
+  }
+
+  // Encoding distribution bar
+  const barEl = $("#encoding-bar");
+  barEl.innerHTML = "";
+
+  const segments = [
+    { label: "Identical", count: identicalCount, color: ENC_COLORS.identical },
+    { label: "Reuse", count: reuseCount, color: ENC_COLORS.reuse },
+    { label: "New Window", count: newCount, color: ENC_COLORS.new },
+  ];
+
+  const barContainer = el("div", { class: "xor-dist-bar" });
+  for (const seg of segments) {
+    if (seg.count === 0) continue;
+    const pct = (seg.count / encoded) * 100;
+    const segDiv = el(
+      "div",
+      {
+        class: "xor-dist-seg",
+        style: { flexBasis: `${pct}%`, background: seg.color },
+      },
+      pct >= 14 ? `${seg.count} ${seg.label}` : `${seg.count}`
+    );
+    barContainer.appendChild(segDiv);
+  }
+  barEl.appendChild(barContainer);
+
+  // Legend
+  const legend = el("div", { class: "xor-dist-legend" });
+  for (const seg of segments) {
+    legend.appendChild(
+      el(
+        "div",
+        { class: "xor-dist-legend-item" },
+        el("span", { class: "xor-dist-dot", style: { background: seg.color } }),
+        el(
+          "span",
+          {},
+          `${seg.label}: ${seg.count} (${encoded > 0 ? Math.round((seg.count / encoded) * 100) : 0}%)`
+        )
+      )
+    );
+  }
+  barEl.appendChild(legend);
+
+  // Narrative story
+  const story = $("#compression-story");
+  const patternName = PATTERNS.find((p) => p.id === activePattern)?.label ?? activePattern;
+  const identPct = encoded > 0 ? Math.round((identicalCount / encoded) * 100) : 0;
+  const reusePct = encoded > 0 ? Math.round((reuseCount / encoded) * 100) : 0;
+
+  if (ratio >= 10) {
+    story.innerHTML =
+      `<strong>${patternName}</strong> achieves <strong class="success">${ratio.toFixed(1)}× compression</strong>. ` +
+      `${identPct}% of values are identical to their predecessor (1 bit each), ` +
+      `${reusePct}% reuse the previous bit window. ` +
+      `Average cost: just <strong class="success">${avgBits.toFixed(1)} bits/value</strong> vs 64 bits raw.`;
+  } else if (ratio >= 3) {
+    story.innerHTML =
+      `<strong>${patternName}</strong> compresses to <strong>${ratio.toFixed(1)}×</strong>. ` +
+      `${identPct}% identical, ${reusePct}% window reuse. ` +
+      `The changing values still share many bits, averaging <strong>${avgBits.toFixed(1)} bits/value</strong>.`;
+  } else {
+    story.innerHTML =
+      `<strong>${patternName}</strong> compresses poorly at <strong class="warn">${ratio.toFixed(1)}×</strong>. ` +
+      `Random values share few bits, so XOR results have many meaningful bits. ` +
+      `Average cost: <strong class="warn">${avgBits.toFixed(1)} bits/value</strong> — close to raw.`;
+  }
+}
+
+/* ─── Recompute & Render All ──────────────────────────────────────── */
+
+function recompute() {
+  values = generateValues(activePattern, SAMPLE_COUNT);
+  rows = computeRows(values);
+
+  updatePatternButtons();
+  renderSparkline();
+  renderDecisionTree();
+  renderTable();
+  renderCostProfile();
+  renderSummary();
+}
+
+/* ─── Init ────────────────────────────────────────────────────────── */
+
+function init() {
+  $("#breadcrumb-nav").innerHTML = buildBreadcrumb("XOR\u2011Delta");
+  renderPatternPicker();
+  recompute();
+
+  let resizeTimer;
+  window.addEventListener("resize", () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      renderSparkline();
+      renderCostProfile();
+    }, 150);
+  });
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/site/tsdb-engine/learn/xor-delta/xor-experience.js
+++ b/site/tsdb-engine/learn/xor-delta/xor-experience.js
@@ -10,6 +10,7 @@ import {
   $,
   $$,
   buildBreadcrumb,
+  buildStat,
   clz64,
   ctz64,
   drawSparkline,
@@ -648,7 +649,7 @@ function renderTable() {
     // Encoding badge
     const badge = el(
       "span",
-      { class: `xor-enc-badge enc-${row.encoding}` },
+      { class: `xp-badge xor-enc-badge enc-${row.encoding}` },
       ENC_LABELS[row.encoding]
     );
     tr.appendChild(el("td", {}, badge));
@@ -780,13 +781,7 @@ function renderSummary() {
   ];
 
   for (const s of stats) {
-    const stat = el(
-      "div",
-      { class: "xp-stat" },
-      el("div", { class: "xp-stat-label" }, s.label),
-      el("div", { class: "xp-stat-value" }, s.value),
-      el("div", { class: "xp-stat-unit" }, s.unit)
-    );
+    const stat = buildStat(s.label, s.value, s.unit);
     if (s.label === "Ratio") {
       const valEl = stat.querySelector(".xp-stat-value");
       valEl.style.color =


### PR DESCRIPTION
Post-launch UX audit of the 6 Learn experiences.

## Fixes
- **Breadcrumb links**: Fixed absolute `/o11ykit/...` paths → relative `../../` (were 404ing)
- **Footer links**: Same fix across all 7 pages
- **Auto-scroll**: Replaced jarring `scrollIntoView({ block: "start" })` with gentle `revealSection()` helper that only scrolls if the target is out of view, then adds a subtle pulse highlight

## Code consolidation
Moved duplicated patterns to `shared.css` / `shared.js`:
- `xp-scroll-x` / `xp-scroll-y`: scrollbar overrides (was in 4 files)
- `xp-story`: narrative callout box (was identical in delta-of-delta + xor-delta)
- `xp-badge`: pill badge base (was identical in delta-of-delta + xor-delta)
- `buildStat()`: stat card builder (was duplicated in 3 JS files)
- `sleep()`: promise delay (was locally defined in query-engine)

Net: 27 fewer lines with better reuse across experiences.