### PR TITLE
feat(learn): beginner-friendly glossary tooltips + experience polish

### DIFF
--- a/site/tsdb-engine/learn/alp/alp-experience.css
+++ b/site/tsdb-engine/learn/alp/alp-experience.css
@@ -10,17 +10,6 @@
   gap: 6px;
   overflow-x: auto;
   padding-bottom: 8px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--xp-border-strong) transparent;
-}
-
-.alp-values-scroll::-webkit-scrollbar {
-  height: 6px;
-}
-
-.alp-values-scroll::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 3px;
 }
 
 .alp-val-chip {

--- a/site/tsdb-engine/learn/alp/alp-experience.js
+++ b/site/tsdb-engine/learn/alp/alp-experience.js
@@ -5,7 +5,7 @@
  *   Exponent Scan → Quantize → Frame-of-Reference → Bit-Width → Pack
  */
 
-import { $, $$, buildBreadcrumb, el, fmt, fmtBytes, Stepper } from "../shared.js";
+import { $, $$, buildBreadcrumb, el, fmt, fmtBytes, initGlossary, Stepper } from "../shared.js";
 
 /* ─── Sample Data Presets ─────────────────────────────────────────── */
 
@@ -146,11 +146,11 @@ function init() {
   $("#breadcrumb-nav").innerHTML = buildBreadcrumb("ALP Compression");
 
   const stages = [
-    { icon: "🔍", label: "Scan" },
-    { icon: "×10ᵉ", label: "Quantize" },
-    { icon: "−min", label: "Frame-of-Ref" },
-    { icon: "🔢", label: "Bit-Width" },
-    { icon: "📦", label: "Pack" },
+    { icon: "🔍", label: "Scan", subtitle: "find the right multiplier" },
+    { icon: "×10ᵉ", label: "Quantize", subtitle: "multiply decimals to integers" },
+    { icon: "−min", label: "Frame-of-Ref", subtitle: "subtract minimum, shrink range" },
+    { icon: "🔢", label: "Bit-Width", subtitle: "calculate minimum bits needed" },
+    { icon: "📦", label: "Pack", subtitle: "write the compressed stream" },
   ];
 
   const pipelineBar = $("#pipeline-bar");
@@ -165,7 +165,8 @@ function init() {
         onClick: () => stepper.goto(i),
       },
       el("span", { class: "stage-icon" }, s.icon),
-      el("span", { class: "stage-label" }, s.label)
+      el("span", { class: "stage-label" }, s.label),
+      el("small", { class: "stage-subtitle" }, s.subtitle)
     );
     pipelineBar.appendChild(stageEl);
   });
@@ -183,6 +184,8 @@ function init() {
     stepper.reset();
   });
   $("#apply-custom").addEventListener("click", applyCustom);
+
+  initGlossary();
 }
 
 /* ─── Pattern Buttons ─────────────────────────────────────────────── */
@@ -277,6 +280,7 @@ function onStageChange(stage) {
 
   if (stage === -1) {
     $("#summary-section").hidden = true;
+    renderOrientationCard();
     return;
   }
 
@@ -312,6 +316,26 @@ function onStageChange(stage) {
   }
 }
 
+/* ─── Step –1: Orientation Card ──────────────────────────────────── */
+
+function renderOrientationCard() {
+  const panel = $("#panel-orient");
+  panel.hidden = false;
+  panel.innerHTML = `
+    <div class="xp-card xp-card-raised">
+      <h3>How ALP Works</h3>
+      <p>ALP compresses decimal metrics in 5 stages:</p>
+      <ol style="margin: 12px 0 16px 20px; line-height: 2;">
+        <li><strong>Scan</strong> — try multipliers to find which power of 10 converts all values to exact integers</li>
+        <li><strong><span class="xp-term" data-term="quantize">Quantize</span></strong> — multiply every value by that power (e.g. 34.5 → 3450)</li>
+        <li><strong><span class="xp-term" data-term="frame-of-reference">Frame-of-Reference</span></strong> — subtract the minimum so all numbers are small offsets</li>
+        <li><strong>Bit-Width</strong> — calculate the minimum bits needed to store the largest offset</li>
+        <li><strong><span class="xp-term" data-term="bit-packing">Pack</span></strong> — write values using only those bits, back-to-back</li>
+      </ol>
+      <p style="color: var(--xp-text-muted);">Click <strong>Next →</strong> to begin</p>
+    </div>`;
+}
+
 /* ─── Stage 0: Exponent Scan ──────────────────────────────────────── */
 
 function renderExponentScan() {
@@ -322,9 +346,9 @@ function renderExponentScan() {
   let html = `
     <div class="xp-card xp-card-raised">
       <h3>Exponent Scan</h3>
-      <p>Try each exponent <code class="xp-code">e = 0…${scan.length - 1}</code>:
+      <p>Try each <span class="xp-term" data-term="exponent">exponent</span> <code class="xp-code">e = 0…${scan.length - 1}</code>:
         multiply by 10<sup>e</sup>, round, and check if the value round-trips exactly.
-        ${winExp >= 0 ? `Smallest working exponent: <strong class="alp-check">e = ${winExp}</strong>` : '<strong class="alp-cross">No exponent works — all values become exceptions</strong>'}
+        ${winExp >= 0 ? `Smallest working <span class="xp-term" data-term="exponent">exponent</span>: <strong class="alp-check">e = ${winExp}</strong>` : '<strong class="alp-cross">No exponent works — all values become exceptions</strong>'}
       </p>
       <div style="overflow-x:auto">
       <table class="alp-exp-table">
@@ -363,7 +387,7 @@ function renderQuantize() {
 
   let gridHTML = `
     <div class="alp-quant-grid">
-      <div class="hdr">Original (f64)</div>
+      <div class="hdr">Original (8-byte float)</div>
       <div class="hdr"></div>
       <div class="hdr">× 10<sup>${encoded.exp}</sup> → integer</div>`;
 
@@ -380,9 +404,9 @@ function renderQuantize() {
 
   panel.innerHTML = `
     <div class="xp-card xp-card-raised">
-      <h3>Integer Quantization</h3>
+      <h3>Integer <span class="xp-term" data-term="quantize">Quantization</span></h3>
       <p>Multiply every value by <code class="xp-code">10<sup>${encoded.exp}</sup> = ${fmt(POW10[encoded.exp])}</code> and round to get exact integers.
-        ${encoded.exceptions.length > 0 ? `<span class="alp-cross">${encoded.exceptions.length} value(s) don't round-trip — stored as exceptions.</span>` : ""}
+        ${encoded.exceptions.length > 0 ? `<span class="alp-cross">${encoded.exceptions.length} value(s) don't round-trip — stored as <span class="xp-term" data-term="exceptions">exceptions</span>.</span>` : ""}
       </p>
       ${gridHTML}
     </div>`;
@@ -413,7 +437,7 @@ function renderFrameOfRef() {
 
   panel.innerHTML = `
     <div class="xp-card xp-card-raised">
-      <h3>Frame-of-Reference</h3>
+      <h3><span class="xp-term" data-term="frame-of-reference">Frame-of-Reference</span></h3>
       <p>Subtract the minimum integer <code class="xp-code">${fmt(encoded.minInt)}</code>
          so all offsets start at 0. Range shrinks from
          <strong>${fmt(encoded.minInt)}–${fmt(maxInt)}</strong> to
@@ -470,7 +494,7 @@ function renderBitWidthPack() {
 
   panel.innerHTML = `
     <div class="xp-card xp-card-raised">
-      <h3>Bit-Width & Packing</h3>
+      <h3><span class="xp-term" data-term="bit-packing">Bit-Width &amp; Packing</span></h3>
       <p>Maximum offset is <code class="xp-code">${fmt(Math.max(...encoded.offsets))}</code>,
          which needs <code class="xp-code">${bw} bits</code> to represent.
          Each value is packed at exactly ${bw} bits — no wasted space.
@@ -527,14 +551,14 @@ function renderExceptionsInline() {
       <div class="alp-exc-item">
         <span class="pos">pos ${exc.idx}</span>
         <span class="raw">${formatNum(exc.value)}</span>
-        <span class="cost">8 bytes (raw f64)</span>
+        <span class="cost">8 bytes (8-byte float)</span>
       </div>`;
   }
 
   panel.innerHTML = `
     <div class="xp-card xp-card-raised" style="border-color: rgba(251,191,36,0.25);">
-      <h3>⚠ Exceptions</h3>
-      <p>${encoded.exceptions.length} value(s) didn't round-trip with exponent
+      <h3>⚠ <span class="xp-term" data-term="exceptions">Exceptions</span></h3>
+      <p>${encoded.exceptions.length} value(s) didn't round-trip with <span class="xp-term" data-term="exponent">exponent</span>
          <code class="xp-code">e = ${encoded.exp}</code>.
          Each is stored as a raw 64-bit float (8 bytes) plus a 2-byte position index.</p>
       <div class="alp-exc-list">${items}</div>

--- a/site/tsdb-engine/learn/alp/index.html
+++ b/site/tsdb-engine/learn/alp/index.html
@@ -73,8 +73,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/alp/index.html
+++ b/site/tsdb-engine/learn/alp/index.html
@@ -38,7 +38,7 @@
           <button class="xp-btn xp-btn-primary" id="apply-custom">Apply</button>
         </div>
         <div class="xp-card alp-values-card" id="values-card">
-          <div class="alp-values-scroll" id="values-scroll"></div>
+          <div class="alp-values-scroll xp-scroll-x" id="values-scroll"></div>
         </div>
       </section>
 

--- a/site/tsdb-engine/learn/alp/index.html
+++ b/site/tsdb-engine/learn/alp/index.html
@@ -23,8 +23,14 @@
         <h1>ALP Compression</h1>
         <p class="lede">
           Adaptive Lossless floating-Point compression turns decimal floats into
-          tightly bit-packed integers — often <strong>4–8×</strong> smaller than raw f64.
+          tightly <span class="xp-term" data-term="bit-packing">bit-packed</span> integers — often <strong>4–8×</strong> smaller than an 8-byte float.
           Step through the pipeline and watch every transformation.
+        </p>
+        <p class="lede" style="margin-top:12px; font-size:15px; color:var(--xp-text-muted);">
+          Metric values like CPU usage (34.5%, 35.1%, 34.8%) look like decimals, but they're actually
+          stored as 64-bit floats — 8 bytes each, most of which carry precision you never needed.
+          ALP exploits the fact that these values are secretly integers in disguise (3450, 3510, 3480)
+          and stores them in a fraction of the space.
         </p>
       </div>
 
@@ -57,6 +63,7 @@
 
       <!-- C–G. Stage Detail Panels -->
       <div id="stage-panels">
+        <div class="alp-panel" id="panel-orient"></div>
         <div class="alp-panel" id="panel-scan" hidden></div>
         <div class="alp-panel" id="panel-quantize" hidden></div>
         <div class="alp-panel" id="panel-for" hidden></div>

--- a/site/tsdb-engine/learn/chunk-stats/index.html
+++ b/site/tsdb-engine/learn/chunk-stats/index.html
@@ -22,16 +22,26 @@
         <p class="xp-eyebrow">Query Optimization</p>
         <h1>Chunk Stats</h1>
         <p class="lede">
-          When a chunk is frozen, the TSDB pre-computes <strong>min, max, sum, count</strong>.
-          During query execution, aligned buckets can be answered from stats alone —
+          When a <span class="xp-term" data-term="chunk">chunk</span> is <span class="xp-term" data-term="frozen">frozen</span>, the TSDB pre-computes <strong>min, max, sum, count</strong>.
+          During query execution, <span class="xp-term" data-term="aligned">aligned</span> buckets can be answered from stats alone —
           no decompression needed. This can be <strong>100× faster</strong>.
+        </p>
+        <p class="lede">
+          When a chunk is sealed, the TSDB pre-computes four statistics: minimum value, maximum value,
+          sum of all values, and count of <span class="xp-term" data-term="sample">samples</span>.
+          These four numbers are enough to answer the most common queries — max(), min(), sum(), avg(),
+          and rate() — without decompressing the <span class="xp-term" data-term="chunk">chunk</span> at all.
+        </p>
+        <p class="lede" style="font-size: 0.9em; color: var(--xp-text-dim);">
+          Decompressing a chunk takes CPU time and memory. For a query spanning 100 chunks, skipping
+          even 80% of them makes the query ~5× faster.
         </p>
       </div>
 
       <!-- A. Full Dataset Sparkline -->
       <section class="xp-section" id="data-section">
         <h2>① Dataset &amp; Chunks</h2>
-        <p>12 chunks of temperature data, 64 samples each. Chunk boundaries are marked with dashed lines.</p>
+        <p>12 <span class="xp-term" data-term="chunk">chunks</span> of temperature data, 64 <span class="xp-term" data-term="sample">samples</span> each. Chunk boundaries are marked with dashed lines.</p>
         <div class="xp-card cs-sparkline-card">
           <canvas id="sparkline-canvas" height="140"></canvas>
         </div>
@@ -40,7 +50,7 @@
       <!-- B. Chunk Timeline -->
       <section class="xp-section" id="timeline-section">
         <h2>② Chunk Timeline</h2>
-        <p>Click any chunk to inspect its pre-computed stats.</p>
+        <p>Click any <span class="xp-term" data-term="chunk">chunk</span> to inspect its pre-computed stats.</p>
         <div class="cs-timeline-strip xp-scroll-x" id="timeline-strip"></div>
         <div class="xp-card cs-detail-panel" id="chunk-detail" hidden>
           <div class="cs-detail-header" id="detail-header"></div>
@@ -52,7 +62,7 @@
       <!-- C. Query Builder -->
       <section class="xp-section" id="query-section">
         <h2>③ Query Builder</h2>
-        <p>Configure an aggregation query and watch the engine decide which chunks to decode.</p>
+        <p>Configure an aggregation query and watch the engine decide which <span class="xp-term" data-term="chunk">chunks</span> to decode.</p>
         <div class="xp-card">
           <div class="xp-controls cs-query-controls">
             <div class="cs-control-group">
@@ -65,7 +75,7 @@
               </select>
             </div>
             <div class="cs-control-group">
-              <label class="xp-label" for="step-select">Step Size</label>
+              <label class="xp-label" for="step-select"><span class="xp-term" data-term="step-aligned aggregation">Step Size</span></label>
               <select class="xp-select" id="step-select">
                 <option value="1">1 chunk</option>
                 <option value="2">2 chunks</option>
@@ -101,29 +111,29 @@
       </section>
 
       <!-- F. Skip Logic Explanation -->
-      <section class="xp-section" id="explain-section">
+      <section class="xp-section" id="skip-logic-section" hidden>
         <h2>⑥ Skip Logic</h2>
         <p>How the engine decides whether to decode or skip each chunk:</p>
         <div class="cs-explain-grid" id="explain-grid">
           <div class="xp-card cs-explain-card" data-agg="max">
             <div class="cs-explain-icon">📈</div>
             <h3>max</h3>
-            <p>If <code class="xp-code">chunk.max ≤ running_max</code> → <strong>skip</strong>. The chunk can't improve the answer.</p>
+            <p>If <code class="xp-code">chunk.max ≤ running_max</code> → <strong>skip</strong>. The <span class="xp-term" data-term="chunk">chunk</span> can't improve the answer.</p>
           </div>
           <div class="xp-card cs-explain-card" data-agg="min">
             <div class="cs-explain-icon">📉</div>
             <h3>min</h3>
-            <p>If <code class="xp-code">chunk.min ≥ running_min</code> → <strong>skip</strong>. The chunk can't lower the answer.</p>
+            <p>If <code class="xp-code">chunk.min ≥ running_min</code> → <strong>skip</strong>. The <span class="xp-term" data-term="chunk">chunk</span> can't lower the answer.</p>
           </div>
           <div class="xp-card cs-explain-card" data-agg="sum">
             <div class="cs-explain-icon">➕</div>
             <h3>sum</h3>
-            <p>If bucket aligns with chunk → use <code class="xp-code">chunk.sum</code> directly. No decode needed.</p>
+            <p>If bucket <span class="xp-term" data-term="aligned">aligns</span> with <span class="xp-term" data-term="chunk">chunk</span> → use <code class="xp-code">chunk.sum</code> directly. No decode needed.</p>
           </div>
           <div class="xp-card cs-explain-card" data-agg="avg">
             <div class="cs-explain-icon">📊</div>
             <h3>avg</h3>
-            <p>If aligned → compute <code class="xp-code">chunk.sum / chunk.count</code>. Both are pre-computed.</p>
+            <p>If <span class="xp-term" data-term="aligned">aligned</span> → compute <code class="xp-code">chunk.sum / chunk.count</code>. Both are pre-computed.</p>
           </div>
         </div>
       </section>

--- a/site/tsdb-engine/learn/chunk-stats/index.html
+++ b/site/tsdb-engine/learn/chunk-stats/index.html
@@ -41,7 +41,7 @@
       <section class="xp-section" id="timeline-section">
         <h2>② Chunk Timeline</h2>
         <p>Click any chunk to inspect its pre-computed stats.</p>
-        <div class="cs-timeline-strip" id="timeline-strip"></div>
+        <div class="cs-timeline-strip xp-scroll-x" id="timeline-strip"></div>
         <div class="xp-card cs-detail-panel" id="chunk-detail" hidden>
           <div class="cs-detail-header" id="detail-header"></div>
           <div class="xp-stats-row" id="detail-stats"></div>

--- a/site/tsdb-engine/learn/chunk-stats/index.html
+++ b/site/tsdb-engine/learn/chunk-stats/index.html
@@ -130,8 +130,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/chunk-stats/stats-experience.css
+++ b/site/tsdb-engine/learn/chunk-stats/stats-experience.css
@@ -18,17 +18,6 @@
   overflow-x: auto;
   padding-bottom: 10px;
   margin-bottom: 16px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--xp-border-strong) transparent;
-}
-
-.cs-timeline-strip::-webkit-scrollbar {
-  height: 6px;
-}
-
-.cs-timeline-strip::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 3px;
 }
 
 .cs-chunk-block {

--- a/site/tsdb-engine/learn/chunk-stats/stats-experience.js
+++ b/site/tsdb-engine/learn/chunk-stats/stats-experience.js
@@ -14,6 +14,7 @@ import {
   el,
   fmt,
   generateSamples,
+  initGlossary,
   revealSection,
 } from "../shared.js";
 
@@ -184,7 +185,7 @@ function selectChunk(id) {
 
   // header
   $("#detail-header").innerHTML = `
-    <h3>Chunk ${id}</h3>
+    <h3><span class="xp-term" data-term="chunk">Chunk</span> ${id}</h3>
     <span class="time-range">${fmtTime(chunk.startTime)} – ${fmtTime(chunk.endTime)}</span>
   `;
 
@@ -249,8 +250,8 @@ function showExecution(buckets, agg, _startChunk) {
   const resultsSection = $("#results-section");
   resultsSection.hidden = true;
 
-  $("#exec-description").textContent =
-    `Running ${agg}() over ${buckets.reduce((s, b) => s + b.chunks.length, 0)} chunks in ${buckets.length} buckets…`;
+  $("#exec-description").innerHTML =
+    `Running ${agg}() over ${buckets.reduce((s, b) => s + b.chunks.length, 0)} <span class="xp-term" data-term="chunk">chunks</span> in ${buckets.length} buckets…`;
 
   const grid = $("#exec-grid");
   grid.innerHTML = "";
@@ -505,6 +506,9 @@ function showResults(bucketResults, agg, decoded, statsOnly, skipped) {
   });
 
   revealSection(section);
+
+  const skipLogic = document.getElementById("skip-logic-section");
+  if (skipLogic) skipLogic.hidden = false;
 }
 
 /* ─── Init ────────────────────────────────────────────────────────── */
@@ -540,6 +544,8 @@ function init() {
       card.classList.toggle("highlight", card.dataset.agg === agg);
     });
   });
+
+  initGlossary();
 }
 
 init();

--- a/site/tsdb-engine/learn/chunk-stats/stats-experience.js
+++ b/site/tsdb-engine/learn/chunk-stats/stats-experience.js
@@ -14,6 +14,7 @@ import {
   el,
   fmt,
   generateSamples,
+  revealSection,
 } from "../shared.js";
 
 /* ─── Constants ───────────────────────────────────────────────────── */
@@ -243,7 +244,7 @@ function runQuery() {
 function showExecution(buckets, agg, _startChunk) {
   const execSection = $("#execution-section");
   execSection.hidden = false;
-  execSection.scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection(execSection);
 
   const resultsSection = $("#results-section");
   resultsSection.hidden = true;
@@ -503,7 +504,7 @@ function showResults(bucketResults, agg, decoded, statsOnly, skipped) {
     resultsGrid.appendChild(cell);
   });
 
-  section.scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection(section);
 }
 
 /* ─── Init ────────────────────────────────────────────────────────── */

--- a/site/tsdb-engine/learn/delta-of-delta/dod-experience.css
+++ b/site/tsdb-engine/learn/delta-of-delta/dod-experience.css
@@ -24,17 +24,6 @@
 
 .dod-table-scroll {
   overflow-x: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--xp-border-strong) transparent;
-}
-
-.dod-table-scroll::-webkit-scrollbar {
-  height: 6px;
-}
-
-.dod-table-scroll::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 3px;
 }
 
 .dod-table {
@@ -83,17 +72,7 @@
 .dod-table tr.tier-row-0 td:first-child { border-left-width: 3px; }
 .dod-table tr.tier-row-1 td:first-child { border-left-width: 3px; }
 
-/* Tier badge */
-.dod-tier-badge {
-  display: inline-block;
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 10px;
-  font-weight: 600;
-  font-family: var(--xp-mono);
-  letter-spacing: 0.04em;
-}
-
+/* Tier badge — base from .xp-badge in shared.css */
 .dod-tier-badge.t0 { background: rgba(52, 211, 153, 0.15); color: var(--tier-0); }
 .dod-tier-badge.t1 { background: rgba(96, 165, 250, 0.15); color: var(--tier-1); }
 .dod-tier-badge.t2 { background: rgba(167, 139, 250, 0.15); color: var(--tier-2); }
@@ -209,16 +188,7 @@
 }
 
 /* ─── Jitter Story ────────────────────────────────────────────────── */
-.dod-story {
-  margin-top: 16px;
-  padding: 16px 20px;
-  background: var(--xp-surface);
-  border: 1px solid var(--xp-border);
-  border-radius: var(--xp-radius-sm);
-  font-size: 14px;
-  line-height: 1.6;
-  color: var(--xp-text-muted);
-}
+/* base from .xp-story in shared.css */
 
 .dod-story strong {
   color: var(--xp-success);

--- a/site/tsdb-engine/learn/delta-of-delta/dod-experience.js
+++ b/site/tsdb-engine/learn/delta-of-delta/dod-experience.js
@@ -6,7 +6,7 @@
  */
 
 import {
-  $, el, buildBreadcrumb, fmt, fmtBytes, zigzagEncode, generateSamples,
+  $, el, buildBreadcrumb, buildStat, fmt, fmtBytes, zigzagEncode, generateSamples,
 } from '../shared.js';
 
 /* ─── Constants ───────────────────────────────────────────────────── */
@@ -177,11 +177,11 @@ function renderTable() {
 
     // Tier badge
     if (row.tier >= 0) {
-      const badge = el('span', { class: `dod-tier-badge t${row.tier}` }, row.tierLabel);
+      const badge = el('span', { class: `xp-badge dod-tier-badge t${row.tier}` }, row.tierLabel);
       tr.appendChild(el('td', {}, badge));
     } else {
       const badge = el('span', {
-        class: 'dod-tier-badge',
+        class: 'xp-badge dod-tier-badge',
         style: { background: 'rgba(139, 92, 246, 0.15)', color: 'var(--region-header)' },
       }, row.tierLabel);
       tr.appendChild(el('td', {}, badge));
@@ -279,11 +279,7 @@ function renderSummary() {
   ];
 
   for (const s of stats) {
-    const stat = el('div', { class: 'xp-stat' },
-      el('div', { class: 'xp-stat-label' }, s.label),
-      el('div', { class: 'xp-stat-value' }, s.value),
-      el('div', { class: 'xp-stat-unit' }, s.unit),
-    );
+    const stat = buildStat(s.label, s.value, s.unit);
     if (s.label === 'Ratio') {
       stat.querySelector('.xp-stat-value').style.color = ratio >= 10 ? 'var(--xp-success)' : ratio >= 4 ? 'var(--xp-accent)' : 'var(--xp-warn)';
     }

--- a/site/tsdb-engine/learn/delta-of-delta/dod-experience.js
+++ b/site/tsdb-engine/learn/delta-of-delta/dod-experience.js
@@ -6,7 +6,7 @@
  */
 
 import {
-  $, el, buildBreadcrumb, buildStat, fmt, fmtBytes, zigzagEncode, generateSamples,
+  $, el, buildBreadcrumb, buildStat, fmt, fmtBytes, zigzagEncode, generateSamples, initGlossary,
 } from '../shared.js';
 
 /* ─── Constants ───────────────────────────────────────────────────── */
@@ -291,10 +291,10 @@ function renderSummary() {
   const t0Pct = tierTotal > 0 ? Math.round((data.tierCounts[0] / tierTotal) * 100) : 0;
 
   if (jitterMs === 0) {
-    story.innerHTML = `With <strong>0 ms jitter</strong>, ${t0Pct}% of deltas-of-deltas are exactly zero — each costs only <strong>1 bit</strong>. The entire timestamp column compresses to <strong>${ratio.toFixed(0)}× smaller</strong> than raw 8-byte timestamps.`;
+    story.innerHTML = `With <strong>0 ms jitter</strong>, ${t0Pct}% of <span class="xp-term" data-term="delta-of-delta">deltas-of-deltas</span> are exactly zero — each costs only <strong>1 bit</strong>. The entire timestamp column compresses to <strong>${ratio.toFixed(0)}× smaller</strong> than raw 8-byte timestamps.`;
   } else {
     const warnClass = avgBits > 10 ? ' warn' : '';
-    story.innerHTML = `With <strong class="${warnClass}">${fmt(jitterMs)} ms jitter</strong>, only ${t0Pct}% of ΔoΔ values are zero. Average encoding cost rises to <strong class="${warnClass}">${avgBits.toFixed(1)} bits/timestamp</strong>. Compression ratio: <strong>${ratio.toFixed(1)}×</strong>.`;
+    story.innerHTML = `With <strong class="${warnClass}">${fmt(jitterMs)} ms jitter</strong>, only ${t0Pct}% of <span class="xp-term" data-term="delta-of-delta">ΔoΔ</span> values are zero. Average encoding cost rises to <strong class="${warnClass}">${avgBits.toFixed(1)} bits/timestamp</strong>. Compression ratio: <strong>${ratio.toFixed(1)}×</strong>.`;
   }
 }
 
@@ -341,6 +341,7 @@ function init() {
 
   // Initial render
   renderAll();
+  initGlossary();
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/site/tsdb-engine/learn/delta-of-delta/index.html
+++ b/site/tsdb-engine/learn/delta-of-delta/index.html
@@ -110,8 +110,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/delta-of-delta/index.html
+++ b/site/tsdb-engine/learn/delta-of-delta/index.html
@@ -27,6 +27,12 @@
           compress to <strong>1 bit each</strong>, 64× smaller than raw.
           Drag the jitter slider and watch compression degrade in real time.
         </p>
+        <p class="lede" style="margin-top: 12px; font-size: 0.95em; color: var(--xp-text-muted);">
+          <strong>Why this matters:</strong> Prometheus timestamps are 64-bit nanosecond integers — 8 bytes each.
+          At 1 sample/15 s, 1 million timestamps = 8 MB. With
+          <span class="xp-term" data-term="delta-of-delta">Delta-of-Delta</span> encoding, a perfectly regular
+          15-second interval costs just 1 bit per sample — 125 KB for the same million samples, a 64× reduction.
+        </p>
       </div>
 
       <!-- A. Controls -->
@@ -57,6 +63,17 @@
         </div>
       </section>
 
+      <!-- Encoding chain explainer -->
+      <div class="xp-card" style="margin: 0 0 24px; padding: 20px 24px;">
+        <p style="margin: 0 0 10px; font-weight: 600; color: var(--xp-text);">Timestamps are compressed in a 4-step chain:</p>
+        <ol style="margin: 0; padding-left: 20px; line-height: 1.9; color: var(--xp-text-muted);">
+          <li><strong>Raw → <span class="xp-term" data-term="delta">Δ (delta)</span>:</strong> record the gap between consecutive timestamps instead of the timestamps themselves. Regular 15-second intervals → all deltas = 15,000,000,000 ns.</li>
+          <li><strong><span class="xp-term" data-term="delta">Δ</span> → <span class="xp-term" data-term="delta-of-delta">ΔoΔ (delta-of-delta)</span>:</strong> record how much each <span class="xp-term" data-term="delta">delta</span> changed. Perfect regularity → ΔoΔ = 0 every time.</li>
+          <li><strong><span class="xp-term" data-term="delta-of-delta">ΔoΔ</span> → <span class="xp-term" data-term="zigzag">ZigZag</span>:</strong> map signed integers to unsigned so small negatives get small codes.</li>
+          <li><strong><span class="xp-term" data-term="zigzag">ZigZag</span> → <span class="xp-term" data-term="tier">Tier</span>:</strong> pick the shortest bit pattern that fits the value.</li>
+        </ol>
+      </div>
+
       <!-- B. Transformation Table -->
       <section class="xp-section" id="table-section">
         <h2>② Transformation Table</h2>
@@ -68,10 +85,10 @@
                 <tr>
                   <th>#</th>
                   <th>Timestamp</th>
-                  <th>Δ (delta)</th>
-                  <th>ΔoΔ</th>
-                  <th>ZigZag</th>
-                  <th>Tier</th>
+                  <th><span class="xp-term" data-term="delta">Δ</span> (delta)</th>
+                  <th><span class="xp-term" data-term="delta-of-delta">ΔoΔ</span></th>
+                  <th><span class="xp-term" data-term="zigzag">ZigZag</span></th>
+                  <th><span class="xp-term" data-term="tier">Tier</span></th>
                   <th>Prefix</th>
                   <th>Bits</th>
                 </tr>
@@ -85,7 +102,7 @@
       <!-- C. Tier Distribution -->
       <section class="xp-section" id="tier-section">
         <h2>③ Tier Distribution</h2>
-        <p>How values spread across encoding tiers — green is cheapest.</p>
+        <p>How values spread across encoding <span class="xp-term" data-term="tier">tiers</span> — green is cheapest.</p>
         <div class="xp-card">
           <div class="dod-tier-bar" id="tier-bar"></div>
           <div class="dod-tier-legend" id="tier-legend"></div>

--- a/site/tsdb-engine/learn/delta-of-delta/index.html
+++ b/site/tsdb-engine/learn/delta-of-delta/index.html
@@ -62,7 +62,7 @@
         <h2>② Transformation Table</h2>
         <p>Each row shows one timestamp flowing through the pipeline.</p>
         <div class="xp-card dod-table-wrap">
-          <div class="dod-table-scroll">
+          <div class="dod-table-scroll xp-scroll-x">
             <table class="xp-table dod-table" id="dod-table">
               <thead>
                 <tr>
@@ -105,7 +105,7 @@
       <section class="xp-section" id="summary-section">
         <h2>⑤ Compression Summary</h2>
         <div class="xp-stats-row" id="summary-stats"></div>
-        <div class="dod-story" id="jitter-story"></div>
+        <div class="dod-story xp-story" id="jitter-story"></div>
       </section>
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">

--- a/site/tsdb-engine/learn/index.html
+++ b/site/tsdb-engine/learn/index.html
@@ -114,7 +114,7 @@
 
       <nav class="xp-topbar" aria-label="Breadcrumb">
         <div class="xp-breadcrumb">
-          <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+          <a href="../">TSDB Engine</a>
           <span class="sep">›</span>
           <span class="current">Learn</span>
         </div>

--- a/site/tsdb-engine/learn/index.html
+++ b/site/tsdb-engine/learn/index.html
@@ -208,8 +208,8 @@ Answer in &lt;1ms</div>
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/" style="color: var(--xp-text-muted); text-decoration: none;">Back to TSDB Engine →</a>
+          Part of <a href="../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">Back to TSDB Engine →</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/index.html
+++ b/site/tsdb-engine/learn/index.html
@@ -105,6 +105,37 @@
         .hub-intro { grid-template-columns: 1fr; }
         .hub-intro-diagram { display: none; }
       }
+      .xp-difficulty {
+        display: inline-block;
+        font-size: 0.7rem;
+        font-weight: 600;
+        padding: 2px 8px;
+        border-radius: 999px;
+        margin-bottom: 8px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+      .xp-difficulty.beginner {
+        background: rgba(34, 197, 94, 0.15);
+        color: #86efac;
+        border: 1px solid rgba(34, 197, 94, 0.3);
+      }
+      .xp-difficulty.intermediate {
+        background: rgba(251, 191, 36, 0.15);
+        color: #fde68a;
+        border: 1px solid rgba(251, 191, 36, 0.3);
+      }
+      .xp-start-here {
+        background: rgba(99, 102, 241, 0.1);
+        border: 1px solid rgba(99, 102, 241, 0.25);
+        border-radius: 8px;
+        padding: 12px 16px;
+        margin-bottom: 24px;
+        font-size: 0.9rem;
+        line-height: 1.6;
+        color: var(--xp-text-muted, #94a3b8);
+      }
+      .xp-start-here a { color: var(--xp-accent); }
     </style>
   </head>
   <body>
@@ -151,10 +182,15 @@ Answer in &lt;1ms</div>
       <section>
         <h2 style="color:#fff; margin-bottom: 4px;">Compression</h2>
         <p style="color: var(--xp-text-muted); font-size: 14px; margin-bottom: 16px;">How raw numbers become tiny bit streams</p>
+        <p class="xp-start-here">
+          💡 New here? Start with <a href="string-interning/">String Interning</a> or 
+          <a href="chunk-stats/">Chunk Stats</a> — they explain the foundations everything else builds on.
+        </p>
         <div class="hub-grid">
 
           <a href="alp/" class="hub-card" style="--card-accent: #10b981; --card-glow: rgba(16, 185, 129, 0.1);">
             <div class="hub-icon" style="--card-glow: rgba(16, 185, 129, 0.1);">📐</div>
+            <span class="xp-difficulty intermediate">Intermediate</span>
             <h3>ALP Compression</h3>
             <p>Watch floating-point numbers get quantized to integers, bit-packed, and compressed to a fraction of their size — with lossless round-trip.</p>
             <span class="hub-tag" style="--card-accent: #10b981; --card-glow: rgba(16, 185, 129, 0.1);">Values</span>
@@ -162,6 +198,7 @@ Answer in &lt;1ms</div>
 
           <a href="delta-of-delta/" class="hub-card" style="--card-accent: #06b6d4; --card-glow: rgba(6, 182, 212, 0.1);">
             <div class="hub-icon" style="--card-glow: rgba(6, 182, 212, 0.1);">⏱️</div>
+            <span class="xp-difficulty beginner">Beginner</span>
             <h3>Delta-of-Delta</h3>
             <p>Regular timestamps compress to almost nothing — just 1 bit per sample when the interval is constant. Watch the math unfold.</p>
             <span class="hub-tag" style="--card-accent: #06b6d4; --card-glow: rgba(6, 182, 212, 0.1);">Timestamps</span>
@@ -169,6 +206,7 @@ Answer in &lt;1ms</div>
 
           <a href="xor-delta/" class="hub-card" style="--card-accent: #a78bfa; --card-glow: rgba(167, 139, 250, 0.1);">
             <div class="hub-icon" style="--card-glow: rgba(167, 139, 250, 0.1);">⊕</div>
+            <span class="xp-difficulty intermediate">Intermediate</span>
             <h3>XOR-Delta</h3>
             <p>Values that barely change need barely any bits. XOR two floats, find the meaningful window, and store just that.</p>
             <span class="hub-tag" style="--card-accent: #a78bfa; --card-glow: rgba(167, 139, 250, 0.1);">Values</span>
@@ -184,6 +222,7 @@ Answer in &lt;1ms</div>
 
           <a href="string-interning/" class="hub-card" style="--card-accent: #f59e0b; --card-glow: rgba(245, 158, 11, 0.1);">
             <div class="hub-icon" style="--card-glow: rgba(245, 158, 11, 0.1);">🏷️</div>
+            <span class="xp-difficulty beginner">Beginner</span>
             <h3>String Interning</h3>
             <p>10,000 series × 4 labels each = 40,000 strings. Interning stores each unique string once and references it by integer ID.</p>
             <span class="hub-tag" style="--card-accent: #f59e0b; --card-glow: rgba(245, 158, 11, 0.1);">Labels</span>
@@ -191,6 +230,7 @@ Answer in &lt;1ms</div>
 
           <a href="chunk-stats/" class="hub-card" style="--card-accent: #f87171; --card-glow: rgba(248, 113, 113, 0.1);">
             <div class="hub-icon" style="--card-glow: rgba(248, 113, 113, 0.1);">📊</div>
+            <span class="xp-difficulty beginner">Beginner</span>
             <h3>Chunk Stats</h3>
             <p>Each compressed chunk stores min, max, sum, and count. Queries can skip entire chunks without decompressing — often 100× faster.</p>
             <span class="hub-tag" style="--card-accent: #f87171; --card-glow: rgba(248, 113, 113, 0.1);">Query</span>
@@ -198,8 +238,9 @@ Answer in &lt;1ms</div>
 
           <a href="query-engine/" class="hub-card" style="--card-accent: #60a5fa; --card-glow: rgba(96, 165, 250, 0.1);">
             <div class="hub-icon" style="--card-glow: rgba(96, 165, 250, 0.1);">🔍</div>
+            <span class="xp-difficulty intermediate">Intermediate</span>
             <h3>Query Engine</h3>
-            <p>From label filters to aggregated answers: postings intersection, chunk pruning, step-aligned bucketing — end to end.</p>
+            <p>From label filters to aggregated answers: finding which series match a query, skipping data outside the query's time range, grouping results into equal time intervals — end to end.</p>
             <span class="hub-tag" style="--card-accent: #60a5fa;">Pipeline</span>
           </a>
 

--- a/site/tsdb-engine/learn/query-engine/index.html
+++ b/site/tsdb-engine/learn/query-engine/index.html
@@ -32,6 +32,7 @@
       <section class="xp-section" id="dataset-section">
         <h2>① Sample Dataset</h2>
         <p>A simulated TSDB with three metrics, multiple label dimensions, and chunked storage.</p>
+        <p class="qe-primer"><strong>The data model:</strong> A monitoring system stores <span class="xp-term" data-term="series">series</span> — each series is one metric stream identified by <span class="xp-term" data-term="label">labels</span> (key=value pairs). Each series is split into fixed-size <span class="xp-term" data-term="chunk">chunks</span> of compressed <span class="xp-term" data-term="sample">samples</span>. A medium-sized system might have 50,000 series, each split into hundreds of chunks.</p>
         <div class="xp-stats-row" id="dataset-stats"></div>
         <div class="xp-card qe-dataset-card" id="dataset-detail"></div>
       </section>
@@ -98,6 +99,7 @@
       <!-- D. Stage 1: Label Matching & Postings Intersection -->
       <section class="xp-section" id="stage-match-section" hidden>
         <h2>④ Label Matching &amp; Postings Intersection</h2>
+        <p class="qe-primer"><strong>How label lookups work:</strong> For each unique label value (e.g. region=us-west-2), the TSDB maintains a <span class="xp-term" data-term="postings list">postings list</span> — a sorted array of <span class="xp-term" data-term="series">series</span> IDs that have that <span class="xp-term" data-term="label">label</span>. To find series matching multiple filters, we <em>intersect</em> these lists: keep only IDs that appear in all of them.</p>
         <p id="match-description"></p>
         <div class="xp-card qe-match-card" id="match-viz"></div>
         <div class="qe-match-summary" id="match-summary"></div>

--- a/site/tsdb-engine/learn/query-engine/index.html
+++ b/site/tsdb-engine/learn/query-engine/index.html
@@ -130,8 +130,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/query-engine/query-experience.js
+++ b/site/tsdb-engine/learn/query-engine/query-experience.js
@@ -6,7 +6,7 @@
  * Stats Check → Decode → Step-Aligned Aggregation
  */
 
-import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, Stepper } from "../shared.js";
+import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, revealSection, Stepper } from "../shared.js";
 
 /* ═══════════════════════════════════════════════════════════════════════
    A. DATASET GENERATION
@@ -748,7 +748,7 @@ function showResults(aggResults, matchedCount, pruneStats, aggFn, stepMinutes, q
   tableContainer.innerHTML = "";
   tableContainer.appendChild(table);
 
-  section.scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection(section);
 }
 
 /* ═══════════════════════════════════════════════════════════════════════
@@ -789,13 +789,13 @@ async function executeQuery() {
 
   const { intersection } = resolvePostings(metric, filters);
   await animateLabelMatch(metric, filters);
-  $("#stage-match-section").scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection($("#stage-match-section"));
   await sleep(600);
 
   // Stage 2: Chunk Pruning
   stepper.goto(2);
   const pruneStats = await animateChunkPruning(intersection, queryRangeHours);
-  $("#stage-prune-section").scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection($("#stage-prune-section"));
   await sleep(600);
 
   // Stage 3: Stats Check (brief pause — conceptual)
@@ -809,7 +809,7 @@ async function executeQuery() {
   // Stage 5: Aggregation
   stepper.goto(5);
   const aggResults = await animateAggregation(intersection, queryRangeHours, stepMinutes, aggFn);
-  $("#stage-agg-section").scrollIntoView({ behavior: "smooth", block: "start" });
+  revealSection($("#stage-agg-section"));
   await sleep(400);
 
   // Show results

--- a/site/tsdb-engine/learn/query-engine/query-experience.js
+++ b/site/tsdb-engine/learn/query-engine/query-experience.js
@@ -6,7 +6,7 @@
  * Stats Check → Decode → Step-Aligned Aggregation
  */
 
-import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, revealSection, Stepper } from "../shared.js";
+import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, revealSection, sleep, Stepper } from "../shared.js";
 
 /* ═══════════════════════════════════════════════════════════════════════
    A. DATASET GENERATION
@@ -823,10 +823,6 @@ async function executeQuery() {
 /* ═══════════════════════════════════════════════════════════════════════
    HELPERS
    ═══════════════════════════════════════════════════════════════════════ */
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 function fmtHour(ms) {
   const d = new Date(ms);

--- a/site/tsdb-engine/learn/query-engine/query-experience.js
+++ b/site/tsdb-engine/learn/query-engine/query-experience.js
@@ -6,7 +6,7 @@
  * Stats Check → Decode → Step-Aligned Aggregation
  */
 
-import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, revealSection, sleep, Stepper } from "../shared.js";
+import { $, $$, buildBreadcrumb, drawSparkline, el, fmt, initGlossary, revealSection, sleep, Stepper } from "../shared.js";
 
 /* ═══════════════════════════════════════════════════════════════════════
    A. DATASET GENERATION
@@ -140,12 +140,12 @@ buildPostingsIndex();
    ═══════════════════════════════════════════════════════════════════════ */
 
 const STAGES = [
-  { icon: "🏷", label: "Label Match" },
-  { icon: "∩", label: "Postings" },
-  { icon: "✂", label: "Prune Chunks" },
-  { icon: "📊", label: "Stats Check" },
-  { icon: "📦", label: "Decode" },
-  { icon: "Σ", label: "Aggregate" },
+  { icon: "🏷", label: "Match Labels", subtitle: "find series matching all label filters" },
+  { icon: "∩", label: "∩ Postings", subtitle: "intersect sorted series ID lists" },
+  { icon: "✂", label: "✂ Prune Chunks", subtitle: "skip chunks outside the time range" },
+  { icon: "📊", label: "Stats Check", subtitle: "answer from min/max/sum/count if possible" },
+  { icon: "📦", label: "Decode", subtitle: "decompress remaining chunks" },
+  { icon: "Σ", label: "Σ Aggregate", subtitle: "compute result per time bucket" },
 ];
 
 let stepper;
@@ -162,7 +162,8 @@ function buildPipeline() {
       "div",
       { class: "xp-pipe-stage", "data-stage": String(i) },
       el("span", { class: "stage-icon" }, stage.icon),
-      el("span", { class: "stage-label" }, stage.label)
+      el("span", { class: "stage-label" }, stage.label),
+      el("small", { class: "stage-subtitle" }, stage.subtitle)
     );
     bar.appendChild(stageEl);
   });
@@ -323,7 +324,7 @@ async function animateLabelMatch(metric, labelFilters) {
 
   // Description
   const desc = $("#match-description");
-  desc.textContent = `Each label filter maps to a sorted postings list. We intersect them using galloping search.`;
+  desc.innerHTML = `Each <span class="xp-term" data-term="label">label</span> filter maps to a sorted <span class="xp-term" data-term="postings list">postings list</span>. We intersect them using <span class="xp-term" data-term="galloping search">galloping search</span>.`;
 
   // Render postings lists
   const postingsGroups = [];
@@ -332,9 +333,12 @@ async function animateLabelMatch(metric, labelFilters) {
     const label = el(
       "div",
       { class: "qe-postings-label" },
-      `Postings for `,
+      el("span", { class: "xp-term", "data-term": "postings" }, "Postings"),
+      " for ",
       el("span", { class: "filter-text" }, pl.key),
-      ` (${pl.ids.length} series)`
+      ` (${pl.ids.length} `,
+      el("span", { class: "xp-term", "data-term": "series" }, "series"),
+      ")"
     );
     group.appendChild(label);
 
@@ -491,7 +495,7 @@ async function animateChunkPruning(matchedSeriesIds, queryRangeHours) {
   const allEnd = Math.max(...matchedSeries.flatMap((s) => s.chunks.map((c) => c.endTime)));
 
   const desc = $("#prune-description");
-  desc.textContent = `Binary-search each series' chunk list to find chunks overlapping the query time range [${fmtHour(rangeStart)} – ${fmtHour(rangeEnd)}].`;
+  desc.innerHTML = `Binary-search each <span class="xp-term" data-term="series">series</span>' <span class="xp-term" data-term="chunk">chunk</span> list to find <span class="xp-term" data-term="chunk">chunks</span> overlapping the query time range [${fmtHour(rangeStart)} – ${fmtHour(rangeEnd)}]. Out-of-range <span class="xp-term" data-term="chunk pruning">chunk pruning</span> avoids unnecessary decoding.`;
 
   const timeline = el("div", { class: "qe-prune-timeline" });
 
@@ -547,7 +551,7 @@ async function animateChunkPruning(matchedSeriesIds, queryRangeHours) {
   const summary = $("#prune-summary");
   summary.innerHTML = "";
   summary.appendChild(
-    el("div", { class: "qe-summary-chip" }, el("strong", {}, String(totalChunks)), " chunks total")
+    el("div", { class: "qe-summary-chip" }, el("strong", {}, String(totalChunks)), " ", el("span", { class: "xp-term", "data-term": "chunk" }, "chunks"), " total")
   );
   summary.appendChild(
     el("div", { class: "qe-summary-chip" }, el("strong", {}, String(inRangeCount)), " in range")
@@ -577,7 +581,7 @@ async function animateAggregation(matchedSeriesIds, queryRangeHours, stepMinutes
   const numBuckets = Math.ceil((rangeEnd - rangeStart) / stepMs);
 
   const desc = $("#agg-description");
-  desc.textContent = `Dividing the ${queryRangeHours}h range into ${numBuckets} buckets of ${stepMinutes}min each. Folding samples with ${aggFn}().`;
+  desc.innerHTML = `Dividing the ${queryRangeHours}h range into ${numBuckets} buckets of ${stepMinutes}min each (<span class="xp-term" data-term="step-aligned aggregation">step-aligned aggregation</span>). Folding <span class="xp-term" data-term="sample">samples</span> with ${aggFn}().`;
 
   // Collect all samples in range from matched series
   const matchedSeries = matchedSeriesIds.map((id) => DATASET[id]);
@@ -841,9 +845,9 @@ function renderDatasetSummary() {
   const statsRow = $("#dataset-stats");
   statsRow.innerHTML = [
     { label: "Metrics", value: String(METRICS.length) },
-    { label: "Series", value: String(totalSeries) },
-    { label: "Chunks", value: fmt(totalChunks) },
-    { label: "Samples", value: fmt(totalSamples) },
+    { label: `<span class="xp-term" data-term="series">Series</span>`, value: String(totalSeries) },
+    { label: `<span class="xp-term" data-term="chunk">Chunks</span>`, value: fmt(totalChunks) },
+    { label: `<span class="xp-term" data-term="sample">Samples</span>`, value: fmt(totalSamples) },
   ]
     .map(
       (s) => `
@@ -875,7 +879,7 @@ function renderDatasetSummary() {
   detail.innerHTML = `
     <table class="qe-dataset-table">
       <thead>
-        <tr><th>Metric</th><th>Labels</th><th>ID</th><th>Chunks</th><th>Samples</th></tr>
+        <tr><th>Metric</th><th><span class="xp-term" data-term="label">Labels</span></th><th>ID</th><th><span class="xp-term" data-term="chunk">Chunks</span></th><th><span class="xp-term" data-term="sample">Samples</span></th></tr>
       </thead>
       <tbody>${rows}</tbody>
     </table>`;
@@ -914,6 +918,8 @@ function init() {
   }
 
   $("#btn-execute").addEventListener("click", executeQuery);
+
+  initGlossary();
 }
 
 init();

--- a/site/tsdb-engine/learn/shared.css
+++ b/site/tsdb-engine/learn/shared.css
@@ -557,3 +557,66 @@ body {
   100% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0); }
 }
 .xp-reveal { animation: xp-reveal-pulse 0.6s ease-out; }
+
+/* ─── Scrollable Container Utilities ─────────────────────────────── */
+
+/* Horizontal scroll with thin themed scrollbar */
+.xp-scroll-x {
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--xp-border-strong) transparent;
+}
+
+.xp-scroll-x::-webkit-scrollbar {
+  height: 6px;
+}
+
+.xp-scroll-x::-webkit-scrollbar-thumb {
+  background: var(--xp-border-strong);
+  border-radius: 3px;
+}
+
+/* Vertical scroll with thin themed scrollbar */
+.xp-scroll-y {
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--xp-border-strong) transparent;
+}
+
+.xp-scroll-y::-webkit-scrollbar {
+  width: 4px;
+}
+
+.xp-scroll-y::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.xp-scroll-y::-webkit-scrollbar-thumb {
+  background: var(--xp-border-strong);
+  border-radius: 2px;
+}
+
+/* ─── Narrative Story Box ─────────────────────────────────────────── */
+
+.xp-story {
+  margin-top: 16px;
+  padding: 16px 20px;
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: var(--xp-radius-sm);
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--xp-text-muted);
+}
+
+/* ─── Pill Badge ──────────────────────────────────────────────────── */
+
+.xp-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: var(--xp-mono);
+  letter-spacing: 0.04em;
+}

--- a/site/tsdb-engine/learn/shared.css
+++ b/site/tsdb-engine/learn/shared.css
@@ -422,6 +422,14 @@ body {
   color: var(--xp-text-muted);
 }
 
+.xp-pipe-stage .stage-subtitle {
+  font-size: 9px;
+  color: var(--xp-text-dim);
+  font-style: italic;
+  line-height: 1.3;
+  max-width: 80px;
+}
+
 .xp-pipe-arrow {
   color: var(--xp-text-dim);
   font-size: 16px;
@@ -619,4 +627,39 @@ body {
   font-weight: 600;
   font-family: var(--xp-mono);
   letter-spacing: 0.04em;
+}
+
+/* ─── Glossary Tooltips ─────────────────────────────────────── */
+.xp-term {
+  border-bottom: 1px dotted var(--xp-accent);
+  cursor: help;
+  color: inherit;
+  position: relative;
+}
+
+.xp-tooltip {
+  position: fixed;
+  z-index: 1000;
+  max-width: 280px;
+  background: #1e2030;
+  border: 1px solid var(--xp-accent);
+  border-radius: 8px;
+  padding: 10px 14px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--xp-text, #e2e8f0);
+}
+
+.xp-tooltip.visible { opacity: 1; }
+
+.xp-tooltip .xp-tooltip-term {
+  font-weight: 600;
+  color: var(--xp-accent);
+  display: block;
+  margin-bottom: 4px;
+  font-size: 0.85rem;
 }

--- a/site/tsdb-engine/learn/shared.css
+++ b/site/tsdb-engine/learn/shared.css
@@ -548,3 +548,12 @@ body {
 .xp-skip-link:focus {
   left: 16px;
 }
+
+/* ─── Reveal pulse (gentle attention without forced scroll) ─────── */
+
+@keyframes xp-reveal-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.4); }
+  70% { box-shadow: 0 0 0 8px rgba(99, 102, 241, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0); }
+}
+.xp-reveal { animation: xp-reveal-pulse 0.6s ease-out; }

--- a/site/tsdb-engine/learn/shared.js
+++ b/site/tsdb-engine/learn/shared.js
@@ -281,3 +281,106 @@ export function buildStat(label, value, unit = '', opts = {}) {
 export function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+/* ─── Glossary Definitions ─────────────────────────────────── */
+export const GLOSSARY = {
+  "chunk": "A fixed-size block of compressed data points for one time-series — typically 120–240 samples covering a short time window (e.g. 1 hour). When a chunk is full it is sealed and its summary statistics are pre-computed.",
+  "series": "One stream of metric data with a unique set of labels — e.g. all CPU readings from a specific pod. A monitoring system may track millions of distinct series.",
+  "sample": "A single (timestamp, value) pair — one measurement at one point in time. Series are made of thousands of samples.",
+  "label": "A key=value pair that describes a metric: e.g. region=us-west-2 or job=api-server. Labels are stored as strings and used to filter and group queries.",
+  "f64": "A 64-bit floating-point number (8 bytes). The standard format for decimal values in most programming languages — e.g. 34.5 or 0.001.",
+  "postings": "A sorted list of series IDs that share a particular label value — e.g. all series where region=us-west-2. The TSDB maintains one postings list per unique label value for fast lookup.",
+  "postings list": "A sorted array of series IDs for a specific label value. Used by the query engine to quickly find matching series without scanning every series.",
+  "postings intersection": "Finding the series IDs that appear in all required postings lists simultaneously — i.e. series matching every label filter in the query.",
+  "galloping search": "A fast algorithm for intersecting two sorted lists. Instead of checking every element it jumps ahead exponentially then binary-searches back. Much faster when one list is much shorter than the other.",
+  "step-aligned aggregation": "Dividing a query's time range into equal-sized buckets ('steps') and computing one aggregate value (sum, avg, max, min) per bucket.",
+  "chunk pruning": "Discarding chunks whose time range doesn't overlap the query's time range before decompressing anything — a fast way to skip irrelevant data.",
+  "XOR": "Exclusive-OR: comparing two numbers bit-by-bit, producing a 1 only where the inputs differ. Similar floating-point values XOR to mostly zeros, which compress very efficiently.",
+  "IEEE 754": "The international standard for floating-point numbers. Every float64 is exactly 64 bits: 1 sign bit + 11 exponent bits + 52 fraction bits.",
+  "frame-of-reference": "A compression step that subtracts the minimum value from all numbers in a block, so all values become small offsets starting near zero. Smaller numbers need fewer bits.",
+  "bit-packing": "Instead of storing each number in a fixed 8 bytes, figure out the minimum bits needed and pack all values back-to-back with no gaps. Saves space when all values are small.",
+  "quantize": "Converting a decimal number to a whole number by multiplying by a power of 10 — e.g. 20.5 × 10 = 205. Integer compression then works far better than floating-point compression.",
+  "exponent": "In ALP compression: the power of 10 used to convert decimals to integers (e.g. exponent 2 means multiply by 100). Not to be confused with the IEEE 754 exponent field inside a float.",
+  "zigzag encoding": "Maps signed integers to unsigned integers so small negative and positive numbers both get small values: 0→0, −1→1, 1→2, −2→3. Allows variable-length codes to handle negatives efficiently.",
+  "zigzag": "Maps signed integers to unsigned integers so small negative and positive numbers both get small values: 0→0, −1→1, 1→2, −2→3. Allows variable-length codes to handle negatives efficiently.",
+  "tier": "In Delta-of-Delta encoding: one of 5 bit-width levels chosen based on how large the delta-of-delta value is. Tier 0 = 1 bit (no change), Tier 4 = 68 bits (large change). Most samples fall in Tier 0 or 1.",
+  "delta": "The difference between two consecutive values. For timestamps: if samples arrive at 10:00:15 and 10:00:30, the delta is 15 seconds.",
+  "delta-of-delta": "The difference between consecutive deltas. If all intervals are exactly 15 s, every delta-of-delta is 0 — which compresses to just 1 bit each.",
+  "FNV-1a": "A fast hash function that converts a string to a fixed-size integer (a 'fingerprint'). Used to decide which slot in the hash table to check first.",
+  "hash function": "A function that converts any input (like a string) to a fixed-size integer. Good hash functions spread inputs evenly across available slots.",
+  "open addressing": "A hash table collision strategy: if the target slot is occupied, try the next slot, then the next, until an empty one is found.",
+  "linear probing": "The simplest open-addressing strategy — if slot N is taken, try N+1, N+2, etc., wrapping around at the end of the table.",
+  "cardinality": "The number of unique values in a set. High cardinality labels (like pod IDs or trace IDs) have many unique values, reducing reuse and increasing memory cost.",
+  "exceptions": "In ALP compression: values that cannot be exactly represented as integers regardless of the exponent. These are stored as raw 8-byte floats alongside the bit-packed data.",
+  "wire format": "The exact byte layout used when data is written to disk or sent over a network — the 'physical' encoding including headers, offsets, and compressed payloads.",
+  "leading zeros": "The number of zero bits at the left of an XOR result. More leading zeros means fewer meaningful bits to store.",
+  "trailing zeros": "The number of zero bits at the right of an XOR result. More trailing zeros means fewer meaningful bits to store.",
+  "meaningful bits": "The bits between the leading and trailing zeros of an XOR result — the only bits that differ between consecutive values and need to be stored.",
+  "window": "In XOR-Delta encoding: the range of bit positions [leading_zeros … 63−trailing_zeros] that contained the previous non-zero XOR. If the new XOR fits in the same window, we reuse it (saves 12 bits of overhead).",
+  "frozen": "A chunk is 'frozen' (sealed) when it reaches its maximum sample count. At that point its summary statistics (min, max, sum, count) are pre-computed and stored alongside it.",
+  "aligned": "A query window is 'aligned' when it exactly covers one or more whole chunks with no partial overlap — allowing the query to be answered from pre-computed chunk statistics without decompression.",
+};
+
+/** Initialise the glossary tooltip layer.
+ *  Call once on DOMContentLoaded. Wraps nothing automatically —
+ *  pages must mark terms with <span class="xp-term" data-term="chunk">chunk</span>.
+ */
+export function initGlossary() {
+  const tip = document.createElement("div");
+  tip.className = "xp-tooltip";
+  tip.innerHTML = '<span class="xp-tooltip-term"></span><span class="xp-tooltip-body"></span>';
+  document.body.appendChild(tip);
+
+  const termEl = tip.querySelector(".xp-tooltip-term");
+  const bodyEl = tip.querySelector(".xp-tooltip-body");
+
+  let hideTimer;
+
+  function show(anchor) {
+    const key = anchor.dataset.term;
+    const def = GLOSSARY[key] || GLOSSARY[key.toLowerCase()];
+    if (!def) return;
+
+    clearTimeout(hideTimer);
+    termEl.textContent = anchor.textContent;
+    bodyEl.textContent = def;
+
+    const rect = anchor.getBoundingClientRect();
+    tip.style.left = Math.min(rect.left, window.innerWidth - 300) + "px";
+    // show above if close to bottom, below otherwise
+    const spaceBelow = window.innerHeight - rect.bottom;
+    if (spaceBelow < 140) {
+      tip.style.top = (rect.top - 8 + window.scrollY) + "px";
+      tip.style.transform = "translateY(-100%)";
+    } else {
+      tip.style.top = (rect.bottom + 8 + window.scrollY) + "px";
+      tip.style.transform = "none";
+    }
+    tip.classList.add("visible");
+  }
+
+  function hide() {
+    hideTimer = setTimeout(() => tip.classList.remove("visible"), 100);
+  }
+
+  document.addEventListener("mouseover", e => {
+    const t = e.target.closest(".xp-term");
+    if (t) show(t);
+  });
+  document.addEventListener("mouseout", e => {
+    if (e.target.closest(".xp-term")) hide();
+  });
+  document.addEventListener("click", e => {
+    const t = e.target.closest(".xp-term");
+    if (t) {
+      // toggle on click for touch devices
+      if (tip.classList.contains("visible")) {
+        tip.classList.remove("visible");
+      } else {
+        show(t);
+      }
+    } else {
+      tip.classList.remove("visible");
+    }
+  });
+}

--- a/site/tsdb-engine/learn/shared.js
+++ b/site/tsdb-engine/learn/shared.js
@@ -197,13 +197,24 @@ export function buildBreadcrumb(title) {
   return `
     <nav class="xp-topbar" aria-label="Breadcrumb">
       <div class="xp-breadcrumb">
-        <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+        <a href="../../">TSDB Engine</a>
         <span class="sep">›</span>
-        <a href="/o11ykit/tsdb-engine/learn/">Learn</a>
+        <a href="../">Learn</a>
         <span class="sep">›</span>
         <span class="current">${title}</span>
       </div>
     </nav>`;
+}
+
+/** Gently reveal a section — only scrolls if not already visible, adds a brief highlight pulse. */
+export function revealSection(el) {
+  const rect = el.getBoundingClientRect();
+  const inView = rect.top >= 0 && rect.bottom <= window.innerHeight;
+  if (!inView) {
+    el.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }
+  el.classList.add("xp-reveal");
+  el.addEventListener("animationend", () => el.classList.remove("xp-reveal"), { once: true });
 }
 
 /** Render a sparkline to a canvas element. */

--- a/site/tsdb-engine/learn/shared.js
+++ b/site/tsdb-engine/learn/shared.js
@@ -252,3 +252,32 @@ export function drawSparkline(canvas, values, opts = {}) {
   ctx.fillStyle = color.replace(')', `, ${fillAlpha})`).replace('rgb', 'rgba');
   ctx.fill();
 }
+
+/* ─── Stat Card Builder ───────────────────────────────────────────── */
+
+/**
+ * Build a standard `.xp-stat` card element.
+ * @param {string} label
+ * @param {string|number} value
+ * @param {string} [unit]
+ * @param {object} [opts]  – opts.cls (extra class on value), opts.color (inline color on value)
+ * @returns {HTMLElement}
+ */
+export function buildStat(label, value, unit = '', opts = {}) {
+  const valueEl = el('div', {
+    class: ['xp-stat-value', opts.cls].filter(Boolean).join(' '),
+    ...(opts.color ? { style: { color: opts.color } } : {}),
+  }, String(value));
+  return el('div', { class: 'xp-stat' },
+    el('div', { class: 'xp-stat-label' }, label),
+    valueEl,
+    unit ? el('div', { class: 'xp-stat-unit' }, unit) : null,
+  );
+}
+
+/* ─── Async Helpers ───────────────────────────────────────────────── */
+
+/** Promise-based sleep. */
+export function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/site/tsdb-engine/learn/string-interning/index.html
+++ b/site/tsdb-engine/learn/string-interning/index.html
@@ -22,16 +22,30 @@
         <p class="xp-eyebrow">Label Storage</p>
         <h1>String Interning</h1>
         <p class="lede">
-          Instead of storing <code class="xp-code">"region=us-west-2"</code> in every series,
-          store it <strong>once</strong> in a byte buffer and reference it by a 4-byte integer ID.
+          <strong>String interning</strong> means: instead of storing the same string over and over, store it
+          <strong>once</strong> in a byte buffer and give each copy a tiny 4-byte integer that points to the original.
+          In metric storage, <span class="xp-term" data-term="label">labels</span> like
+          <code class="xp-code">region=us-west-2</code> appear in thousands of
+          <span class="xp-term" data-term="series">series</span> — without interning, each copy wastes memory.
           Generate Kubernetes-style metrics and watch memory usage collapse as strings are reused.
+        </p>
+      </div>
+
+      <!-- Series & Labels primer -->
+      <div class="xp-card" style="margin-bottom:0">
+        <p style="margin:0;font-size:14px;line-height:1.7">
+          A <strong><span class="xp-term" data-term="series">series</span></strong> is one stream of metric data
+          uniquely identified by its <strong><span class="xp-term" data-term="label">labels</span></strong>.
+          Labels are <code class="xp-code">key=value</code> pairs like <code class="xp-code">job=api</code> or
+          <code class="xp-code">region=us-west</code>. A monitoring system tracking 10,000 pods might have 50,000+
+          series — but most share the same small set of label values, making interning highly effective.
         </p>
       </div>
 
       <!-- A. Series Generator -->
       <section class="xp-section" id="generator-section">
         <h2>① Generate Series</h2>
-        <p>Create realistic Kubernetes metric series with shared labels. Adjust the count and hit Generate.</p>
+        <p>Create realistic Kubernetes metric <span class="xp-term" data-term="series">series</span> with shared <span class="xp-term" data-term="label">labels</span>. Adjust the count and hit Generate.</p>
         <div class="xp-card">
           <div class="xp-controls" id="gen-controls">
             <div class="xp-slider-group">
@@ -57,7 +71,7 @@
       <!-- B. Naive vs Interned Split View -->
       <section class="xp-section" id="split-section">
         <h2>③ Naive vs Interned</h2>
-        <p>Side-by-side: every series stores full strings (left) vs. integer IDs into a shared buffer (right).</p>
+        <p>Side-by-side: every <span class="xp-term" data-term="series">series</span> stores full strings (left) vs. integer IDs into a shared buffer (right).</p>
         <div class="intern-split">
           <div class="xp-card intern-panel" id="naive-panel">
             <h3>Naive Storage</h3>
@@ -93,8 +107,16 @@
       <!-- D. Intern Animation -->
       <section class="xp-section" id="animation-section">
         <h2>⑤ Intern a String</h2>
-        <p>Step through the FNV-1a hash → open-addressing → store-or-reuse pipeline.</p>
+        <p>Step through the <span class="xp-term" data-term="FNV-1a">FNV-1a</span> hash → <span class="xp-term" data-term="open addressing">open-addressing</span> → store-or-reuse pipeline.</p>
         <div class="xp-card xp-card-raised">
+          <div style="margin-bottom:16px;font-size:13px;line-height:1.8;color:var(--xp-text-muted)">
+            <p style="margin:0 0 8px">To check whether a string is already stored, we use a <strong>hash table</strong> — a data structure for near-instant lookups:</p>
+            <ol style="margin:0;padding-left:20px">
+              <li><strong>Hash</strong>: run the string through a <span class="xp-term" data-term="hash function">hash function</span> (<span class="xp-term" data-term="FNV-1a">FNV-1a</span>) to get a slot number</li>
+              <li><strong>Probe</strong>: check that slot; if taken by a different string, check the next slot (<span class="xp-term" data-term="linear probing">linear probing</span>)</li>
+              <li><strong>Insert or reuse</strong>: if the string is new, store it and record its position; if it already exists, return the existing position</li>
+            </ol>
+          </div>
           <div class="xp-controls">
             <div class="xp-slider-group">
               <label class="xp-label" for="anim-string-select">String to intern</label>
@@ -114,7 +136,7 @@
 
           <!-- Hash table visualization -->
           <div class="intern-hash-table-wrap">
-            <span class="xp-label">Hash Table (open addressing)</span>
+            <span class="xp-label">Hash Table (<span class="xp-term" data-term="open addressing">open addressing</span>)</span>
             <div class="intern-hash-grid" id="hash-grid"></div>
           </div>
         </div>
@@ -123,7 +145,7 @@
       <!-- E. Cardinality Impact -->
       <section class="xp-section" id="cardinality-section">
         <h2>⑥ Cardinality Impact</h2>
-        <p>Memory grows differently for naive vs interned as the number of unique strings changes.</p>
+        <p>Memory grows differently for naive vs interned as <span class="xp-term" data-term="cardinality">cardinality</span> (the number of unique strings) changes.</p>
         <div class="xp-card">
           <canvas id="cardinality-canvas" width="900" height="300" style="width:100%;height:280px;"></canvas>
           <div class="intern-chart-legend" id="cardinality-legend"></div>

--- a/site/tsdb-engine/learn/string-interning/index.html
+++ b/site/tsdb-engine/learn/string-interning/index.html
@@ -132,8 +132,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/string-interning/index.html
+++ b/site/tsdb-engine/learn/string-interning/index.html
@@ -61,7 +61,7 @@
         <div class="intern-split">
           <div class="xp-card intern-panel" id="naive-panel">
             <h3>Naive Storage</h3>
-            <div class="intern-panel-body" id="naive-body"></div>
+            <div class="intern-panel-body xp-scroll-y" id="naive-body"></div>
             <div class="intern-panel-footer" id="naive-footer"></div>
           </div>
           <div class="xp-card intern-panel" id="interned-panel">
@@ -72,11 +72,11 @@
             </div>
             <div class="intern-id-table-wrap">
               <span class="xp-label">ID Table</span>
-              <div class="intern-id-table" id="id-table"></div>
+              <div class="intern-id-table xp-scroll-y" id="id-table"></div>
             </div>
             <div class="intern-refs-wrap">
               <span class="xp-label">Series References</span>
-              <div class="intern-panel-body" id="interned-body"></div>
+              <div class="intern-panel-body xp-scroll-y" id="interned-body"></div>
             </div>
             <div class="intern-panel-footer" id="interned-footer"></div>
           </div>

--- a/site/tsdb-engine/learn/string-interning/intern-experience.css
+++ b/site/tsdb-engine/learn/string-interning/intern-experience.css
@@ -64,19 +64,6 @@
   min-height: 0;
 }
 
-.intern-panel-body::-webkit-scrollbar {
-  width: 4px;
-}
-
-.intern-panel-body::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.intern-panel-body::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 2px;
-}
-
 .intern-panel-footer {
   padding-top: 10px;
   border-top: 1px solid var(--xp-border);
@@ -176,15 +163,6 @@
   max-height: 120px;
   overflow-y: auto;
   padding-right: 4px;
-}
-
-.intern-id-table::-webkit-scrollbar {
-  width: 4px;
-}
-
-.intern-id-table::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 2px;
 }
 
 .intern-id-entry {

--- a/site/tsdb-engine/learn/string-interning/intern-experience.js
+++ b/site/tsdb-engine/learn/string-interning/intern-experience.js
@@ -2,7 +2,7 @@
  * String Interning — Interactive Experience
  * Demonstrates how TSDB engines store label strings once and reference them by ID.
  */
-import { $, $$, buildBreadcrumb, buildStat, el, fmt, fmtBytes, Stepper } from "../shared.js";
+import { $, $$, buildBreadcrumb, buildStat, el, fmt, fmtBytes, initGlossary, Stepper } from "../shared.js";
 
 /* ─── Constants ──────────────────────────────────────────────────── */
 
@@ -211,8 +211,8 @@ function renderStats(stats) {
 /* ─── Render: Generator Summary ──────────────────────────────────── */
 
 function renderGenSummary(stats) {
-  $("#gen-summary").textContent =
-    `${fmt(stats.totalSeries)} series × ${Object.keys(LABEL_DEFS).length} labels = ${fmt(stats.totalRefs)} label references`;
+  $("#gen-summary").innerHTML =
+    `${fmt(stats.totalSeries)} <span class="xp-term" data-term="series">series</span> × ${Object.keys(LABEL_DEFS).length} <span class="xp-term" data-term="label">labels</span> = ${fmt(stats.totalRefs)} label references`;
 }
 
 /* ─── Render: Naive Panel ────────────────────────────────────────── */
@@ -508,7 +508,7 @@ function runInternAnimation() {
       }
       case 1: {
         // Step 1: Compute FNV-1a hash
-        let html = '<div class="anim-label">FNV-1a Hash</div>';
+        let html = '<div class="anim-label"><span class="xp-term" data-term="FNV-1a">FNV-1a</span> Hash</div>';
         html += '<div class="intern-char-grid">';
         for (let i = 0; i < str.length; i++) {
           html += `<span class="intern-char-cell active">${escHtml(str[i])}</span>`;
@@ -533,7 +533,7 @@ function runInternAnimation() {
       }
       case 3: {
         // Step 3: Probe
-        let html = '<div class="anim-label">Linear Probe</div>';
+        let html = '<div class="anim-label"><span class="xp-term" data-term="linear probing">Linear Probe</span></div>';
         if (probeSteps.length === 0 && isNew) {
           html += `<div>Bucket <span class="anim-highlight">${bucketIdx}</span> is <span class="anim-highlight">empty</span> — no collision!</div>`;
           const cell = $(`.intern-hash-cell[data-idx="${bucketIdx}"]`, $("#hash-grid"));
@@ -818,6 +818,8 @@ function init() {
 
   // Resize handler for canvas
   window.addEventListener("resize", () => renderCardinalityChart());
+
+  initGlossary();
 }
 
 document.addEventListener("DOMContentLoaded", init);

--- a/site/tsdb-engine/learn/string-interning/intern-experience.js
+++ b/site/tsdb-engine/learn/string-interning/intern-experience.js
@@ -2,7 +2,7 @@
  * String Interning — Interactive Experience
  * Demonstrates how TSDB engines store label strings once and reference them by ID.
  */
-import { $, $$, buildBreadcrumb, el, fmt, fmtBytes, Stepper } from "../shared.js";
+import { $, $$, buildBreadcrumb, buildStat, el, fmt, fmtBytes, Stepper } from "../shared.js";
 
 /* ─── Constants ──────────────────────────────────────────────────── */
 
@@ -204,14 +204,7 @@ function renderStats(stats) {
     ["Savings", `${stats.ratio.toFixed(1)}×`, ""],
   ];
   for (const [label, value, unit] of items) {
-    row.appendChild(
-      el(
-        "div",
-        { class: "xp-stat" },
-        el("span", { class: "xp-stat-label" }, label),
-        el("span", { class: "xp-stat-value" }, value, el("span", { class: "xp-stat-unit" }, unit))
-      )
-    );
+    row.appendChild(buildStat(label, value, unit));
   }
 }
 

--- a/site/tsdb-engine/learn/xor-delta/index.html
+++ b/site/tsdb-engine/learn/xor-delta/index.html
@@ -51,7 +51,7 @@
         <h2>③ XOR Visualization Table</h2>
         <p>Each row shows a value XOR'd with its predecessor. Click any row to expand bit-level detail.</p>
         <div class="xp-card xor-table-wrap">
-          <div class="xor-table-scroll">
+          <div class="xor-table-scroll xp-scroll-x">
             <table class="xp-table xor-table" id="xor-table">
               <thead>
                 <tr>
@@ -85,7 +85,7 @@
         <h2>⑤ Compression Summary</h2>
         <div class="xp-stats-row" id="summary-stats"></div>
         <div class="xor-encoding-bar" id="encoding-bar"></div>
-        <div class="xor-story" id="compression-story"></div>
+        <div class="xor-story xp-story" id="compression-story"></div>
       </section>
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">

--- a/site/tsdb-engine/learn/xor-delta/index.html
+++ b/site/tsdb-engine/learn/xor-delta/index.html
@@ -23,9 +23,21 @@
         <h1>XOR‑Delta</h1>
         <p class="lede">
           Metrics that change slowly — temperature, CPU&nbsp;%, latency — produce nearly
-          identical IEEE&nbsp;754 bit patterns. XOR‑Delta exploits this: XOR consecutive
+          identical <span class="xp-term" data-term="IEEE 754">IEEE&nbsp;754</span> bit patterns.
+          XOR‑Delta exploits this: <span class="xp-term" data-term="XOR">XOR</span> consecutive
           values, and most bits cancel out. The remaining handful of
-          <strong>meaningful bits</strong> is all you need to store.
+          <strong><span class="xp-term" data-term="meaningful bits">meaningful bits</span></strong>
+          is all you need to store.
+        </p>
+        <p class="xp-why-matters">
+          Two consecutive CPU readings like 50.0 and 51.0 are stored as 64-bit floats — but they
+          share 57 of their 64 bits. <span class="xp-term" data-term="XOR">XOR</span>-Delta stores
+          only the 7 bits that differ, plus a tiny header describing where those bits live. Most
+          metric sequences compress to 2–14 bits per sample instead of 64.
+        </p>
+        <p class="xp-why-matters">
+          The very first value is always stored as raw 64 bits. Compression applies from the second
+          value onward.
         </p>
       </div>
 
@@ -39,16 +51,10 @@
         </div>
       </section>
 
-      <!-- D. Encoding Decision Tree -->
-      <section class="xp-section" id="tree-section">
-        <h2>② Encoding Decision Tree</h2>
-        <p>Every value follows this flowchart. Click a table row below to highlight the path taken.</p>
-        <div class="xp-card" id="decision-tree"></div>
-      </section>
-
       <!-- B. XOR Visualization Table -->
       <section class="xp-section" id="table-section">
-        <h2>③ XOR Visualization Table</h2>
+        <h2>② XOR Visualization Table</h2>
+        <p>For each value after the first, <span class="xp-term" data-term="XOR">XOR</span> it with the previous value to get only the bits that changed:</p>
         <p>Each row shows a value XOR'd with its predecessor. Click any row to expand bit-level detail.</p>
         <div class="xp-card xor-table-wrap">
           <div class="xor-table-scroll xp-scroll-x">
@@ -58,9 +64,9 @@
                   <th>#</th>
                   <th>Value</th>
                   <th>XOR with prev</th>
-                  <th>Lead 0s</th>
-                  <th>Trail 0s</th>
-                  <th>Meaningful</th>
+                  <th><span class="xp-term" data-term="leading zeros">Lead 0s</span></th>
+                  <th><span class="xp-term" data-term="trailing zeros">Trail 0s</span></th>
+                  <th><span class="xp-term" data-term="meaningful bits">Meaningful</span></th>
                   <th>Encoding</th>
                   <th>Cost</th>
                 </tr>
@@ -69,6 +75,14 @@
             </table>
           </div>
         </div>
+      </section>
+
+      <!-- D. Encoding Decision Tree -->
+      <section class="xp-section" id="tree-section">
+        <h2>③ Encoding Decision Tree</h2>
+        <p>Based on the <span class="xp-term" data-term="XOR">XOR</span> result, the encoder picks the most efficient encoding:</p>
+        <p>Every value follows this flowchart. Click a table row above to highlight the path taken.</p>
+        <div class="xp-card" id="decision-tree"></div>
       </section>
 
       <!-- E. Compression Cost Profile -->

--- a/site/tsdb-engine/learn/xor-delta/index.html
+++ b/site/tsdb-engine/learn/xor-delta/index.html
@@ -90,8 +90,8 @@
 
       <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--xp-border); text-align: center;">
         <p style="font-size: 13px; color: var(--xp-text-dim);">
-          Part of <a href="/o11ykit/" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
-          · <a href="/o11ykit/tsdb-engine/learn/" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
+          Part of <a href="../../../" style="color: var(--xp-accent); text-decoration: none;">o11ykit</a>
+          · <a href="../" style="color: var(--xp-text-muted); text-decoration: none;">← Back to Learn</a>
         </p>
       </footer>
 

--- a/site/tsdb-engine/learn/xor-delta/xor-experience.css
+++ b/site/tsdb-engine/learn/xor-delta/xor-experience.css
@@ -16,17 +16,6 @@
 
 .xor-table-scroll {
   overflow-x: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--xp-border-strong) transparent;
-}
-
-.xor-table-scroll::-webkit-scrollbar {
-  height: 6px;
-}
-
-.xor-table-scroll::-webkit-scrollbar-thumb {
-  background: var(--xp-border-strong);
-  border-radius: 3px;
 }
 
 .xor-table {
@@ -117,13 +106,8 @@
 }
 
 /* ─── Encoding Badges ─────────────────────────────────────────────── */
+/* Encoding badge — base from .xp-badge in shared.css */
 .xor-enc-badge {
-  display: inline-block;
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 10px;
-  font-weight: 600;
-  font-family: var(--xp-mono);
   letter-spacing: 0.02em;
 }
 
@@ -485,16 +469,7 @@
 }
 
 /* ─── Story Box ───────────────────────────────────────────────────── */
-.xor-story {
-  margin-top: 16px;
-  padding: 16px 20px;
-  background: var(--xp-surface);
-  border: 1px solid var(--xp-border);
-  border-radius: var(--xp-radius-sm);
-  font-size: 14px;
-  line-height: 1.6;
-  color: var(--xp-text-muted);
-}
+/* base from .xp-story in shared.css */
 
 .xor-story strong {
   color: var(--xp-text);

--- a/site/tsdb-engine/learn/xor-delta/xor-experience.js
+++ b/site/tsdb-engine/learn/xor-delta/xor-experience.js
@@ -18,6 +18,7 @@ import {
   float64ToBits,
   fmt,
   fmtBytes,
+  initGlossary,
 } from "../shared.js";
 
 /* ─── Constants ───────────────────────────────────────────────────── */
@@ -300,7 +301,7 @@ function renderDecisionTree() {
     <div class="dt-flow">
       <div class="dt-row">
         <div class="${nc("xor-q")}">
-          <span class="dt-label">XOR = 0 ?</span>
+          <span class="dt-label"><span class="xp-term" data-term="XOR">XOR</span> = 0 ?</span>
         </div>
         <div class="${ac("xor-yes")}">
           <span class="dt-lbl dt-lbl-yes">yes</span>
@@ -318,7 +319,7 @@ function renderDecisionTree() {
 
       <div class="dt-row">
         <div class="${nc("window-q")}">
-          <span class="dt-label">Window fits ?</span>
+          <span class="dt-label"><span class="xp-term" data-term="window">Window</span> fits ?</span>
           <span class="dt-cost">lead ≥ prev_lead &amp;&amp; trail ≥ prev_trail</span>
         </div>
         <div class="${ac("win-yes")}">
@@ -326,7 +327,7 @@ function renderDecisionTree() {
           <span class="dt-arrow-line">→</span>
         </div>
         <div class="${nc("reuse")}">
-          <span class="dt-label">Write "<code>10</code>" + meaningful</span>
+          <span class="dt-label">Write "<code>10</code>" + <span class="xp-term" data-term="meaningful bits">meaningful</span></span>
           <span class="dt-cost">2 + M bits${isReuse ? costNote : ""}</span>
         </div>
       </div>
@@ -337,7 +338,7 @@ function renderDecisionTree() {
 
       <div class="dt-row">
         <div class="${nc("new")}">
-          <span class="dt-label">Write "<code>11</code>" + 6‑bit lead + 6‑bit len + meaningful</span>
+          <span class="dt-label">Write "<code>11</code>" + 6‑bit lead + 6‑bit len + <span class="xp-term" data-term="meaningful bits">meaningful</span></span>
           <span class="dt-cost">14 + M bits${isNew ? costNote : ""}</span>
         </div>
       </div>
@@ -447,6 +448,14 @@ function buildFirstValueDetail(row) {
   const panel = el("div", { class: "xor-detail-panel xp-animate-in" });
   panel.appendChild(el("h3", {}, `Value #${row.idx}: ${row.value} — stored as raw 64 bits`));
   panel.appendChild(buildBitGrid(row.bits, { label: "IEEE 754 bits" }));
+  const ieee754Note = el(
+    "p",
+    { class: "xor-ieee-note" },
+    `Each float64 is: 1 sign bit + 11 exponent bits + 52 fraction bits (`,
+    el("span", { class: "xp-term", "data-term": "IEEE 754" }, "IEEE 754"),
+    `)`
+  );
+  panel.appendChild(ieee754Note);
 
   const encSection = el("div", { class: "xor-encoded-section" });
   encSection.appendChild(el("div", { class: "xor-bitgrid-label" }, "Encoded output"));
@@ -508,9 +517,9 @@ function buildDetailPanel(row) {
   if (row.encoding === "identical") {
     encGrid.appendChild(el("span", { class: "xor-enc-bit enc-ctrl" }, "0"));
     encSection.appendChild(encGrid);
-    encSection.appendChild(
-      el("div", { class: "xor-enc-annotation" }, '"0" → values are identical. Total: 1 bit.')
-    );
+    const ann = el("div", { class: "xor-enc-annotation" });
+    ann.innerHTML = `"0" → values are identical. Total: 1 bit.`;
+    encSection.appendChild(ann);
   } else if (row.encoding === "reuse") {
     // Control: "10"
     encGrid.appendChild(el("span", { class: "xor-enc-bit enc-ctrl" }, "1"));
@@ -523,13 +532,11 @@ function buildDetailPanel(row) {
       encGrid.appendChild(el("span", { class: "xor-enc-bit enc-data" }, row.xorBits[i]));
     }
     encSection.appendChild(encGrid);
-    encSection.appendChild(
-      el(
-        "div",
-        { class: "xor-enc-annotation" },
-        `"1" (not identical) + "0" (reuse window) + ${row.windowMeaningful} bits in window [${wl}…${63 - wt}] = ${row.cost} bits total`
-      )
-    );
+    const ann = el("div", { class: "xor-enc-annotation" });
+    ann.innerHTML =
+      `"1" (not identical) + "0" (reuse <span class="xp-term" data-term="window">window</span>) + ` +
+      `${row.windowMeaningful} bits in <span class="xp-term" data-term="window">window</span> [${wl}…${63 - wt}] = ${row.cost} bits total`;
+    encSection.appendChild(ann);
 
     // Legend
     const legend = el("div", { class: "xor-enc-legend" });
@@ -560,13 +567,13 @@ function buildDetailPanel(row) {
       encGrid.appendChild(el("span", { class: "xor-enc-bit enc-data" }, row.xorBits[i]));
     }
     encSection.appendChild(encGrid);
-    encSection.appendChild(
-      el(
-        "div",
-        { class: "xor-enc-annotation" },
-        `"11" (new window) + ${lzBin} (leading=${row.leadingZeros}) + ${mlBin} (meaningful=${row.meaningfulBits}) + ${row.meaningfulBits} data bits = ${row.cost} bits total`
-      )
-    );
+    const ann = el("div", { class: "xor-enc-annotation" });
+    ann.innerHTML =
+      `"11" (new <span class="xp-term" data-term="window">window</span>) + ` +
+      `${lzBin} (<span class="xp-term" data-term="leading zeros">leading</span>=${row.leadingZeros}) + ` +
+      `${mlBin} (<span class="xp-term" data-term="meaningful bits">meaningful</span>=${row.meaningfulBits}) + ` +
+      `${row.meaningfulBits} data bits = ${row.cost} bits total`;
+    encSection.appendChild(ann);
 
     // Legend
     const legend = el("div", { class: "xor-enc-legend" });
@@ -844,17 +851,17 @@ function renderSummary() {
     story.innerHTML =
       `<strong>${patternName}</strong> achieves <strong class="success">${ratio.toFixed(1)}× compression</strong>. ` +
       `${identPct}% of values are identical to their predecessor (1 bit each), ` +
-      `${reusePct}% reuse the previous bit window. ` +
+      `${reusePct}% reuse the previous bit <span class="xp-term" data-term="window">window</span>. ` +
       `Average cost: just <strong class="success">${avgBits.toFixed(1)} bits/value</strong> vs 64 bits raw.`;
   } else if (ratio >= 3) {
     story.innerHTML =
       `<strong>${patternName}</strong> compresses to <strong>${ratio.toFixed(1)}×</strong>. ` +
-      `${identPct}% identical, ${reusePct}% window reuse. ` +
+      `${identPct}% identical, ${reusePct}% <span class="xp-term" data-term="window">window</span> reuse. ` +
       `The changing values still share many bits, averaging <strong>${avgBits.toFixed(1)} bits/value</strong>.`;
   } else {
     story.innerHTML =
       `<strong>${patternName}</strong> compresses poorly at <strong class="warn">${ratio.toFixed(1)}×</strong>. ` +
-      `Random values share few bits, so XOR results have many meaningful bits. ` +
+      `Random values share few bits, so <span class="xp-term" data-term="XOR">XOR</span> results have many <span class="xp-term" data-term="meaningful bits">meaningful bits</span>. ` +
       `Average cost: <strong class="warn">${avgBits.toFixed(1)} bits/value</strong> — close to raw.`;
   }
 }
@@ -879,6 +886,7 @@ function init() {
   $("#breadcrumb-nav").innerHTML = buildBreadcrumb("XOR\u2011Delta");
   renderPatternPicker();
   recompute();
+  initGlossary();
 
   let resizeTimer;
   window.addEventListener("resize", () => {

--- a/site/tsdb-engine/learn/xor-delta/xor-experience.js
+++ b/site/tsdb-engine/learn/xor-delta/xor-experience.js
@@ -10,6 +10,7 @@ import {
   $,
   $$,
   buildBreadcrumb,
+  buildStat,
   clz64,
   ctz64,
   drawSparkline,
@@ -648,7 +649,7 @@ function renderTable() {
     // Encoding badge
     const badge = el(
       "span",
-      { class: `xor-enc-badge enc-${row.encoding}` },
+      { class: `xp-badge xor-enc-badge enc-${row.encoding}` },
       ENC_LABELS[row.encoding]
     );
     tr.appendChild(el("td", {}, badge));
@@ -780,13 +781,7 @@ function renderSummary() {
   ];
 
   for (const s of stats) {
-    const stat = el(
-      "div",
-      { class: "xp-stat" },
-      el("div", { class: "xp-stat-label" }, s.label),
-      el("div", { class: "xp-stat-value" }, s.value),
-      el("div", { class: "xp-stat-unit" }, s.unit)
-    );
+    const stat = buildStat(s.label, s.value, s.unit);
     if (s.label === "Ratio") {
       const valEl = stat.querySelector(".xp-stat-value");
       valEl.style.color =


### PR DESCRIPTION
Makes all 6 Learn experiences accessible to people without prior TSDB knowledge.

## Glossary Tooltip System ("Kindle underlines")
- 38 technical term definitions in `shared.js`
- Hover or click any dotted-underline term to see a definition card
- Works across all pages; pages just wrap terms in `<span class="xp-term" data-term="chunk">chunk</span>`
- Terms covered: chunk, series, sample, label, postings, XOR, IEEE 754, bit-packing, quantize, zigzag, FNV-1a, cardinality, frame-of-reference, and more

## Hub Page
- Difficulty badges: 3 Beginner, 3 Intermediate  
- "Start Here" recommendation callout pointing to String Interning + Chunk Stats
- Card descriptions rewritten in plain English (no more "postings intersection", "step-aligned bucketing", etc.)

## Per-Experience Improvements
- **ALP**: Step 0 orientation card naming all 5 stages; pipeline subtitles; `f64` → "8-byte float"
- **Delta-of-Delta**: "1M timestamps = 8 MB raw vs 125 KB" motivating stat; 4-step encoding chain explanation before the table; column header tooltips
- **XOR-Delta**: "50.0 and 51.0 share 57 of 64 bits" intro; sections 2 & 3 swapped (XOR table now comes before decision tree it references); IEEE 754 field note
- **String Interning**: "interning" defined in hero; series+label primer card; hash table primer before animation
- **Chunk Stats**: min/max/sum/count explained; Skip Logic section now hidden until after first query run
- **Query Engine**: data model primer; postings index explanation; plain-English subtitles on all 6 pipeline stages