### PR TITLE
fix(learn): UX audit — breadcrumbs, autoscroll, nav, code sharing

### DIFF
--- a/site/tsdb-engine/learn/alp/alp-experience.css
+++ b/site/tsdb-engine/learn/alp/alp-experience.css
@@ -10,17 +10,6 @@
   gap: 6px;
   overflow-x: auto;
   padding-bottom: 8px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--xp-border-strong) transparent;
-}
-
-.alp-values-scroll::-webkit-scrollbar {
-  height: 6px;
-}
-
-.alp-values-scroll::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 3px;
 }
 
 .alp-val-chip {

--- a/site/tsdb-engine/learn/alp/index.html
+++ b/site/tsdb-engine/learn/alp/index.html
@@ -73,8 +73,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/alp/index.html
+++ b/site/tsdb-engine/learn/alp/index.html
@@ -38,7 +38,7 @@
           <button class="xp-btn xp-btn-primary" id="apply-custom">Apply</button>
         </div>
         <div class="xp-card alp-values-card" id="values-card">
-          <div class="alp-values-scroll" id="values-scroll"></div>
+          <div class="alp-values-scroll xp-scroll-x" id="values-scroll"></div>
         </div>
       </section>
 

--- a/site/tsdb-engine/learn/chunk-stats/index.html
+++ b/site/tsdb-engine/learn/chunk-stats/index.html
@@ -41,7 +41,7 @@
       <section class="xp-section" id="timeline-section">
         <h2>② Chunk Timeline</h2>
         <p>Click any chunk to inspect its pre-computed stats.</p>
-        <div class="cs-timeline-strip" id="timeline-strip"></div>
+        <div class="cs-timeline-strip xp-scroll-x" id="timeline-strip"></div>
         <div class="xp-card cs-detail-panel" id="chunk-detail" hidden>
           <div class="cs-detail-header" id="detail-header"></div>
           <div class="xp-stats-row" id="detail-stats"></div>

--- a/site/tsdb-engine/learn/chunk-stats/index.html
+++ b/site/tsdb-engine/learn/chunk-stats/index.html
@@ -130,8 +130,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/chunk-stats/stats-experience.css
+++ b/site/tsdb-engine/learn/chunk-stats/stats-experience.css
@@ -18,17 +18,6 @@
   overflow-x: auto;
   padding-bottom: 10px;
   margin-bottom: 16px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--xp-border-strong) transparent;
-}
-
-.cs-timeline-strip::-webkit-scrollbar {
-  height: 6px;
-}
-
-.cs-timeline-strip::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 3px;
 }
 
 .cs-chunk-block {

--- a/site/tsdb-engine/learn/chunk-stats/stats-experience.js
+++ b/site/tsdb-engine/learn/chunk-stats/stats-experience.js
@@ -14,6 +14,7 @@ import {
   el,
   fmt,
   generateSamples,
+  revealSection,
 } from "../shared.js";
 
 /* ─── Constants ───────────────────────────────────────────────────── */
@@ -243,7 +244,7 @@ function runQuery() {
 function showExecution(buckets, agg, _startChunk) {
   const execSection = $("#execution-section");
   execSection.hidden = false;
-  execSection.scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection(execSection);
 
   const resultsSection = $("#results-section");
   resultsSection.hidden = true;
@@ -503,7 +504,7 @@ function showResults(bucketResults, agg, decoded, statsOnly, skipped) {
     resultsGrid.appendChild(cell);
   });
 
-  section.scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection(section);
 }
 
 /* ─── Init ────────────────────────────────────────────────────────── */

--- a/site/tsdb-engine/learn/delta-of-delta/dod-experience.css
+++ b/site/tsdb-engine/learn/delta-of-delta/dod-experience.css
@@ -24,17 +24,6 @@
 
 .dod-table-scroll {
   overflow-x: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--xp-border-strong) transparent;
-}
-
-.dod-table-scroll::-webkit-scrollbar {
-  height: 6px;
-}
-
-.dod-table-scroll::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 3px;
 }
 
 .dod-table {
@@ -83,17 +72,7 @@
 .dod-table tr.tier-row-0 td:first-child { border-left-width: 3px; }
 .dod-table tr.tier-row-1 td:first-child { border-left-width: 3px; }
 
-/* Tier badge */
-.dod-tier-badge {
-  display: inline-block;
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 10px;
-  font-weight: 600;
-  font-family: var(--xp-mono);
-  letter-spacing: 0.04em;
-}
-
+/* Tier badge — base from .xp-badge in shared.css */
 .dod-tier-badge.t0 { background: rgba(52, 211, 153, 0.15); color: var(--tier-0); }
 .dod-tier-badge.t1 { background: rgba(96, 165, 250, 0.15); color: var(--tier-1); }
 .dod-tier-badge.t2 { background: rgba(167, 139, 250, 0.15); color: var(--tier-2); }
@@ -209,16 +188,7 @@
 }
 
 /* ─── Jitter Story ────────────────────────────────────────────────── */
-.dod-story {
-  margin-top: 16px;
-  padding: 16px 20px;
-  background: var(--xp-surface);
-  border: 1px solid var(--xp-border);
-  border-radius: var(--xp-radius-sm);
-  font-size: 14px;
-  line-height: 1.6;
-  color: var(--xp-text-muted);
-}
+/* base from .xp-story in shared.css */
 
 .dod-story strong {
   color: var(--xp-success);

--- a/site/tsdb-engine/learn/delta-of-delta/dod-experience.js
+++ b/site/tsdb-engine/learn/delta-of-delta/dod-experience.js
@@ -6,7 +6,7 @@
  */
 
 import {
-  $, el, buildBreadcrumb, fmt, fmtBytes, zigzagEncode, generateSamples,
+  $, el, buildBreadcrumb, buildStat, fmt, fmtBytes, zigzagEncode, generateSamples,
 } from '../shared.js';
 
 /* ─── Constants ───────────────────────────────────────────────────── */
@@ -177,11 +177,11 @@ function renderTable() {
 
     // Tier badge
     if (row.tier >= 0) {
-      const badge = el('span', { class: `dod-tier-badge t${row.tier}` }, row.tierLabel);
+      const badge = el('span', { class: `xp-badge dod-tier-badge t${row.tier}` }, row.tierLabel);
       tr.appendChild(el('td', {}, badge));
     } else {
       const badge = el('span', {
-        class: 'dod-tier-badge',
+        class: 'xp-badge dod-tier-badge',
         style: { background: 'rgba(139, 92, 246, 0.15)', color: 'var(--region-header)' },
       }, row.tierLabel);
       tr.appendChild(el('td', {}, badge));
@@ -279,11 +279,7 @@ function renderSummary() {
   ];
 
   for (const s of stats) {
-    const stat = el('div', { class: 'xp-stat' },
-      el('div', { class: 'xp-stat-label' }, s.label),
-      el('div', { class: 'xp-stat-value' }, s.value),
-      el('div', { class: 'xp-stat-unit' }, s.unit),
-    );
+    const stat = buildStat(s.label, s.value, s.unit);
     if (s.label === 'Ratio') {
       stat.querySelector('.xp-stat-value').style.color = ratio >= 10 ? 'var(--xp-success)' : ratio >= 4 ? 'var(--xp-accent)' : 'var(--xp-warn)';
     }

--- a/site/tsdb-engine/learn/delta-of-delta/index.html
+++ b/site/tsdb-engine/learn/delta-of-delta/index.html
@@ -110,8 +110,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/delta-of-delta/index.html
+++ b/site/tsdb-engine/learn/delta-of-delta/index.html
@@ -62,7 +62,7 @@
         <h2>② Transformation Table</h2>
         <p>Each row shows one timestamp flowing through the pipeline.</p>
         <div class="xp-card dod-table-wrap">
-          <div class="dod-table-scroll">
+          <div class="dod-table-scroll xp-scroll-x">
             <table class="xp-table dod-table" id="dod-table">
               <thead>
                 <tr>
@@ -105,7 +105,7 @@
       <section class="xp-section" id="summary-section">
         <h2>⑤ Compression Summary</h2>
         <div class="xp-stats-row" id="summary-stats"></div>
-        <div class="dod-story" id="jitter-story"></div>
+        <div class="dod-story xp-story" id="jitter-story"></div>
       </section>
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">

--- a/site/tsdb-engine/learn/index.html
+++ b/site/tsdb-engine/learn/index.html
@@ -114,7 +114,7 @@
 
       <nav class="xp-topbar" aria-label="Breadcrumb">
         <div class="xp-breadcrumb">
-          <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+          <a href="../">TSDB Engine</a>
           <span class="sep">›</span>
           <span class="current">Learn</span>
         </div>

--- a/site/tsdb-engine/learn/index.html
+++ b/site/tsdb-engine/learn/index.html
@@ -208,8 +208,8 @@ Answer in &lt;1ms</div>
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/" style="color: var(--xp-text-muted); text-decoration: none;">Back to TSDB Engine →</a>
+          Part of <a href="../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">Back to TSDB Engine →</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/query-engine/index.html
+++ b/site/tsdb-engine/learn/query-engine/index.html
@@ -130,8 +130,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/query-engine/query-experience.js
+++ b/site/tsdb-engine/learn/query-engine/query-experience.js
@@ -6,7 +6,7 @@
  * Stats Check → Decode → Step-Aligned Aggregation
  */
 
-import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, Stepper } from "../shared.js";
+import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, revealSection, Stepper } from "../shared.js";
 
 /* ═══════════════════════════════════════════════════════════════════════
    A. DATASET GENERATION
@@ -748,7 +748,7 @@ function showResults(aggResults, matchedCount, pruneStats, aggFn, stepMinutes, q
   tableContainer.innerHTML = "";
   tableContainer.appendChild(table);
 
-  section.scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection(section);
 }
 
 /* ═══════════════════════════════════════════════════════════════════════
@@ -789,13 +789,13 @@ async function executeQuery() {
 
   const { intersection } = resolvePostings(metric, filters);
   await animateLabelMatch(metric, filters);
-  $("#stage-match-section").scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection($("#stage-match-section"));
   await sleep(600);
 
   // Stage 2: Chunk Pruning
   stepper.goto(2);
   const pruneStats = await animateChunkPruning(intersection, queryRangeHours);
-  $("#stage-prune-section").scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection($("#stage-prune-section"));
   await sleep(600);
 
   // Stage 3: Stats Check (brief pause — conceptual)
@@ -809,7 +809,7 @@ async function executeQuery() {
   // Stage 5: Aggregation
   stepper.goto(5);
   const aggResults = await animateAggregation(intersection, queryRangeHours, stepMinutes, aggFn);
-  $("#stage-agg-section").scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection($("#stage-agg-section"));
   await sleep(400);
 
   // Show results

--- a/site/tsdb-engine/learn/query-engine/query-experience.js
+++ b/site/tsdb-engine/learn/query-engine/query-experience.js
@@ -6,7 +6,7 @@
  * Stats Check → Decode → Step-Aligned Aggregation
  */
 
-import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, revealSection, Stepper } from "../shared.js";
+import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, revealSection, sleep, Stepper } from "../shared.js";
 
 /* ═══════════════════════════════════════════════════════════════════════
    A. DATASET GENERATION
@@ -823,10 +823,6 @@ async function executeQuery() {
 /* ═══════════════════════════════════════════════════════════════════════
    HELPERS
    ═══════════════════════════════════════════════════════════════════════ */
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 function fmtHour(ms) {
   const d = new Date(ms);

--- a/site/tsdb-engine/learn/shared.css
+++ b/site/tsdb-engine/learn/shared.css
@@ -557,3 +557,66 @@ body {
   100% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0); }
 }
 .xp-reveal { animation: xp-reveal-pulse 0.6s ease-out; }
+
+/* ─── Scrollable Container Utilities ─────────────────────────────── */
+
+/* Horizontal scroll with thin themed scrollbar */
+.xp-scroll-x {
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--xp-border-strong) transparent;
+}
+
+.xp-scroll-x::-webkit-scrollbar {
+  height: 6px;
+}
+
+.xp-scroll-x::-webkit-scrollbar-thumb {
+  background: var(--xp-border-strong);
+  border-radius: 3px;
+}
+
+/* Vertical scroll with thin themed scrollbar */
+.xp-scroll-y {
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--xp-border-strong) transparent;
+}
+
+.xp-scroll-y::-webkit-scrollbar {
+  width: 4px;
+}
+
+.xp-scroll-y::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.xp-scroll-y::-webkit-scrollbar-thumb {
+  background: var(--xp-border-strong);
+  border-radius: 2px;
+}
+
+/* ─── Narrative Story Box ─────────────────────────────────────────── */
+
+.xp-story {
+  margin-top: 16px;
+  padding: 16px 20px;
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--xp-text-muted);
+}
+
+/* ─── Pill Badge ──────────────────────────────────────────────────── */
+
+.xp-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: var(--xp-mono);
+  letter-spacing: 0.04em;
+}

--- a/site/tsdb-engine/learn/shared.css
+++ b/site/tsdb-engine/learn/shared.css
@@ -548,3 +548,12 @@ body {
 .xp-skip-link:focus {
   left: 16px;
 }
+
+/* ─── Reveal pulse (gentle attention without forced scroll) ─────── */
+
+@keyframes xp-reveal-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.4); }
+  70% { box-shadow: 0 0 0 8px rgba(99, 102, 241, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0); }
+}
+.xp-reveal { animation: xp-reveal-pulse 0.6s ease-out; }

--- a/site/tsdb-engine/learn/shared.js
+++ b/site/tsdb-engine/learn/shared.js
@@ -197,13 +197,24 @@ export function buildBreadcrumb(title) {
   return `
     <nav class="xp-topbar" aria-label="Breadcrumb">
       <div class="xp-breadcrumb">
-        <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+        <a href="../../">TSDB Engine</a>
         <span class="sep">›</span>
-        <a href="/o11ykit/tsdb-engine/learn/">Learn</a>
+        <a href="../">Learn</a>
         <span class="sep">›</span>
         <span class="current">${title}</span>
       </div>
     </nav>`;
+}
+
+/** Gently reveal a section — only scrolls if not already visible, adds a brief highlight pulse. */
+export function revealSection(el) {
+  const rect = el.getBoundingClientRect();
+  const inView = rect.top >= 0 && rect.bottom <= window.innerHeight;
+  if (!inView) {
+    el.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }
+  el.classList.add("xp-reveal");
+  el.addEventListener("animationend", () => el.classList.remove("xp-reveal"), { once: true });
 }
 
 /** Render a sparkline to a canvas element. */

--- a/site/tsdb-engine/learn/shared.js
+++ b/site/tsdb-engine/learn/shared.js
@@ -252,3 +252,32 @@ export function drawSparkline(canvas, values, opts = {}) {
   ctx.fillStyle = color.replace(')', `, ${fillAlpha})`).replace('rgb', 'rgba');
   ctx.fill();
 }
+
+/* ─── Stat Card Builder ───────────────────────────────────────────── */
+
+/**
+ * Build a standard `.xp-stat` card element.
+ * @param {string} label
+ * @param {string|number} value
+ * @param {string} [unit]
+ * @param {object} [opts]  – opts.cls (extra class on value), opts.color (inline color on value)
+ * @returns {HTMLElement}
+ */
+export function buildStat(label, value, unit = '', opts = {}) {
+  const valueEl = el('div', {
+    class: ['xp-stat-value', opts.cls].filter(Boolean).join(' '),
+    ...(opts.color ? { style: { color: opts.color } } : {}),
+  }, String(value));
+  return el('div', { class: 'xp-stat' },
+    el('div', { class: 'xp-stat-label' }, label),
+    valueEl,
+    unit ? el('div', { class: 'xp-stat-unit' }, unit) : null,
+  );
+}
+
+/* ─── Async Helpers ───────────────────────────────────────────────── */
+
+/** Promise-based sleep. */
+export function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/site/tsdb-engine/learn/string-interning/index.html
+++ b/site/tsdb-engine/learn/string-interning/index.html
@@ -132,8 +132,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/string-interning/index.html
+++ b/site/tsdb-engine/learn/string-interning/index.html
@@ -61,7 +61,7 @@
         <div class="intern-split">
           <div class="xp-card intern-panel" id="naive-panel">
             <h3>Naive Storage</h3>
-            <div class="intern-panel-body" id="naive-body"></div>
+            <div class="intern-panel-body xp-scroll-y" id="naive-body"></div>
             <div class="intern-panel-footer" id="naive-footer"></div>
           </div>
           <div class="xp-card intern-panel" id="interned-panel">
@@ -72,11 +72,11 @@
             </div>
             <div class="intern-id-table-wrap">
               <span class="xp-label">ID Table</span>
-              <div class="intern-id-table" id="id-table"></div>
+              <div class="intern-id-table xp-scroll-y" id="id-table"></div>
             </div>
             <div class="intern-refs-wrap">
               <span class="xp-label">Series References</span>
-              <div class="intern-panel-body" id="interned-body"></div>
+              <div class="intern-panel-body xp-scroll-y" id="interned-body"></div>
             </div>
             <div class="intern-panel-footer" id="interned-footer"></div>
           </div>

--- a/site/tsdb-engine/learn/string-interning/intern-experience.css
+++ b/site/tsdb-engine/learn/string-interning/intern-experience.css
@@ -64,19 +64,6 @@
   min-height: 0;
 }
 
-.intern-panel-body::-webkit-scrollbar {
-  width: 4px;
-}
-
-.intern-panel-body::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.intern-panel-body::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 2px;
-}
-
 .intern-panel-footer {
   padding-top: 10px;
   border-top: 1px solid var(--xp-border);
@@ -176,15 +163,6 @@
   max-height: 120px;
   overflow-y: auto;
   padding-right: 4px;
-}
-
-.intern-id-table::-webkit-scrollbar {
-  width: 4px;
-}
-
-.intern-id-table::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 2px;
 }
 
 .intern-id-entry {

--- a/site/tsdb-engine/learn/string-interning/intern-experience.js
+++ b/site/tsdb-engine/learn/string-interning/intern-experience.js
@@ -2,7 +2,7 @@
  * String Interning — Interactive Experience
  * Demonstrates how TSDB engines store label strings once and reference them by ID.
  */
-import { $, $$, buildBreadcrumb, el, fmt, fmtBytes, Stepper } from "../shared.js";
+import { $, $$, buildBreadcrumb, buildStat, el, fmt, fmtBytes, Stepper } from "../shared.js";
 
 /* ─── Constants ──────────────────────────────────────────────────── */
 
@@ -204,14 +204,7 @@ function renderStats(stats) {
     ["Savings", `${stats.ratio.toFixed(1)}×`, ""],
   ];
   for (const [label, value, unit] of items) {
-    row.appendChild(
-      el(
-        "div",
-        { class: "xp-stat" },
-        el("span", { class: "xp-stat-label" }, label),
-        el("span", { class: "xp-stat-value" }, value, el("span", { class: "xp-stat-unit" }, unit))
-      )
-    );
+    row.appendChild(buildStat(label, value, unit));
   }
 }
 

--- a/site/tsdb-engine/learn/xor-delta/index.html
+++ b/site/tsdb-engine/learn/xor-delta/index.html
@@ -51,7 +51,7 @@
         <h2>③ XOR Visualization Table</h2>
         <p>Each row shows a value XOR'd with its predecessor. Click any row to expand bit-level detail.</p>
         <div class="xp-card xor-table-wrap">
-          <div class="xor-table-scroll">
+          <div class="xor-table-scroll xp-scroll-x">
             <table class="xp-table xor-table" id="xor-table">
               <thead>
                 <tr>
@@ -85,7 +85,7 @@
         <h2>⑤ Compression Summary</h2>
         <div class="xp-stats-row" id="summary-stats"></div>
         <div class="xor-encoding-bar" id="encoding-bar"></div>
-        <div class="xor-story" id="compression-story"></div>
+        <div class="xor-story xp-story" id="compression-story"></div>
       </section>
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">

--- a/site/tsdb-engine/learn/xor-delta/index.html
+++ b/site/tsdb-engine/learn/xor-delta/index.html
@@ -90,8 +90,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/xor-delta/xor-experience.css
+++ b/site/tsdb-engine/learn/xor-delta/xor-experience.css
@@ -16,17 +16,6 @@
 
 .xor-table-scroll {
   overflow-x: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--xp-border-strong) transparent;
-}
-
-.xor-table-scroll::-webkit-scrollbar {
-  height: 6px;
-}
-
-.xor-table-scroll::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 3px;
 }
 
 .xor-table {
@@ -117,13 +106,8 @@
 }
 
 /* ─── Encoding Badges ─────────────────────────────────────────────── */
+/* Encoding badge — base from .xp-badge in shared.css */
 .xor-enc-badge {
-  display: inline-block;
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 10px;
-  font-weight: 600;
-  font-family: var(--xp-mono);
   letter-spacing: 0.02em;
 }
 
@@ -485,16 +469,7 @@
 }
 
 /* ─── Story Box ───────────────────────────────────────────────────── */
-.xor-story {
-  margin-top: 16px;
-  padding: 16px 20px;
-  background: var(--xp-surface);
-  border: 1px solid var(--xp-border);
-  border-radius: var(--xp-radius-sm);
-  font-size: 14px;
-  line-height: 1.6;
-  color: var(--xp-text-muted);
-}
+/* base from .xp-story in shared.css */
 
 .xor-story strong {
   color: var(--xp-text);

--- a/site/tsdb-engine/learn/xor-delta/xor-experience.js
+++ b/site/tsdb-engine/learn/xor-delta/xor-experience.js
@@ -10,6 +10,7 @@ import {
   $,
   $$,
   buildBreadcrumb,
+  buildStat,
   clz64,
   ctz64,
   drawSparkline,
@@ -648,7 +649,7 @@ function renderTable() {
     // Encoding badge
     const badge = el(
       "span",
-      { class: `xor-enc-badge enc-${row.encoding}` },
+      { class: `xp-badge xor-enc-badge enc-${row.encoding}` },
       ENC_LABELS[row.encoding]
     );
     tr.appendChild(el("td", {}, badge));
@@ -780,13 +781,7 @@ function renderSummary() {
   ];
 
   for (const s of stats) {
-    const stat = el(
-      "div",
-      { class: "xp-stat" },
-      el("div", { class: "xp-stat-label" }, s.label),
-      el("div", { class: "xp-stat-value" }, s.value),
-      el("div", { class: "xp-stat-unit" }, s.unit)
-    );
+    const stat = buildStat(s.label, s.value, s.unit);
     if (s.label === "Ratio") {
       const valEl = stat.querySelector(".xp-stat-value");
       valEl.style.color =


### PR DESCRIPTION
Post-launch UX audit of the 6 Learn experiences.

## Fixes
- **Breadcrumb + footer links**: Fixed absolute `/o11ykit/...` paths → relative paths (were 404ing)
- **Auto-scroll**: Replaced jarring `scrollIntoView({ block: "start" })` with `revealSection()` — only scrolls if target is out of view, adds a subtle pulse instead

## Code consolidation (moved to shared.css / shared.js)
- `xp-scroll-x` / `xp-scroll-y`: scrollbar overrides (was duplicated in 4 files)
- `xp-story`: narrative callout box (was identical in delta-of-delta + xor-delta)
- `xp-badge`: pill badge base (was identical in delta-of-delta + xor-delta)
- `buildStat()`: stat card builder (was duplicated in 3 JS files)
- `sleep()`: promise delay (was locally defined in query-engine)

Net: 27 fewer lines with better reuse