### PR TITLE
fix: absorb PR #94 — lint cleanup, chart fix, package-lock update

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,8 @@
       "!**/.site",
       "!**/playwright-report",
       "!**/test-results",
-      "!octo11y"
+      "!octo11y",
+      "!packages/o11ytsdb/bench"
     ]
   },
   "formatter": {
@@ -31,5 +32,17 @@
       "semicolons": "always",
       "trailingCommas": "es5"
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["site/tsdb-engine/js/byte-explorer.js"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noInnerDeclarations": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/octo11y/package-lock.json
+++ b/octo11y/package-lock.json
@@ -76,7 +76,9 @@
       "version": "0.2.0",
       "dependencies": {
         "@actions/core": "^1.11.0",
+        "@actions/exec": "^1.1.1",
         "@actions/tool-cache": "^2.0.1",
+        "@benchkit/actions-common": "*",
         "@benchkit/format": "*"
       }
     },
@@ -5184,7 +5186,7 @@
     },
     "packages/adapters": {
       "name": "@benchkit/adapters",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@benchkit/format": "*",
@@ -5201,7 +5203,7 @@
     },
     "packages/chart": {
       "name": "@benchkit/chart",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@benchkit/format": "*",
@@ -5219,7 +5221,7 @@
     },
     "packages/core": {
       "name": "@octo11y/core",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT"
     },
     "packages/dashboard": {
@@ -5240,7 +5242,7 @@
     },
     "packages/format": {
       "name": "@benchkit/format",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@octo11y/core": "*"

--- a/octo11y/packages/chart/src/labels.ts
+++ b/octo11y/packages/chart/src/labels.ts
@@ -40,9 +40,10 @@ export function isMonitorMetric(metric: string): boolean {
 }
 
 export function defaultMonitorMetricLabel(metric: string): string {
-  const raw = metric
-    .replace(new RegExp(`^${SERIES_MONITOR_PREFIX.replace("/", "\\/")}`), "")
-    .replace(new RegExp(`^${MONITOR_METRIC_PREFIX.replace(".", "\\.")}`), "");
+  let raw = metric.startsWith(SERIES_MONITOR_PREFIX)
+    ? metric.slice(SERIES_MONITOR_PREFIX.length)
+    : metric;
+  raw = raw.startsWith(MONITOR_METRIC_PREFIX) ? raw.slice(MONITOR_METRIC_PREFIX.length) : raw;
   if (MONITOR_METRIC_LABELS[raw]) {
     return MONITOR_METRIC_LABELS[raw];
   }

--- a/octo11y/packages/chart/src/labels.ts
+++ b/octo11y/packages/chart/src/labels.ts
@@ -1,5 +1,8 @@
 import { MONITOR_METRIC_PREFIX } from "@benchkit/format";
 
+/** Prefix used in aggregated series files (after the aggregate action normalises OTLP names). */
+const SERIES_MONITOR_PREFIX = "_monitor/";
+
 const MONITOR_METRIC_LABELS: Record<string, string> = {
   cpu_system_ms: "CPU system time (ms)",
   cpu_system_pct: "CPU system %",
@@ -21,7 +24,7 @@ function titleCase(input: string): string {
 }
 
 export function defaultMetricLabel(metric: string): string {
-  if (metric.startsWith(MONITOR_METRIC_PREFIX)) {
+  if (metric.startsWith(SERIES_MONITOR_PREFIX) || metric.startsWith(MONITOR_METRIC_PREFIX)) {
     return defaultMonitorMetricLabel(metric);
   }
 
@@ -30,13 +33,16 @@ export function defaultMetricLabel(metric: string): string {
     .replace(/_/g, " ");
 }
 
-/** Returns true when the metric name belongs to the monitor action's output. */
+/** Returns true when the metric name belongs to the monitor action's output.
+ *  Handles both the raw OTLP format (`_monitor.`) and the aggregated series format (`_monitor/`). */
 export function isMonitorMetric(metric: string): boolean {
-  return metric.startsWith(MONITOR_METRIC_PREFIX);
+  return metric.startsWith(SERIES_MONITOR_PREFIX) || metric.startsWith(MONITOR_METRIC_PREFIX);
 }
 
 export function defaultMonitorMetricLabel(metric: string): string {
-  const raw = metric.replace(new RegExp(`^${MONITOR_METRIC_PREFIX.replace(".", "\\.")}`), "");
+  const raw = metric
+    .replace(new RegExp(`^${SERIES_MONITOR_PREFIX.replace("/", "\\/")}`), "")
+    .replace(new RegExp(`^${MONITOR_METRIC_PREFIX.replace(".", "\\.")}`), "");
   if (MONITOR_METRIC_LABELS[raw]) {
     return MONITOR_METRIC_LABELS[raw];
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7872,27 +7872,6 @@
         "node": ">=22.0.0"
       }
     },
-    "packages/adapters/node_modules/@otlpkit/otlpjson": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@otlpkit/otlpjson/-/otlpjson-0.1.0.tgz",
-      "integrity": "sha512-by7zPm+QMmhilnhQoCZ7vJvvt0qLBG3mElcMb90j0KLsYP8C15Xls6Yyt1IsYpZaBctPj4Zs5hxgyVeSBqVxBA==",
-      "license": "UNLICENSED",
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "packages/adapters/node_modules/@otlpkit/query": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@otlpkit/query/-/query-0.1.0.tgz",
-      "integrity": "sha512-ehtAr7ZSN6lLI89g7QOHybIwPmhiFzc0rgcXasEW0PQXRPa0JcskM5m5U0NL3vwh2q6ezRFjAQdkL4C0EHHVgw==",
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@otlpkit/otlpjson": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
     "packages/o11ytsdb": {
       "version": "0.0.1",
       "license": "UNLICENSED",
@@ -7927,15 +7906,6 @@
       "dependencies": {
         "@otlpkit/otlpjson": "^0.2.3"
       },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "packages/query/node_modules/@otlpkit/otlpjson": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@otlpkit/otlpjson/-/otlpjson-0.1.0.tgz",
-      "integrity": "sha512-by7zPm+QMmhilnhQoCZ7vJvvt0qLBG3mElcMb90j0KLsYP8C15Xls6Yyt1IsYpZaBctPj4Zs5hxgyVeSBqVxBA==",
-      "license": "UNLICENSED",
       "engines": {
         "node": ">=22.0.0"
       }

--- a/packages/o11ytsdb/bench/ab-stepagg.mjs
+++ b/packages/o11ytsdb/bench/ab-stepagg.mjs
@@ -10,7 +10,7 @@ const PER_SERIES = Math.ceil(N / SERIES);
 const T0 = 1700000000000n;
 const INTERVAL = 15000n;
 const STEP = 60000n;
-const STEP_N = 60000;
+const _STEP_N = 60000;
 
 // Build ranges (simulate 30 series)
 const ranges = [];
@@ -31,8 +31,7 @@ function stepAggOriginal(ranges, step) {
   for (const r of ranges) {
     if (r.timestamps.length === 0) continue;
     if (r.timestamps[0] < minT) minT = r.timestamps[0];
-    if (r.timestamps[r.timestamps.length - 1] > maxT)
-      maxT = r.timestamps[r.timestamps.length - 1];
+    if (r.timestamps[r.timestamps.length - 1] > maxT) maxT = r.timestamps[r.timestamps.length - 1];
   }
   const bucketCount = Number((maxT - minT) / step) + 1;
   const values = new Float64Array(bucketCount);
@@ -68,8 +67,7 @@ function stepAggDataView(ranges, step) {
   for (const r of ranges) {
     if (r.timestamps.length === 0) continue;
     if (r.timestamps[0] < minT) minT = r.timestamps[0];
-    if (r.timestamps[r.timestamps.length - 1] > maxT)
-      maxT = r.timestamps[r.timestamps.length - 1];
+    if (r.timestamps[r.timestamps.length - 1] > maxT) maxT = r.timestamps[r.timestamps.length - 1];
   }
   const bucketCount = Number((maxT - minT) / step) + 1;
   const values = new Float64Array(bucketCount);
@@ -87,7 +85,7 @@ function stepAggDataView(ranges, step) {
     const ts = tsNum[ri];
     const vs = ranges[ri].values;
     for (let i = 0, len = ts.length; i < len; i++) {
-      const bucket = (ts[i] - minTN) / stepN | 0;
+      const bucket = ((ts[i] - minTN) / stepN) | 0;
       if (vs[i] < values[bucket]) values[bucket] = vs[i];
     }
   }
@@ -105,16 +103,22 @@ function bench(name, fn, warmup = 3, runs = 7) {
     times.push(performance.now() - t0);
   }
   times.sort((a, b) => a - b);
-  console.log(`  ${name.padEnd(30)} min=${times[0].toFixed(1)}ms  med=${times[3].toFixed(1)}ms  max=${times[6].toFixed(1)}ms`);
+  console.log(
+    `  ${name.padEnd(30)} min=${times[0].toFixed(1)}ms  med=${times[3].toFixed(1)}ms  max=${times[6].toFixed(1)}ms`
+  );
   return times[3]; // median
 }
 
-console.log(`  ${SERIES} series × ${PER_SERIES.toLocaleString()} pts = ${(SERIES * PER_SERIES).toLocaleString()} samples\n`);
+console.log(
+  `  ${SERIES} series × ${PER_SERIES.toLocaleString()} pts = ${(SERIES * PER_SERIES).toLocaleString()} samples\n`
+);
 
 const medOrig = bench("Original (BigInt)", () => stepAggOriginal(ranges, STEP));
 const medNew = bench("DataView + Number", () => stepAggDataView(ranges, STEP));
 
-console.log(`\n  Speedup: ${(medOrig / medNew).toFixed(2)}x  (${(medOrig - medNew).toFixed(1)}ms saved)`);
+console.log(
+  `\n  Speedup: ${(medOrig / medNew).toFixed(2)}x  (${(medOrig - medNew).toFixed(1)}ms saved)`
+);
 
 // Verify correctness
 const a = stepAggOriginal(ranges, STEP);
@@ -124,4 +128,6 @@ for (let i = 0; i < a.length; i++) {
   const err = Math.abs(a[i] - b[i]);
   if (err > maxErr) maxErr = err;
 }
-console.log(`  Max error: ${maxErr} (${maxErr === 0 ? 'EXACT MATCH ✓' : maxErr < 1e-10 ? 'negligible ✓' : 'MISMATCH ✗'})`);
+console.log(
+  `  Max error: ${maxErr} (${maxErr === 0 ? "EXACT MATCH ✓" : maxErr < 1e-10 ? "negligible ✓" : "MISMATCH ✗"})`
+);

--- a/packages/o11ytsdb/bench/alp-test.mjs
+++ b/packages/o11ytsdb/bench/alp-test.mjs
@@ -4,7 +4,7 @@
  * Tests round-trip correctness and compression ratio across data patterns.
  */
 import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { deflateRawSync, inflateRawSync } from "node:zlib";
 
@@ -18,10 +18,10 @@ const mem = () => new Uint8Array(w.memory.buffer);
 
 const CHUNK = 128;
 const patterns = [
-  ["constant", (i) => 42.0],
+  ["constant", (_i) => 42.0],
   ["counter", (i) => i * 1.0],
   ["sine", (i) => Math.sin(i * 0.01) * 100],
-  ["random", (i) => Math.random() * 1000],
+  ["random", (_i) => Math.random() * 1000],
   ["step", (i) => Math.floor(i / 100) * 10.0],
   ["pct", (i) => 45.2 + Math.sin(i * 0.1) * 5],
   ["latency_ms", (i) => 12.5 + i * 0.001],
@@ -85,10 +85,8 @@ function verify(original, decoded) {
 }
 
 console.log("\n  Codec comparison (chunk=128, deflate level=1)\n");
-console.log(
-  "  Pattern       raw(B/pt) XOR    ALP    XOR+df ALP+df  Best"
-);
-console.log("  " + "─".repeat(65));
+console.log("  Pattern       raw(B/pt) XOR    ALP    XOR+df ALP+df  Best");
+console.log(`  ${"─".repeat(65)}`);
 
 let allOk = true;
 for (const [name, fn] of patterns) {
@@ -116,11 +114,11 @@ for (const [name, fn] of patterns) {
 
   console.log(
     `  ${name.padEnd(13)} ${(rawBytes / CHUNK).toFixed(1).padStart(8)}  ` +
-    `${(xorBuf.length / CHUNK).toFixed(2).padStart(5)}  ` +
-    `${(alpBuf.length / CHUNK).toFixed(2).padStart(5)}  ` +
-    `${(xorDefBuf.length / CHUNK).toFixed(2).padStart(5)}  ` +
-    `${(alpDefBuf.length / CHUNK).toFixed(2).padStart(5)}  ` +
-    `${ok ? "" : "✗ "}${bestName}`
+      `${(xorBuf.length / CHUNK).toFixed(2).padStart(5)}  ` +
+      `${(alpBuf.length / CHUNK).toFixed(2).padStart(5)}  ` +
+      `${(xorDefBuf.length / CHUNK).toFixed(2).padStart(5)}  ` +
+      `${(alpDefBuf.length / CHUNK).toFixed(2).padStart(5)}  ` +
+      `${ok ? "" : "✗ "}${bestName}`
   );
 }
 

--- a/packages/o11ytsdb/bench/competitive.bench.ts
+++ b/packages/o11ytsdb/bench/competitive.bench.ts
@@ -17,19 +17,25 @@
  * where does our specialized codec sit?"
  */
 
-import { Suite, printReport, fmtBytes, fmt } from './harness.js';
-import type { BenchReport } from './harness.js';
-import { allGenerators } from './vectors.js';
-import type { ChunkData } from './vectors.js';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { gzipSync, gunzipSync, brotliCompressSync, brotliDecompressSync, constants as zlibConstants } from 'node:zlib';
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  brotliCompressSync,
+  brotliDecompressSync,
+  gunzipSync,
+  gzipSync,
+  constants as zlibConstants,
+} from "node:zlib";
+import type { BenchReport } from "./harness.js";
+import { printReport, Suite } from "./harness.js";
+import type { ChunkData } from "./vectors.js";
+import { allGenerators } from "./vectors.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ── Load our codec ───────────────────────────────────────────────────
 
-const codecPath = join(__dirname, '..', '..', 'dist', 'codec.js');
+const codecPath = join(__dirname, "..", "..", "dist", "codec.js");
 const { encodeChunk, decodeChunk } = await import(codecPath);
 
 // ── Competitor implementations ───────────────────────────────────────
@@ -46,7 +52,10 @@ function rawEncode(data: ChunkData): Uint8Array {
   return new Uint8Array(buf);
 }
 
-function rawDecode(buf: Uint8Array, n: number): { timestamps: BigInt64Array; values: Float64Array } {
+function rawDecode(
+  buf: Uint8Array,
+  n: number
+): { timestamps: BigInt64Array; values: Float64Array } {
   const f64 = new Float64Array(buf.buffer, buf.byteOffset, n * 2);
   const timestamps = new BigInt64Array(n);
   const values = new Float64Array(n);
@@ -60,7 +69,7 @@ function rawDecode(buf: Uint8Array, n: number): { timestamps: BigInt64Array; val
 /** 2. JSON: what people actually do. */
 function jsonEncode(data: ChunkData): Uint8Array {
   const obj = {
-    timestamps: Array.from(data.timestamps, t => Number(t)),
+    timestamps: Array.from(data.timestamps, (t) => Number(t)),
     values: Array.from(data.values),
   };
   return new TextEncoder().encode(JSON.stringify(obj));
@@ -80,7 +89,10 @@ function gzipRawEncode(data: ChunkData): Uint8Array {
   return gzipSync(raw, { level: 6 });
 }
 
-function gzipRawDecode(buf: Uint8Array, n: number): { timestamps: BigInt64Array; values: Float64Array } {
+function gzipRawDecode(
+  buf: Uint8Array,
+  n: number
+): { timestamps: BigInt64Array; values: Float64Array } {
   const raw = gunzipSync(buf);
   return rawDecode(new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength), n);
 }
@@ -93,7 +105,10 @@ function brotliRawEncode(data: ChunkData): Uint8Array {
   });
 }
 
-function brotliRawDecode(buf: Uint8Array, n: number): { timestamps: BigInt64Array; values: Float64Array } {
+function brotliRawDecode(
+  buf: Uint8Array,
+  n: number
+): { timestamps: BigInt64Array; values: Float64Array } {
   const raw = brotliDecompressSync(buf);
   return rawDecode(new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength), n);
 }
@@ -142,32 +157,52 @@ interface Competitor {
 }
 
 const competitors: Competitor[] = [
-  { name: 'raw', encode: rawEncode, decode: rawDecode, needsCount: true },
-  { name: 'json', encode: jsonEncode, decode: (buf) => jsonDecode(buf), needsCount: false },
-  { name: 'gzip-raw', encode: gzipRawEncode, decode: (buf, n) => gzipRawDecode(buf, n), needsCount: true },
-  { name: 'brotli-raw', encode: brotliRawEncode, decode: (buf, n) => brotliRawDecode(buf, n), needsCount: true },
-  { name: 'xor-delta', encode: xorEncode, decode: (buf) => xorDecode(buf), needsCount: false },
-  { name: 'xor+gzip', encode: xorGzipEncode, decode: (buf) => xorGzipDecode(buf), needsCount: false },
-  { name: 'xor+brotli', encode: xorBrotliEncode, decode: (buf) => xorBrotliDecode(buf), needsCount: false },
+  { name: "raw", encode: rawEncode, decode: rawDecode, needsCount: true },
+  { name: "json", encode: jsonEncode, decode: (buf) => jsonDecode(buf), needsCount: false },
+  {
+    name: "gzip-raw",
+    encode: gzipRawEncode,
+    decode: (buf, n) => gzipRawDecode(buf, n),
+    needsCount: true,
+  },
+  {
+    name: "brotli-raw",
+    encode: brotliRawEncode,
+    decode: (buf, n) => brotliRawDecode(buf, n),
+    needsCount: true,
+  },
+  { name: "xor-delta", encode: xorEncode, decode: (buf) => xorDecode(buf), needsCount: false },
+  {
+    name: "xor+gzip",
+    encode: xorGzipEncode,
+    decode: (buf) => xorGzipDecode(buf),
+    needsCount: false,
+  },
+  {
+    name: "xor+brotli",
+    encode: xorBrotliEncode,
+    decode: (buf) => xorBrotliDecode(buf),
+    needsCount: false,
+  },
 ];
 
 // ── Main ─────────────────────────────────────────────────────────────
 
 export default async function (): Promise<BenchReport> {
-  const suite = new Suite('competitive');
+  const suite = new Suite("competitive");
   const generators = allGenerators(1024);
 
-  console.log('  Competitors:', competitors.map(c => c.name).join(', '));
+  console.log("  Competitors:", competitors.map((c) => c.name).join(", "));
   console.log();
 
   // ── Compression comparison table (custom, not the suite's) ──
-  console.log('  ── Compression comparison ──\n');
+  console.log("  ── Compression comparison ──\n");
 
   // Header.
-  let hdr = '    Vector'.padEnd(24);
+  let hdr = "    Vector".padEnd(24);
   for (const c of competitors) hdr += c.name.padStart(12);
-  console.log(hdr + '  (bytes/point)');
-  console.log('    ' + '─'.repeat(hdr.length - 4 + 16));
+  console.log(`${hdr}  (bytes/point)`);
+  console.log(`    ${"─".repeat(hdr.length - 4 + 16)}`);
 
   for (const gen of generators) {
     let line = `    ${gen.name}`.padEnd(24);
@@ -177,8 +212,11 @@ export default async function (): Promise<BenchReport> {
       line += bpp.toFixed(2).padStart(12);
       // Also register in the suite for JSON output.
       suite.addCompression(
-        gen.name, c.name, gen.timestamps.length,
-        gen.timestamps.length * 16, encoded.length,
+        gen.name,
+        c.name,
+        gen.timestamps.length,
+        gen.timestamps.length * 16,
+        encoded.length
       );
     }
     console.log(line);
@@ -186,10 +224,10 @@ export default async function (): Promise<BenchReport> {
   console.log();
 
   // Ratio table.
-  hdr = '    Vector'.padEnd(24);
+  hdr = "    Vector".padEnd(24);
   for (const c of competitors) hdr += c.name.padStart(12);
-  console.log(hdr + '  (compression ratio)');
-  console.log('    ' + '─'.repeat(hdr.length - 4 + 20));
+  console.log(`${hdr}  (compression ratio)`);
+  console.log(`    ${"─".repeat(hdr.length - 4 + 20)}`);
 
   for (const gen of generators) {
     let line = `    ${gen.name}`.padEnd(24);
@@ -206,14 +244,19 @@ export default async function (): Promise<BenchReport> {
   // ── Encode throughput ──
   for (const c of competitors) {
     for (const gen of generators) {
-      suite.add(`encode_${gen.name}`, c.name, () => {
-        c.encode(gen);
-      }, {
-        unit: 'samples/sec',
-        itemsPerCall: gen.timestamps.length,
-        iterations: 200,
-        warmup: 50,
-      });
+      suite.add(
+        `encode_${gen.name}`,
+        c.name,
+        () => {
+          c.encode(gen);
+        },
+        {
+          unit: "samples/sec",
+          itemsPerCall: gen.timestamps.length,
+          iterations: 200,
+          warmup: 50,
+        }
+      );
     }
   }
 
@@ -222,14 +265,19 @@ export default async function (): Promise<BenchReport> {
     for (const gen of generators) {
       const encoded = c.encode(gen);
       const n = gen.timestamps.length;
-      suite.add(`decode_${gen.name}`, c.name, () => {
-        c.decode(encoded, n);
-      }, {
-        unit: 'samples/sec',
-        itemsPerCall: n,
-        iterations: 200,
-        warmup: 50,
-      });
+      suite.add(
+        `decode_${gen.name}`,
+        c.name,
+        () => {
+          c.decode(encoded, n);
+        },
+        {
+          unit: "samples/sec",
+          itemsPerCall: n,
+          iterations: 200,
+          warmup: 50,
+        }
+      );
     }
   }
 

--- a/packages/o11ytsdb/bench/compress-test.mjs
+++ b/packages/o11ytsdb/bench/compress-test.mjs
@@ -16,13 +16,15 @@
  */
 
 import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
 import {
-  deflateRawSync, inflateRawSync,
-  zstdCompressSync, zstdDecompressSync,
   constants,
+  deflateRawSync,
+  inflateRawSync,
+  zstdCompressSync,
+  zstdDecompressSync,
 } from "node:zlib";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -39,14 +41,21 @@ const NUM_CHUNKS = 200; // 200 chunks of 512 = 102,400 samples per pattern
 let _counterVal = 0;
 let _gaugeVal = 50;
 const PATTERNS = {
-  constant:    (i) => 42.0,
-  counter:     (i) => { _counterVal += 1 + Math.floor(Math.random() * 10); return _counterVal; },
-  gauge_cpu:   (i) => { _gaugeVal += (Math.random() - 0.48) * 5; _gaugeVal = Math.max(0, Math.min(100, _gaugeVal)); return Math.round(_gaugeVal * 100) / 100; },
-  sine:        (i) => Math.sin(i * 0.01) * 100,
-  random:      (i) => Math.random() * 1000,
-  step:        (i) => Math.floor(i / 100) * 10.0,
-  latency_ms:  (i) => Math.round(Math.random() * 500 * 100) / 100,
-  req_rate:    (i) => Math.max(0, 1000 + Math.sin(i * 0.001) * 200 + (Math.random() - 0.5) * 100), // ~1000 rps with daily wave + noise
+  constant: (_i) => 42.0,
+  counter: (_i) => {
+    _counterVal += 1 + Math.floor(Math.random() * 10);
+    return _counterVal;
+  },
+  gauge_cpu: (_i) => {
+    _gaugeVal += (Math.random() - 0.48) * 5;
+    _gaugeVal = Math.max(0, Math.min(100, _gaugeVal));
+    return Math.round(_gaugeVal * 100) / 100;
+  },
+  sine: (i) => Math.sin(i * 0.01) * 100,
+  random: (_i) => Math.random() * 1000,
+  step: (i) => Math.floor(i / 100) * 10.0,
+  latency_ms: (_i) => Math.round(Math.random() * 500 * 100) / 100,
+  req_rate: (i) => Math.max(0, 1000 + Math.sin(i * 0.001) * 200 + (Math.random() - 0.5) * 100), // ~1000 rps with daily wave + noise
 };
 
 // ── WASM loader ──────────────────────────────────────────────────────
@@ -205,7 +214,8 @@ function makeConfigs(wasm) {
     // Raw float64 + secondary (no codec)
     {
       name: "raw+deflate1",
-      encode: (vals) => deflateCompress(Buffer.from(vals.buffer, vals.byteOffset, vals.byteLength), 1),
+      encode: (vals) =>
+        deflateCompress(Buffer.from(vals.buffer, vals.byteOffset, vals.byteLength), 1),
       decode: (buf) => new Float64Array(deflateDecompress(buf).buffer),
       group: 1,
     },
@@ -288,7 +298,10 @@ function concatBufs(bufs) {
   const total = bufs.reduce((s, b) => s + b.length, 0);
   const out = Buffer.alloc(total);
   let off = 0;
-  for (const b of bufs) { out.set(b, off); off += b.length; }
+  for (const b of bufs) {
+    out.set(b, off);
+    off += b.length;
+  }
   return out;
 }
 
@@ -311,7 +324,7 @@ function runConfig(config, rawChunks) {
 
   // Encode all chunks.
   const t0 = performance.now();
-  const encodedChunks = rawChunks.map(c => config.encode(c));
+  const encodedChunks = rawChunks.map((c) => config.encode(c));
   const encodeMs = performance.now() - t0;
 
   let totalCompressedBytes;
@@ -336,7 +349,7 @@ function runConfig(config, rawChunks) {
     const tg0 = performance.now();
     for (let i = 0; i < encodedChunks.length; i += groupSize) {
       const batch = encodedChunks.slice(i, i + groupSize);
-      const sizes = batch.map(b => b.length);
+      const sizes = batch.map((b) => b.length);
       const compressed = config.groupCompress(batch);
       groups.push(compressed);
       groupSizes.push(sizes);
@@ -364,8 +377,8 @@ function runConfig(config, rawChunks) {
     // Return combined.
     return {
       bPerPt: totalCompressedBytes / totalSamples,
-      encodeUs: (encodeMs + groupEncodeMs) / numChunks * 1000,
-      decodeUs: decodeMs / numChunks * 1000,
+      encodeUs: ((encodeMs + groupEncodeMs) / numChunks) * 1000,
+      decodeUs: (decodeMs / numChunks) * 1000,
       totalEncode: encodeMs + groupEncodeMs,
       totalDecode: decodeMs,
       totalBytes: totalCompressedBytes,
@@ -374,8 +387,8 @@ function runConfig(config, rawChunks) {
 
   return {
     bPerPt: totalCompressedBytes / totalSamples,
-    encodeUs: encodeMs / numChunks * 1000,
-    decodeUs: decodeMs / numChunks * 1000,
+    encodeUs: (encodeMs / numChunks) * 1000,
+    decodeUs: (decodeMs / numChunks) * 1000,
     totalEncode: encodeMs,
     totalDecode: decodeMs,
     totalBytes: totalCompressedBytes,
@@ -389,7 +402,9 @@ async function main() {
   const configs = makeConfigs(wasm);
   const patternNames = Object.keys(PATTERNS);
 
-  console.log(`\n  Secondary compression experiment: ${NUM_CHUNKS} chunks × ${CHUNK_SIZE} samples = ${(NUM_CHUNKS * CHUNK_SIZE).toLocaleString()} pts/pattern\n`);
+  console.log(
+    `\n  Secondary compression experiment: ${NUM_CHUNKS} chunks × ${CHUNK_SIZE} samples = ${(NUM_CHUNKS * CHUNK_SIZE).toLocaleString()} pts/pattern\n`
+  );
 
   // Pre-generate all pattern data once for consistency across configs.
   const patternChunks = generateAllPatternChunks(NUM_CHUNKS, CHUNK_SIZE);
@@ -429,15 +444,25 @@ async function main() {
 
   // ── Per-pattern B/pt breakdown for selected configs ──
 
-  const showConfigs = ["ALP only", "ALP+zstd1", "ALP+zstd3", "ALP+zstd1×8", "ALP+zstd3×16", "XOR only", "XOR+zstd1", "raw+zstd3", "raw+zstd3×8"];
+  const showConfigs = [
+    "ALP only",
+    "ALP+zstd1",
+    "ALP+zstd3",
+    "ALP+zstd1×8",
+    "ALP+zstd3×16",
+    "XOR only",
+    "XOR+zstd1",
+    "raw+zstd3",
+    "raw+zstd3×8",
+  ];
 
   console.log(`\n  Per-pattern B/pt (selected configs):\n`);
-  const hdr = "  " + "Pattern".padEnd(12) + showConfigs.map(n => n.padStart(14)).join("");
+  const hdr = `  ${"Pattern".padEnd(12)}${showConfigs.map((n) => n.padStart(14)).join("")}`;
   console.log(hdr);
-  console.log("  " + "─".repeat(12 + showConfigs.length * 14));
+  console.log(`  ${"─".repeat(12 + showConfigs.length * 14)}`);
 
   for (const pname of patternNames) {
-    let line = "  " + pname.padEnd(12);
+    let line = `  ${pname.padEnd(12)}`;
     for (const cname of showConfigs) {
       const r = allResults[cname]?.[pname];
       line += r ? r.bPerPt.toFixed(2).padStart(14) : "N/A".padStart(14);
@@ -448,21 +473,34 @@ async function main() {
   // ── Best overall ──
 
   console.log();
-  let bestBpt = Infinity, bestName = "";
+  let bestBpt = Infinity,
+    bestName = "";
   for (const cfg of configs) {
-    const avg = Object.values(allResults[cfg.name]).reduce((s, r) => s + r.bPerPt, 0) / patternNames.length;
-    if (avg < bestBpt) { bestBpt = avg; bestName = cfg.name; }
+    const avg =
+      Object.values(allResults[cfg.name]).reduce((s, r) => s + r.bPerPt, 0) / patternNames.length;
+    if (avg < bestBpt) {
+      bestBpt = avg;
+      bestName = cfg.name;
+    }
   }
   console.log(`  Best avg compression: ${bestName} → ${bestBpt.toFixed(2)} B/pt`);
 
-  let bestDec = Infinity, bestDecName = "";
+  let bestDec = Infinity,
+    bestDecName = "";
   for (const cfg of configs) {
-    const avg = Object.values(allResults[cfg.name]).reduce((s, r) => s + r.decodeUs, 0) / patternNames.length;
-    if (avg < bestDec) { bestDec = avg; bestDecName = cfg.name; }
+    const avg =
+      Object.values(allResults[cfg.name]).reduce((s, r) => s + r.decodeUs, 0) / patternNames.length;
+    if (avg < bestDec) {
+      bestDec = avg;
+      bestDecName = cfg.name;
+    }
   }
   console.log(`  Fastest decode:       ${bestDecName} → ${bestDec.toFixed(0)} µs/chunk`);
 
   console.log();
 }
 
-main().catch(e => { console.error(e); process.exit(1); });
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/o11ytsdb/bench/delta-alp-test.mjs
+++ b/packages/o11ytsdb/bench/delta-alp-test.mjs
@@ -4,7 +4,7 @@
  * improvement for monotonic counter patterns.
  */
 import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -80,12 +80,20 @@ class Rng {
     const s = this.s;
     const result = Math.imul(this.rotl(Math.imul(s[0], 5), 7), 9) >>> 0;
     const t = s[1] << 9;
-    s[2] ^= s[0]; s[3] ^= s[1]; s[1] ^= s[2]; s[0] ^= s[3];
-    s[2] ^= t; s[3] = this.rotl(s[3], 11);
+    s[2] ^= s[0];
+    s[3] ^= s[1];
+    s[1] ^= s[2];
+    s[0] ^= s[3];
+    s[2] ^= t;
+    s[3] = this.rotl(s[3], 11);
     return result / 0x100000000;
   }
-  rotl(x, k) { return ((x << k) | (x >>> (32 - k))) >>> 0; }
-  int(lo, hi) { return lo + Math.floor(this.next() * (hi - lo + 1)); }
+  rotl(x, k) {
+    return ((x << k) | (x >>> (32 - k))) >>> 0;
+  }
+  int(lo, hi) {
+    return lo + Math.floor(this.next() * (hi - lo + 1));
+  }
 }
 
 // ── Test patterns ──
@@ -97,7 +105,10 @@ const patterns = [
   (() => {
     const vals = new Float64Array(CHUNK);
     let v = 1_000_000;
-    for (let i = 0; i < CHUNK; i++) { v += rng.int(10, 200); vals[i] = v; }
+    for (let i = 0; i < CHUNK; i++) {
+      v += rng.int(10, 200);
+      vals[i] = v;
+    }
     return { name: "monotonicCounter", vals };
   })(),
   // Counter with 40% idle (same as engine.bench pattern)
@@ -142,10 +153,8 @@ const patterns = [
 // ── Run tests ──
 
 console.log(`\n  Delta-ALP codec test (chunk=${CHUNK})\n`);
-console.log(
-  "  Pattern              plainALP  deltaALP  ratio  tag  roundTrip"
-);
-console.log("  " + "─".repeat(70));
+console.log("  Pattern              plainALP  deltaALP  ratio  tag  roundTrip");
+console.log(`  ${"─".repeat(70)}`);
 
 let allOk = true;
 for (const { name, vals } of patterns) {
@@ -156,7 +165,7 @@ for (const { name, vals } of patterns) {
   const { compressed: statsBuf, stats } = alpEncodeWithStats(vals);
 
   // Check if delta-ALP was used: first byte == 0xDA
-  const isDelta = statsBuf[0] === 0xDA;
+  const isDelta = statsBuf[0] === 0xda;
 
   // Decode the stats-encoded blob
   const decoded = alpDecode(statsBuf);
@@ -172,11 +181,11 @@ for (const { name, vals } of patterns) {
 
   console.log(
     `  ${name.padEnd(22)}` +
-    `${String(plainBuf.length).padStart(6)} B  ` +
-    `${String(statsBuf.length).padStart(6)} B  ` +
-    `${ratio.toFixed(2).padStart(5)}x  ` +
-    `${isDelta ? "δALP" : " ALP"}  ` +
-    `${ok && okPlain ? "✓" : "✗ FAIL"}`
+      `${String(plainBuf.length).padStart(6)} B  ` +
+      `${String(statsBuf.length).padStart(6)} B  ` +
+      `${ratio.toFixed(2).padStart(5)}x  ` +
+      `${isDelta ? "δALP" : " ALP"}  ` +
+      `${ok && okPlain ? "✓" : "✗ FAIL"}`
   );
 }
 

--- a/packages/o11ytsdb/bench/diag-chunks.mjs
+++ b/packages/o11ytsdb/bench/diag-chunks.mjs
@@ -89,11 +89,11 @@ function parseALPChunk(buf) {
   }
 
   // Exception FoR-u64 block.
-  let excMinU64 = 0n;
+  let _excMinU64 = 0n;
   let excBitWidth = 0;
   let excForBytes = 0;
   if (excCount > 0) {
-    excMinU64 = dv.getBigUint64(pos);
+    _excMinU64 = dv.getBigUint64(pos);
     pos += 8;
     excBitWidth = buf[pos];
     pos += 1;
@@ -337,7 +337,7 @@ for (const [name, gen] of Object.entries(generators)) {
     String(parsed.headerBytes).padStart(5),
     String(parsed.forPayloadBytes).padStart(6),
     String(parsed.excCount).padStart(6),
-    (parsed.excPct + "%").padStart(6),
+    `${parsed.excPct}%`.padStart(6),
     String(parsed.excPosBytes).padStart(7),
     String(parsed.excForBytes).padStart(7),
     String(parsed.excBitWidth).padStart(6),

--- a/packages/o11ytsdb/bench/diag-correctness.mjs
+++ b/packages/o11ytsdb/bench/diag-correctness.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
 /**
  * Diagnostic: test correctness of column-store read for OTel process data.
  */
-import { join, dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgDir = join(__dirname, "..");
@@ -100,42 +100,84 @@ for (const d of data) {
 
 console.log("Query range:", minT.toString(), "->", maxT.toString());
 console.log("Series 0:", data[0].timestamps.length, "pts");
-console.log("  range:", data[0].timestamps[0].toString(), "->", data[0].timestamps[data[0].timestamps.length - 1].toString());
+console.log(
+  "  range:",
+  data[0].timestamps[0].toString(),
+  "->",
+  data[0].timestamps[data[0].timestamps.length - 1].toString()
+);
 
 const r = store.read(ids[0], minT, maxT);
 console.log("Read returned:", r.timestamps.length, "pts");
 
 if (r.timestamps.length !== data[0].timestamps.length) {
-  console.log("LENGTH MISMATCH:", data[0].timestamps.length, "expected,", r.timestamps.length, "got");
+  console.log(
+    "LENGTH MISMATCH:",
+    data[0].timestamps.length,
+    "expected,",
+    r.timestamps.length,
+    "got"
+  );
   console.log("  delta:", r.timestamps.length - data[0].timestamps.length);
 
   if (r.timestamps.length > 0) {
-    console.log("  result first:", r.timestamps[0].toString(), "last:", r.timestamps[r.timestamps.length - 1].toString());
+    console.log(
+      "  result first:",
+      r.timestamps[0].toString(),
+      "last:",
+      r.timestamps[r.timestamps.length - 1].toString()
+    );
   }
 
   // Find first divergence
   const n = Math.min(r.timestamps.length, data[0].timestamps.length);
   for (let i = 0; i < n; i++) {
     if (r.timestamps[i] !== data[0].timestamps[i]) {
-      console.log("  First ts diff at i=" + i + ":", r.timestamps[i].toString(), "vs", data[0].timestamps[i].toString());
+      console.log(
+        `  First ts diff at i=${i}:`,
+        r.timestamps[i].toString(),
+        "vs",
+        data[0].timestamps[i].toString()
+      );
       // Show context
       for (let j = Math.max(0, i - 2); j <= Math.min(n - 1, i + 2); j++) {
         const match = r.timestamps[j] === data[0].timestamps[j] ? "=" : "≠";
-        console.log("    [" + j + "] read=" + r.timestamps[j]?.toString() + " " + match + " expected=" + data[0].timestamps[j].toString());
+        console.log(
+          "    [" +
+            j +
+            "] read=" +
+            r.timestamps[j]?.toString() +
+            " " +
+            match +
+            " expected=" +
+            data[0].timestamps[j].toString()
+        );
       }
       break;
     }
     if (Math.abs(r.values[i] - data[0].values[i]) > 1e-10) {
-      console.log("  First val diff at i=" + i + ":", r.values[i], "vs", data[0].values[i]);
+      console.log(`  First val diff at i=${i}:`, r.values[i], "vs", data[0].values[i]);
       break;
     }
   }
 } else {
   let mismatches = 0;
   for (let i = 0; i < data[0].timestamps.length; i++) {
-    if (r.timestamps[i] !== data[0].timestamps[i] || Math.abs(r.values[i] - data[0].values[i]) > 1e-10) {
+    if (
+      r.timestamps[i] !== data[0].timestamps[i] ||
+      Math.abs(r.values[i] - data[0].values[i]) > 1e-10
+    ) {
       if (mismatches === 0) {
-        console.log("  First mismatch at i=" + i + ": ts", r.timestamps[i]?.toString(), "vs", data[0].timestamps[i].toString(), "val", r.values[i], "vs", data[0].values[i]);
+        console.log(
+          `  First mismatch at i=${i}: ts`,
+          r.timestamps[i]?.toString(),
+          "vs",
+          data[0].timestamps[i].toString(),
+          "val",
+          r.values[i],
+          "vs",
+          data[0].values[i]
+        );
       }
       mismatches++;
     }

--- a/packages/o11ytsdb/bench/diag-exponent.mjs
+++ b/packages/o11ytsdb/bench/diag-exponent.mjs
@@ -3,44 +3,48 @@
  * Exponent selection diagnostic — tries every ALP exponent on real OTel
  * data and reports actual encoded sizes to validate the cost model.
  */
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const pkgDir = join(__dirname, '..');
+const pkgDir = join(__dirname, "..");
 
-const { loadWasm, makeALPValuesCodec } = await import(join(__dirname, 'dist', 'wasm-loader.js'));
-const wasm = await loadWasm(join(pkgDir, 'wasm/o11ytsdb-rust.wasm'));
+const { loadWasm, makeALPValuesCodec } = await import(join(__dirname, "dist", "wasm-loader.js"));
+const wasm = await loadWasm(join(pkgDir, "wasm/o11ytsdb-rust.wasm"));
 const alp = makeALPValuesCodec(wasm);
 
-const { loadOtelData } = await import(join(__dirname, 'load-otel.mjs'));
+const { loadOtelData } = await import(join(__dirname, "load-otel.mjs"));
 
 // Load real data
-const cpuSeries = await loadOtelData(join(__dirname, 'data/cpu.jsonl'));
-const infraSeries = await loadOtelData(join(__dirname, 'data/infra.jsonl'));
+const cpuSeries = await loadOtelData(join(__dirname, "data/cpu.jsonl"));
+const infraSeries = await loadOtelData(join(__dirname, "data/infra.jsonl"));
 
 // Pick representative series from different metric types
 const targets = [
-  ...cpuSeries.filter(s => s.labels.get('__name__') === 'system.cpu.utilization').slice(0, 2),
-  ...cpuSeries.filter(s => s.labels.get('__name__') === 'system.cpu.time').slice(0, 2),
-  ...cpuSeries.filter(s => s.labels.get('__name__') === 'system.cpu.load_average.1m'),
-  ...infraSeries.filter(s => s.labels.get('__name__') === 'system.memory.utilization').slice(0, 2),
-  ...infraSeries.filter(s => s.labels.get('__name__') === 'system.filesystem.utilization').slice(0, 1),
-  ...infraSeries.filter(s => s.labels.get('__name__') === 'system.network.io').slice(0, 2),
-  ...infraSeries.filter(s => s.labels.get('__name__') === 'system.disk.io_time').slice(0, 1),
+  ...cpuSeries.filter((s) => s.labels.get("__name__") === "system.cpu.utilization").slice(0, 2),
+  ...cpuSeries.filter((s) => s.labels.get("__name__") === "system.cpu.time").slice(0, 2),
+  ...cpuSeries.filter((s) => s.labels.get("__name__") === "system.cpu.load_average.1m"),
+  ...infraSeries
+    .filter((s) => s.labels.get("__name__") === "system.memory.utilization")
+    .slice(0, 2),
+  ...infraSeries
+    .filter((s) => s.labels.get("__name__") === "system.filesystem.utilization")
+    .slice(0, 1),
+  ...infraSeries.filter((s) => s.labels.get("__name__") === "system.network.io").slice(0, 2),
+  ...infraSeries.filter((s) => s.labels.get("__name__") === "system.disk.io_time").slice(0, 1),
 ];
 
 console.log(`Exponent selection diagnostic (${targets.length} series)\n`);
 
 for (const s of targets) {
-  const name = s.labels.get('__name__');
-  const extra = s.labels.get('state') || s.labels.get('direction') || s.labels.get('device') || '';
+  const name = s.labels.get("__name__");
+  const extra = s.labels.get("state") || s.labels.get("direction") || s.labels.get("device") || "";
   const chunk = s.values.subarray(0, Math.min(640, s.values.length));
   const n = chunk.length;
 
   // Current codec result (uses cost-model exponent selection)
   const { compressed } = alp.encodeValuesWithStats(chunk);
-  
+
   // Parse what exponent was chosen
   const chosenExp = compressed[2];
   const chosenExc = (compressed[12] << 8) | compressed[13];
@@ -50,16 +54,21 @@ for (const s of targets) {
   const decoded = alp.decodeValues(compressed);
   let ok = true;
   for (let i = 0; i < n; i++) {
-    if (chunk[i] !== decoded[i]) { ok = false; break; }
+    if (chunk[i] !== decoded[i]) {
+      ok = false;
+      break;
+    }
   }
 
-  console.log(`  ${name} [${extra}] — ${n} pts, chosen e=${chosenExp} bw=${chosenBw} exc=${chosenExc}/${n} → ${compressed.byteLength} B (${(compressed.byteLength/n).toFixed(2)} B/pt) roundtrip=${ok ? '✓' : '✗'}`);
+  console.log(
+    `  ${name} [${extra}] — ${n} pts, chosen e=${chosenExp} bw=${chosenBw} exc=${chosenExc}/${n} → ${compressed.byteLength} B (${(compressed.byteLength / n).toFixed(2)} B/pt) roundtrip=${ok ? "✓" : "✗"}`
+  );
 }
 
 // Now do a deep dive on cpu.utilization: what would each exponent cost?
 console.log(`\n\nDeep dive: system.cpu.utilization (first non-constant series)\n`);
-const utilSeries = cpuSeries.filter(s => {
-  if (s.labels.get('__name__') !== 'system.cpu.utilization') return false;
+const utilSeries = cpuSeries.filter((s) => {
+  if (s.labels.get("__name__") !== "system.cpu.utilization") return false;
   // Skip constant series (all zeros)
   for (let i = 1; i < Math.min(10, s.values.length); i++) {
     if (s.values[i] !== s.values[0]) return true;
@@ -71,20 +80,26 @@ if (utilSeries.length > 0) {
   const s = utilSeries[0];
   const chunk = s.values.subarray(0, Math.min(640, s.values.length));
   const n = chunk.length;
-  
-  console.log(`  Sample values: ${Array.from(chunk.subarray(0, 5)).map(v => v.toPrecision(6)).join(', ')}`);
+
+  console.log(
+    `  Sample values: ${Array.from(chunk.subarray(0, 5))
+      .map((v) => v.toPrecision(6))
+      .join(", ")}`
+  );
   console.log(`  ${n} samples\n`);
 
   // For each exponent, manually count matches and estimate what the cost model sees
-  console.log(`  ${'Exp'.padStart(4)} ${'Matches'.padStart(8)} ${'Exceptions'.padStart(11)} ${'Est bw'.padStart(7)} ${'Est cost'.padStart(9)}  ${'Actual'.padStart(8)} ${'Actual B/pt'.padStart(12)}`);
-  console.log(`  ${'─'.repeat(70)}`);
+  console.log(
+    `  ${"Exp".padStart(4)} ${"Matches".padStart(8)} ${"Exceptions".padStart(11)} ${"Est bw".padStart(7)} ${"Est cost".padStart(9)}  ${"Actual".padStart(8)} ${"Actual B/pt".padStart(12)}`
+  );
+  console.log(`  ${"─".repeat(70)}`);
 
   // We can't easily try each exponent through WASM since the codec picks its own.
   // But we can simulate the cost model in JS.
-  const POW10 = Array.from({length: 19}, (_, i) => 10 ** i);
-  
+  const POW10 = Array.from({ length: 19 }, (_, i) => 10 ** i);
+
   function alpTry(val, e) {
-    if (!isFinite(val)) return null;
+    if (!Number.isFinite(val)) return null;
     const scaled = val * POW10[e];
     if (Math.abs(scaled) > 9.2e18) return null;
     const intVal = Math.round(scaled);
@@ -93,7 +108,9 @@ if (utilSeries.length > 0) {
   }
 
   for (let e = 0; e <= 18; e++) {
-    let matchCount = 0, minInt = Infinity, maxInt = -Infinity;
+    let matchCount = 0,
+      minInt = Infinity,
+      maxInt = -Infinity;
     for (let i = 0; i < n; i++) {
       const iv = alpTry(chunk[i], e);
       if (iv !== null) {
@@ -105,8 +122,8 @@ if (utilSeries.length > 0) {
     const excCount = n - matchCount;
     const range = matchCount >= 2 ? maxInt - minInt : 0;
     const bw = range > 0 ? Math.ceil(Math.log2(range + 1)) : 0;
-    
-    const matchBytes = Math.ceil(n * bw / 8);
+
+    const matchBytes = Math.ceil((n * bw) / 8);
     const excBytes4 = excCount * 4;
     const excBytes6 = excCount * 6;
     const excBytes8 = excCount * 8;
@@ -114,11 +131,15 @@ if (utilSeries.length > 0) {
     const cost6 = 14 + matchBytes + excBytes6;
     const cost8 = 14 + matchBytes + excBytes8;
 
-    console.log(`  ${String(e).padStart(4)} ${String(matchCount).padStart(8)} ${String(excCount).padStart(11)} ${String(bw).padStart(7)} ${String(cost6).padStart(9)}  (c=4: ${cost4}, c=8: ${cost8})`);
+    console.log(
+      `  ${String(e).padStart(4)} ${String(matchCount).padStart(8)} ${String(excCount).padStart(11)} ${String(bw).padStart(7)} ${String(cost6).padStart(9)}  (c=4: ${cost4}, c=8: ${cost8})`
+    );
   }
 
   // Also show what pure Gorilla XOR on all values would cost
   // (The codec result at e=0 with all exceptions IS effectively Gorilla on all values)
   const { compressed } = alp.encodeValuesWithStats(chunk);
-  console.log(`\n  Actual encoded: ${compressed.byteLength} B (${(compressed.byteLength/n).toFixed(2)} B/pt), e=${compressed[2]}, bw=${compressed[3]}, exc=${(compressed[12]<<8)|compressed[13]}`);
+  console.log(
+    `\n  Actual encoded: ${compressed.byteLength} B (${(compressed.byteLength / n).toFixed(2)} B/pt), e=${compressed[2]}, bw=${compressed[3]}, exc=${(compressed[12] << 8) | compressed[13]}`
+  );
 }

--- a/packages/o11ytsdb/bench/diag-for-u64.mjs
+++ b/packages/o11ytsdb/bench/diag-for-u64.mjs
@@ -1,20 +1,22 @@
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const pkgDir = join(__dirname, '..');
+const pkgDir = join(__dirname, "..");
 
-const { loadWasm, makeALPValuesCodec } = await import(join(__dirname, 'dist', 'wasm-loader.js'));
-const wasm = await loadWasm(join(pkgDir, 'wasm/o11ytsdb-rust.wasm'));
+const { loadWasm, makeALPValuesCodec } = await import(join(__dirname, "dist", "wasm-loader.js"));
+const wasm = await loadWasm(join(pkgDir, "wasm/o11ytsdb-rust.wasm"));
 const alp = makeALPValuesCodec(wasm);
 
-const { loadOtelData } = await import(join(__dirname, 'load-otel.mjs'));
-const series = await loadOtelData(join(__dirname, 'data/cpu.jsonl'));
+const { loadOtelData } = await import(join(__dirname, "load-otel.mjs"));
+const series = await loadOtelData(join(__dirname, "data/cpu.jsonl"));
 
-const utils = series.filter(s => s.labels.get('__name__') === 'system.cpu.utilization').slice(0, 8);
+const utils = series
+  .filter((s) => s.labels.get("__name__") === "system.cpu.utilization")
+  .slice(0, 8);
 for (const s of utils) {
-  const st = s.labels.get('state') || '';
-  const cpu = s.labels.get('cpu') || '';
+  const st = s.labels.get("state") || "";
+  const cpu = s.labels.get("cpu") || "";
   const chunk = s.values.subarray(0, Math.min(525, s.values.length));
   const n = chunk.length;
   const { compressed } = alp.encodeValuesWithStats(chunk);
@@ -22,16 +24,16 @@ for (const s of utils) {
   const e = compressed[2];
   const bw = compressed[3];
   const excCount = (compressed[12] << 8) | compressed[13];
-  
+
   // Parse FoR-u64 exc_bw from the payload.
-  const bitPackedBytes = Math.ceil(hdrN * bw / 8);
-  const posBytes = (excCount > 0 && excCount < hdrN) ? excCount * 2 : 0;
+  const bitPackedBytes = Math.ceil((hdrN * bw) / 8);
+  const posBytes = excCount > 0 && excCount < hdrN ? excCount * 2 : 0;
   const excPayloadStart = 14 + bitPackedBytes + posBytes;
   let excBw = 0;
   if (excCount > 0 && excPayloadStart + 9 <= compressed.byteLength) {
     excBw = compressed[excPayloadStart + 8];
   }
-  
+
   // Compute sortable-u64 range in JS for validation.
   function f64ToSortableU64(f) {
     const buf = new ArrayBuffer(8);
@@ -40,20 +42,28 @@ for (const s of utils) {
     if (bits & (1n << 63n)) return ~bits;
     return bits ^ (1n << 63n);
   }
-  
-  let minSU = 0xFFFFFFFFFFFFFFFFn, maxSU = 0n;
+
+  let minSU = 0xffffffffffffffffn,
+    maxSU = 0n;
   for (let i = 0; i < n; i++) {
     const su = f64ToSortableU64(chunk[i]);
     if (su < minSU) minSU = su;
     if (su > maxSU) maxSU = su;
   }
   const range = maxSU - minSU;
-  const jsBw = range > 0n ? BigInt(64) - BigInt(Math.clz32(Number(range >> 32n))) + 32n : 0n;
+  const _jsBw = range > 0n ? BigInt(64) - BigInt(Math.clz32(Number(range >> 32n))) + 32n : 0n;
   // More precise:
   let rBw = 0;
   let r = range;
-  while (r > 0n) { rBw++; r >>= 1n; }
-  
-  console.log(`${cpu}/${st}: e=${e} bw=${bw} exc=${excCount}/${hdrN} exc_bw=${excBw} size=${compressed.byteLength} (${(compressed.byteLength/n).toFixed(2)} B/pt)  JS-range-bits=${rBw}`);
-  console.log(`  val range: [${Math.min(...chunk).toPrecision(4)}, ${Math.max(...chunk).toPrecision(4)}]`);
+  while (r > 0n) {
+    rBw++;
+    r >>= 1n;
+  }
+
+  console.log(
+    `${cpu}/${st}: e=${e} bw=${bw} exc=${excCount}/${hdrN} exc_bw=${excBw} size=${compressed.byteLength} (${(compressed.byteLength / n).toFixed(2)} B/pt)  JS-range-bits=${rBw}`
+  );
+  console.log(
+    `  val range: [${Math.min(...chunk).toPrecision(4)}, ${Math.max(...chunk).toPrecision(4)}]`
+  );
 }

--- a/packages/o11ytsdb/bench/diagnose-bpt.mjs
+++ b/packages/o11ytsdb/bench/diagnose-bpt.mjs
@@ -1,37 +1,45 @@
 #!/usr/bin/env node
-import { loadOtelData } from './load-otel.mjs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadOtelData } from "./load-otel.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const series = await loadOtelData(join(__dirname, 'data/host-metrics.jsonl'));
+const series = await loadOtelData(join(__dirname, "data/host-metrics.jsonl"));
 const totalPts = series.reduce((s, x) => s + x.timestamps.length, 0);
 
-console.log('Total series:', series.length);
-console.log('Total points:', totalPts);
-console.log('Avg pts/series:', (totalPts / series.length).toFixed(0));
+console.log("Total series:", series.length);
+console.log("Total points:", totalPts);
+console.log("Avg pts/series:", (totalPts / series.length).toFixed(0));
 console.log();
 
 // Bucket series by length
 const buckets = new Map();
 for (const s of series) {
   const n = s.timestamps.length;
-  const bucket = n < 50 ? '<50' : n < 200 ? '50-200' : n < 1000 ? '200-1K' : n < 10000 ? '1K-10K' : '10K+';
+  const bucket =
+    n < 50 ? "<50" : n < 200 ? "50-200" : n < 1000 ? "200-1K" : n < 10000 ? "1K-10K" : "10K+";
   const b = buckets.get(bucket) || { count: 0, pts: 0 };
   b.count++;
   b.pts += n;
   buckets.set(bucket, b);
 }
-const order = ['<50', '50-200', '200-1K', '1K-10K', '10K+'];
+const order = ["<50", "50-200", "200-1K", "1K-10K", "10K+"];
 for (const key of order) {
   const b = buckets.get(key);
-  if (b) console.log(`  ${key.padEnd(10)} ${String(b.count).padStart(4)} series  ${String(b.pts).padStart(8)} pts  ${((b.pts / totalPts) * 100).toFixed(1)}%`);
+  if (b)
+    console.log(
+      `  ${key.padEnd(10)} ${String(b.count).padStart(4)} series  ${String(b.pts).padStart(8)} pts  ${((b.pts / totalPts) * 100).toFixed(1)}%`
+    );
 }
 console.log();
 
-const shortSeries = series.filter(s => s.timestamps.length < 128);
-console.log(`Series with <128 pts (never freeze a full chunk): ${shortSeries.length} / ${series.length}`);
-console.log(`Points in those short series: ${shortSeries.reduce((s, x) => s + x.timestamps.length, 0)}`);
+const shortSeries = series.filter((s) => s.timestamps.length < 128);
+console.log(
+  `Series with <128 pts (never freeze a full chunk): ${shortSeries.length} / ${series.length}`
+);
+console.log(
+  `Points in those short series: ${shortSeries.reduce((s, x) => s + x.timestamps.length, 0)}`
+);
 console.log();
 
 // Raw cost: 16 B/pt (8 ts + 8 val). With shared-ts column, ts is amortized.
@@ -46,12 +54,14 @@ const estLabelBytes = series.reduce((s, x) => {
   return s + lb;
 }, 0);
 console.log(`Estimated label storage: ${(estLabelBytes / 1024).toFixed(0)} KB`);
-console.log(`Estimated hot value buffers: ${(series.length * estHotBufPerSeries / 1024).toFixed(0)} KB`);
+console.log(
+  `Estimated hot value buffers: ${((series.length * estHotBufPerSeries) / 1024).toFixed(0)} KB`
+);
 
 // Count groups and their sizes
 const groups = new Map();
 for (const s of series) {
-  const name = s.labels.get('__name__');
+  const name = s.labels.get("__name__");
   const g = groups.get(name) || { count: 0, pts: 0 };
   g.count++;
   g.pts += s.timestamps.length;
@@ -59,4 +69,6 @@ for (const s of series) {
 }
 console.log(`\nGroups (metric names): ${groups.size}`);
 // Each group has its own hot timestamp buffer
-console.log(`Estimated hot ts buffers (per group): ${(groups.size * 128 * 8 / 1024).toFixed(0)} KB`);
+console.log(
+  `Estimated hot ts buffers (per group): ${((groups.size * 128 * 8) / 1024).toFixed(0)} KB`
+);

--- a/packages/o11ytsdb/bench/engine.bench.ts
+++ b/packages/o11ytsdb/bench/engine.bench.ts
@@ -10,23 +10,23 @@
  * Codec, it automatically gets benchmarked against all others.
  */
 
-import { Suite, printReport, fmt, fmtBytes } from './harness.js';
-import type { BenchReport } from './harness.js';
-import { Rng, generateLabelSets } from './vectors.js';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { BenchReport } from "./harness.js";
+import { fmt, fmtBytes, printReport, Suite } from "./harness.js";
+import { generateLabelSets, Rng } from "./vectors.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 function pkgPath(rel: string): string {
-  return join(__dirname, '..', '..', rel);
+  return join(__dirname, "..", "..", rel);
 }
 
 // ── Types (import from compiled src) ─────────────────────────────────
 
-type StorageBackend = import('../dist/types.js').StorageBackend;
-type Codec = import('../dist/types.js').Codec;
-type Labels = import('../dist/types.js').Labels;
-type QueryEngine = import('../dist/types.js').QueryEngine;
+type StorageBackend = import("../dist/types.js").StorageBackend;
+type Codec = import("../dist/types.js").Codec;
+type Labels = import("../dist/types.js").Labels;
+type QueryEngine = import("../dist/types.js").QueryEngine;
 
 // ── Configuration ────────────────────────────────────────────────────
 
@@ -44,21 +44,21 @@ async function loadBackends(): Promise<StorageBackend[]> {
 
   // FlatStore (baseline — no compression).
   try {
-    const { FlatStore } = await import(pkgPath('dist/flat-store.js'));
+    const { FlatStore } = await import(pkgPath("dist/flat-store.js"));
     backends.push(new FlatStore());
-  } catch (e) {
-    console.log('  ⚠ FlatStore not built — skipping');
+  } catch (_e) {
+    console.log("  ⚠ FlatStore not built — skipping");
   }
 
   // ChunkedStore with XOR-delta (Gorilla) codec.
   try {
-    const { ChunkedStore } = await import(pkgPath('dist/chunked-store.js'));
-    const { loadWasm, makeCodecImpl } = await import('./wasm-loader.js');
-    const wasmPath = pkgPath('wasm/o11ytsdb-rust.wasm');
+    const { ChunkedStore } = await import(pkgPath("dist/chunked-store.js"));
+    const { loadWasm, makeCodecImpl } = await import("./wasm-loader.js");
+    const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
-    const rustImpl = makeCodecImpl(wasm, 'rust', 'Rust→WASM');
+    const rustImpl = makeCodecImpl(wasm, "rust", "Rust→WASM");
     const rustCodec: Codec = {
-      name: 'rust-wasm',
+      name: "rust-wasm",
       encode: rustImpl.encode,
       decode: rustImpl.decode,
     };
@@ -69,125 +69,227 @@ async function loadBackends(): Promise<StorageBackend[]> {
 
   // ColumnStore with XOR-delta values (shared timestamps, uncompressed ts).
   try {
-    const { ColumnStore } = await import(pkgPath('dist/column-store.js'));
-    const { loadWasm, makeValuesCodec } = await import('./wasm-loader.js');
-    const wasmPath = pkgPath('wasm/o11ytsdb-rust.wasm');
+    const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+    const { loadWasm, makeValuesCodec } = await import("./wasm-loader.js");
+    const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
     const wasmVals = makeValuesCodec(wasm);
-    backends.push(new ColumnStore(
-      { name: 'rust-wasm-values', encodeValues: wasmVals.encodeValues, decodeValues: wasmVals.decodeValues, encodeValuesWithStats: wasmVals.encodeValuesWithStats },
-      CHUNK_SIZE, () => 0,
-    ));
+    backends.push(
+      new ColumnStore(
+        {
+          name: "rust-wasm-values",
+          encodeValues: wasmVals.encodeValues,
+          decodeValues: wasmVals.decodeValues,
+          encodeValuesWithStats: wasmVals.encodeValuesWithStats,
+        },
+        CHUNK_SIZE,
+        () => 0
+      )
+    );
   } catch (e) {
     console.log(`  ⚠ ColumnStore/XOR not available — skipping (${(e as Error).message})`);
   }
 
   // ColumnStore with XOR values + delta-of-delta timestamp compression.
   try {
-    const { ColumnStore } = await import(pkgPath('dist/column-store.js'));
-    const { loadWasm, makeValuesCodec, makeTimestampCodec } = await import('./wasm-loader.js');
-    const wasmPath = pkgPath('wasm/o11ytsdb-rust.wasm');
+    const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+    const { loadWasm, makeValuesCodec, makeTimestampCodec } = await import("./wasm-loader.js");
+    const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
     const wasmVals = makeValuesCodec(wasm);
     const wasmTs = makeTimestampCodec(wasm);
-    backends.push(new ColumnStore(
-      { name: 'rust-wasm-full', encodeValues: wasmVals.encodeValues, decodeValues: wasmVals.decodeValues, encodeValuesWithStats: wasmVals.encodeValuesWithStats },
-      CHUNK_SIZE, () => 0, undefined,
-      { name: 'rust-wasm-ts', encodeTimestamps: wasmTs.encodeTimestamps, decodeTimestamps: wasmTs.decodeTimestamps },
-    ));
+    backends.push(
+      new ColumnStore(
+        {
+          name: "rust-wasm-full",
+          encodeValues: wasmVals.encodeValues,
+          decodeValues: wasmVals.decodeValues,
+          encodeValuesWithStats: wasmVals.encodeValuesWithStats,
+        },
+        CHUNK_SIZE,
+        () => 0,
+        undefined,
+        {
+          name: "rust-wasm-ts",
+          encodeTimestamps: wasmTs.encodeTimestamps,
+          decodeTimestamps: wasmTs.decodeTimestamps,
+        }
+      )
+    );
   } catch (e) {
     console.log(`  ⚠ ColumnStore/XOR+TS not available — skipping (${(e as Error).message})`);
   }
 
   // ColumnStore with ALP values + delta-of-delta timestamps (no range-decode).
   try {
-    const { ColumnStore } = await import(pkgPath('dist/column-store.js'));
-    const { loadWasm, makeALPValuesCodec, makeTimestampCodec } = await import('./wasm-loader.js');
-    const wasmPath = pkgPath('wasm/o11ytsdb-rust.wasm');
+    const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+    const { loadWasm, makeALPValuesCodec, makeTimestampCodec } = await import("./wasm-loader.js");
+    const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
     const alpVals = makeALPValuesCodec(wasm);
     const wasmTs = makeTimestampCodec(wasm);
-    backends.push(new ColumnStore(
-      { name: 'alp-full', encodeValues: alpVals.encodeValues, decodeValues: alpVals.decodeValues, encodeValuesWithStats: alpVals.encodeValuesWithStats, encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats, decodeBatchValues: alpVals.decodeBatchValues },
-      CHUNK_SIZE, () => 0, undefined,
-      { name: 'rust-wasm-ts', encodeTimestamps: wasmTs.encodeTimestamps, decodeTimestamps: wasmTs.decodeTimestamps },
-    ));
+    backends.push(
+      new ColumnStore(
+        {
+          name: "alp-full",
+          encodeValues: alpVals.encodeValues,
+          decodeValues: alpVals.decodeValues,
+          encodeValuesWithStats: alpVals.encodeValuesWithStats,
+          encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats,
+          decodeBatchValues: alpVals.decodeBatchValues,
+        },
+        CHUNK_SIZE,
+        () => 0,
+        undefined,
+        {
+          name: "rust-wasm-ts",
+          encodeTimestamps: wasmTs.encodeTimestamps,
+          decodeTimestamps: wasmTs.decodeTimestamps,
+        }
+      )
+    );
   } catch (e) {
     console.log(`  ⚠ ColumnStore/ALP not available — skipping (${(e as Error).message})`);
   }
 
   // ColumnStore with ALP values + timestamps + fused range-decode (best config).
   try {
-    const { ColumnStore } = await import(pkgPath('dist/column-store.js'));
-    const { loadWasm, makeALPValuesCodec, makeTimestampCodec, makeALPRangeCodec } = await import('./wasm-loader.js');
-    const wasmPath = pkgPath('wasm/o11ytsdb-rust.wasm');
+    const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+    const { loadWasm, makeALPValuesCodec, makeTimestampCodec, makeALPRangeCodec } = await import(
+      "./wasm-loader.js"
+    );
+    const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
     const alpVals = makeALPValuesCodec(wasm);
     const wasmTs = makeTimestampCodec(wasm);
     const rangeCodec = makeALPRangeCodec(wasm);
-    backends.push(new ColumnStore(
-      { name: 'alp-range', encodeValues: alpVals.encodeValues, decodeValues: alpVals.decodeValues, encodeValuesWithStats: alpVals.encodeValuesWithStats, encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats, decodeBatchValues: alpVals.decodeBatchValues },
-      CHUNK_SIZE, () => 0, undefined,
-      { name: 'rust-wasm-ts', encodeTimestamps: wasmTs.encodeTimestamps, decodeTimestamps: wasmTs.decodeTimestamps },
-      rangeCodec,
-    ));
+    backends.push(
+      new ColumnStore(
+        {
+          name: "alp-range",
+          encodeValues: alpVals.encodeValues,
+          decodeValues: alpVals.decodeValues,
+          encodeValuesWithStats: alpVals.encodeValuesWithStats,
+          encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats,
+          decodeBatchValues: alpVals.decodeBatchValues,
+        },
+        CHUNK_SIZE,
+        () => 0,
+        undefined,
+        {
+          name: "rust-wasm-ts",
+          encodeTimestamps: wasmTs.encodeTimestamps,
+          decodeTimestamps: wasmTs.decodeTimestamps,
+        },
+        rangeCodec
+      )
+    );
   } catch (e) {
     console.log(`  ⚠ ColumnStore/ALP+range not available — skipping (${(e as Error).message})`);
   }
 
   // RowGroupStore with ALP values + timestamps (row-group packing, no range-decode).
   try {
-    const { RowGroupStore } = await import(pkgPath('dist/row-group-store.js'));
-    const { loadWasm, makeALPValuesCodec, makeTimestampCodec } = await import('./wasm-loader.js');
-    const wasmPath = pkgPath('wasm/o11ytsdb-rust.wasm');
+    const { RowGroupStore } = await import(pkgPath("dist/row-group-store.js"));
+    const { loadWasm, makeALPValuesCodec, makeTimestampCodec } = await import("./wasm-loader.js");
+    const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
     const alpVals = makeALPValuesCodec(wasm);
     const wasmTs = makeTimestampCodec(wasm);
-    backends.push(new RowGroupStore(
-      { name: 'rg-alp-full', encodeValues: alpVals.encodeValues, decodeValues: alpVals.decodeValues, encodeValuesWithStats: alpVals.encodeValuesWithStats, encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats, decodeBatchValues: alpVals.decodeBatchValues },
-      CHUNK_SIZE, () => 0, undefined,
-      { name: 'rust-wasm-ts', encodeTimestamps: wasmTs.encodeTimestamps, decodeTimestamps: wasmTs.decodeTimestamps },
-    ));
+    backends.push(
+      new RowGroupStore(
+        {
+          name: "rg-alp-full",
+          encodeValues: alpVals.encodeValues,
+          decodeValues: alpVals.decodeValues,
+          encodeValuesWithStats: alpVals.encodeValuesWithStats,
+          encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats,
+          decodeBatchValues: alpVals.decodeBatchValues,
+        },
+        CHUNK_SIZE,
+        () => 0,
+        undefined,
+        {
+          name: "rust-wasm-ts",
+          encodeTimestamps: wasmTs.encodeTimestamps,
+          decodeTimestamps: wasmTs.decodeTimestamps,
+        }
+      )
+    );
   } catch (e) {
     console.log(`  ⚠ RowGroupStore/ALP not available — skipping (${(e as Error).message})`);
   }
 
   // RowGroupStore with ALP values + timestamps + fused range-decode.
   try {
-    const { RowGroupStore } = await import(pkgPath('dist/row-group-store.js'));
-    const { loadWasm, makeALPValuesCodec, makeTimestampCodec, makeALPRangeCodec } = await import('./wasm-loader.js');
-    const wasmPath = pkgPath('wasm/o11ytsdb-rust.wasm');
+    const { RowGroupStore } = await import(pkgPath("dist/row-group-store.js"));
+    const { loadWasm, makeALPValuesCodec, makeTimestampCodec, makeALPRangeCodec } = await import(
+      "./wasm-loader.js"
+    );
+    const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
     const alpVals = makeALPValuesCodec(wasm);
     const wasmTs = makeTimestampCodec(wasm);
     const rangeCodec = makeALPRangeCodec(wasm);
-    backends.push(new RowGroupStore(
-      { name: 'rg-alp-range', encodeValues: alpVals.encodeValues, decodeValues: alpVals.decodeValues, encodeValuesWithStats: alpVals.encodeValuesWithStats, encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats, decodeBatchValues: alpVals.decodeBatchValues },
-      CHUNK_SIZE, () => 0, undefined,
-      { name: 'rust-wasm-ts', encodeTimestamps: wasmTs.encodeTimestamps, decodeTimestamps: wasmTs.decodeTimestamps },
-      rangeCodec,
-    ));
+    backends.push(
+      new RowGroupStore(
+        {
+          name: "rg-alp-range",
+          encodeValues: alpVals.encodeValues,
+          decodeValues: alpVals.decodeValues,
+          encodeValuesWithStats: alpVals.encodeValuesWithStats,
+          encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats,
+          decodeBatchValues: alpVals.decodeBatchValues,
+        },
+        CHUNK_SIZE,
+        () => 0,
+        undefined,
+        {
+          name: "rust-wasm-ts",
+          encodeTimestamps: wasmTs.encodeTimestamps,
+          decodeTimestamps: wasmTs.decodeTimestamps,
+        },
+        rangeCodec
+      )
+    );
   } catch (e) {
     console.log(`  ⚠ RowGroupStore/ALP+range not available — skipping (${(e as Error).message})`);
   }
 
   // ColumnStore with ALP + precision=3 (decimal quantization on ingest, eliminates exceptions).
   try {
-    const { ColumnStore } = await import(pkgPath('dist/column-store.js'));
-    const { loadWasm, makeALPValuesCodec, makeTimestampCodec, makeALPRangeCodec } = await import('./wasm-loader.js');
-    const wasmPath = pkgPath('wasm/o11ytsdb-rust.wasm');
+    const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+    const { loadWasm, makeALPValuesCodec, makeTimestampCodec, makeALPRangeCodec } = await import(
+      "./wasm-loader.js"
+    );
+    const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
     const alpVals = makeALPValuesCodec(wasm);
     const wasmTs = makeTimestampCodec(wasm);
     const rangeCodec = makeALPRangeCodec(wasm);
-    backends.push(new ColumnStore(
-      { name: 'alp-p3', encodeValues: alpVals.encodeValues, decodeValues: alpVals.decodeValues, encodeValuesWithStats: alpVals.encodeValuesWithStats, encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats, decodeBatchValues: alpVals.decodeBatchValues },
-      CHUNK_SIZE, () => 0, undefined,
-      { name: 'rust-wasm-ts', encodeTimestamps: wasmTs.encodeTimestamps, decodeTimestamps: wasmTs.decodeTimestamps },
-      rangeCodec,
-      undefined, // labelIndex
-      3,         // precision — round to 3 decimal places
-    ));
+    backends.push(
+      new ColumnStore(
+        {
+          name: "alp-p3",
+          encodeValues: alpVals.encodeValues,
+          decodeValues: alpVals.decodeValues,
+          encodeValuesWithStats: alpVals.encodeValuesWithStats,
+          encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats,
+          decodeBatchValues: alpVals.decodeBatchValues,
+        },
+        CHUNK_SIZE,
+        () => 0,
+        undefined,
+        {
+          name: "rust-wasm-ts",
+          encodeTimestamps: wasmTs.encodeTimestamps,
+          decodeTimestamps: wasmTs.decodeTimestamps,
+        },
+        rangeCodec,
+        undefined, // labelIndex
+        3 // precision — round to 3 decimal places
+      )
+    );
   } catch (e) {
     console.log(`  ⚠ ColumnStore/ALP+p3 not available — skipping (${(e as Error).message})`);
   }
@@ -196,7 +298,7 @@ async function loadBackends(): Promise<StorageBackend[]> {
 }
 
 async function loadQueryEngine(): Promise<QueryEngine> {
-  const { ScanEngine } = await import(pkgPath('dist/query.js'));
+  const { ScanEngine } = await import(pkgPath("dist/query.js"));
   return new ScanEngine();
 }
 
@@ -218,7 +320,7 @@ function generateData(): IngestData {
   for (let s = 0; s < NUM_SERIES; s++) {
     const ls = labelSets[s]!;
     const m = new Map<string, string>();
-    m.set('__name__', `metric_${s % 10}`); // 10 distinct metric names
+    m.set("__name__", `metric_${s % 10}`); // 10 distinct metric names
     for (const [k, v] of ls.labels) m.set(k, v);
     labels.push(m);
 
@@ -337,20 +439,22 @@ function generateData(): IngestData {
 
 // ── Benchmark ────────────────────────────────────────────────────────
 
-export default async function(): Promise<BenchReport> {
-  const suite = new Suite('engine');
+export default async function (): Promise<BenchReport> {
+  const suite = new Suite("engine");
   const backends = await loadBackends();
   const qe = await loadQueryEngine();
   const data = generateData();
 
-  console.log(`  Configuration: ${NUM_SERIES} series × ${POINTS_PER_SERIES.toLocaleString()} pts = ${TOTAL_SAMPLES.toLocaleString()} total`);
-  console.log(`  Backends: ${backends.map(b => b.name).join(', ')}`);
+  console.log(
+    `  Configuration: ${NUM_SERIES} series × ${POINTS_PER_SERIES.toLocaleString()} pts = ${TOTAL_SAMPLES.toLocaleString()} total`
+  );
+  console.log(`  Backends: ${backends.map((b) => b.name).join(", ")}`);
   console.log(`  Query engine: ${qe.name}`);
   console.log();
 
   // ── Ingest benchmark ──
 
-  console.log('  ── Ingest ──\n');
+  console.log("  ── Ingest ──\n");
 
   // Populate all backends (measured).
   const populated: StorageBackend[] = [];
@@ -371,38 +475,49 @@ export default async function(): Promise<BenchReport> {
     for (let offset = 0; offset < POINTS_PER_SERIES; offset += CHUNK_SIZE) {
       const end = Math.min(offset + CHUNK_SIZE, POINTS_PER_SERIES);
       for (let s = 0; s < NUM_SERIES; s++) {
-        fresh.appendBatch(ids[s]!, data.timestamps[s]!.subarray(offset, end), data.values[s]!.subarray(offset, end));
+        fresh.appendBatch(
+          ids[s]!,
+          data.timestamps[s]?.subarray(offset, end),
+          data.values[s]?.subarray(offset, end)
+        );
       }
     }
 
     const elapsed = performance.now() - start;
     const throughput = TOTAL_SAMPLES / (elapsed / 1000);
 
-    suite.add(`ingest_batch`, fresh.name, () => {
-      // Already measured above — this is a no-op placeholder.
-      // We recorded the real measurement manually.
-    }, { iterations: 1, itemsPerCall: TOTAL_SAMPLES, unit: 'samples/sec' });
+    suite.add(
+      `ingest_batch`,
+      fresh.name,
+      () => {
+        // Already measured above — this is a no-op placeholder.
+        // We recorded the real measurement manually.
+      },
+      { iterations: 1, itemsPerCall: TOTAL_SAMPLES, unit: "samples/sec" }
+    );
 
     // Record as a compression result for the memory table.
     suite.addCompression(
-      'at_rest',
+      "at_rest",
       fresh.name,
       TOTAL_SAMPLES,
       TOTAL_SAMPLES * 16, // raw = 16 bytes/sample
-      fresh.memoryBytes(),
+      fresh.memoryBytes()
     );
 
     populated.push(fresh);
 
     const mem = fresh.memoryBytes();
-    console.log(`    ${fresh.name.padEnd(28)} ${fmt(throughput).padStart(10)} samples/sec    ${fmtBytes(mem).padStart(10)}    ${(mem / TOTAL_SAMPLES).toFixed(1)} B/pt`);
+    console.log(
+      `    ${fresh.name.padEnd(28)} ${fmt(throughput).padStart(10)} samples/sec    ${fmtBytes(mem).padStart(10)}    ${(mem / TOTAL_SAMPLES).toFixed(1)} B/pt`
+    );
   }
 
   console.log();
 
   // ── Query benchmarks ──
 
-  console.log('  ── Query: single series (full range) ──\n');
+  console.log("  ── Query: single series (full range) ──\n");
 
   for (const store of populated) {
     // Pick series 0, full range.
@@ -410,45 +525,65 @@ export default async function(): Promise<BenchReport> {
     const start = T0;
     const end = T0 + BigInt(POINTS_PER_SERIES) * INTERVAL;
 
-    suite.add('query_single', store.name, () => {
-      store.read(sid, start, end);
-    }, { warmup: 10, iterations: 50, itemsPerCall: POINTS_PER_SERIES, unit: 'samples/sec' });
+    suite.add(
+      "query_single",
+      store.name,
+      () => {
+        store.read(sid, start, end);
+      },
+      { warmup: 10, iterations: 50, itemsPerCall: POINTS_PER_SERIES, unit: "samples/sec" }
+    );
   }
 
-  console.log('  ── Query: multi-series select (10 series, full range) ──\n');
+  console.log("  ── Query: multi-series select (10 series, full range) ──\n");
 
   for (const store of populated) {
-    const metric = 'metric_0'; // 10 series match
+    const metric = "metric_0"; // 10 series match
     const start = T0;
     const end = T0 + BigInt(POINTS_PER_SERIES) * INTERVAL;
 
-    suite.add('query_select_10', store.name, () => {
-      qe.query(store, { metric, start, end });
-    }, { warmup: 5, iterations: 20, itemsPerCall: 10 * POINTS_PER_SERIES, unit: 'samples/sec' });
+    suite.add(
+      "query_select_10",
+      store.name,
+      () => {
+        qe.query(store, { metric, start, end });
+      },
+      { warmup: 5, iterations: 20, itemsPerCall: 10 * POINTS_PER_SERIES, unit: "samples/sec" }
+    );
   }
 
-  console.log('  ── Query: aggregated sum (10 series → 1) ──\n');
+  console.log("  ── Query: aggregated sum (10 series → 1) ──\n");
 
   for (const store of populated) {
-    const metric = 'metric_0';
+    const metric = "metric_0";
     const start = T0;
     const end = T0 + BigInt(POINTS_PER_SERIES) * INTERVAL;
 
-    suite.add('query_sum_10', store.name, () => {
-      qe.query(store, { metric, start, end, agg: 'sum' });
-    }, { warmup: 5, iterations: 20, itemsPerCall: 10 * POINTS_PER_SERIES, unit: 'samples/sec' });
+    suite.add(
+      "query_sum_10",
+      store.name,
+      () => {
+        qe.query(store, { metric, start, end, agg: "sum" });
+      },
+      { warmup: 5, iterations: 20, itemsPerCall: 10 * POINTS_PER_SERIES, unit: "samples/sec" }
+    );
   }
 
-  console.log('  ── Query: time range (last 10%) ──\n');
+  console.log("  ── Query: time range (last 10%) ──\n");
 
   for (const store of populated) {
     const rangeLen = BigInt(POINTS_PER_SERIES) * INTERVAL;
-    const start = T0 + rangeLen * 9n / 10n;
+    const start = T0 + (rangeLen * 9n) / 10n;
     const end = T0 + rangeLen;
 
-    suite.add('query_timerange', store.name, () => {
-      store.read(0, start, end);
-    }, { warmup: 10, iterations: 50, itemsPerCall: POINTS_PER_SERIES / 10, unit: 'samples/sec' });
+    suite.add(
+      "query_timerange",
+      store.name,
+      () => {
+        store.read(0, start, end);
+      },
+      { warmup: 10, iterations: 50, itemsPerCall: POINTS_PER_SERIES / 10, unit: "samples/sec" }
+    );
   }
 
   // ── Correctness check ──
@@ -465,14 +600,20 @@ export default async function(): Promise<BenchReport> {
       const otherData = other.read(0, start, end);
       // Precision-quantized backends legitimately differ from the baseline.
       // Skip cross-validation when comparing lossy vs lossless backends.
-      const isLossy = other.name.includes('-p');
-      const ok = refData.timestamps.length === otherData.timestamps.length &&
+      const isLossy = other.name.includes("-p");
+      const ok =
+        refData.timestamps.length === otherData.timestamps.length &&
         (isLossy
           ? refData.values.every((v, j) => Math.abs(v - otherData.values[j]!) < 0.01)
           : refData.values.every((v, j) => v === otherData.values[j]));
-      const detail = isLossy ? 'approx (precision-quantized)' : 'bit-exact';
-      suite.addValidation(ref.name, other.name, 'series_0_full', ok,
-        ok ? detail : `length ${refData.timestamps.length} vs ${otherData.timestamps.length}`);
+      const detail = isLossy ? "approx (precision-quantized)" : "bit-exact";
+      suite.addValidation(
+        ref.name,
+        other.name,
+        "series_0_full",
+        ok,
+        ok ? detail : `length ${refData.timestamps.length} vs ${otherData.timestamps.length}`
+      );
     }
   }
 
@@ -486,8 +627,8 @@ export default async function(): Promise<BenchReport> {
 // ── Helper: create a fresh backend by name ───────────────────────────
 
 async function freshBackend(name: string): Promise<StorageBackend> {
-  if (name === 'flat') {
-    const { FlatStore } = await import(pkgPath('dist/flat-store.js'));
+  if (name === "flat") {
+    const { FlatStore } = await import(pkgPath("dist/flat-store.js"));
     return new FlatStore();
   }
 
@@ -496,24 +637,24 @@ async function freshBackend(name: string): Promise<StorageBackend> {
   if (chunkedMatch) {
     const [, codecName, sizeStr] = chunkedMatch;
     const size = parseInt(sizeStr!, 10);
-    const { ChunkedStore } = await import(pkgPath('dist/chunked-store.js'));
+    const { ChunkedStore } = await import(pkgPath("dist/chunked-store.js"));
 
-    if (codecName === 'ts') {
-      const codec = await import(pkgPath('dist/codec.js'));
+    if (codecName === "ts") {
+      const codec = await import(pkgPath("dist/codec.js"));
       return new ChunkedStore(
-        { name: 'ts', encode: codec.encodeChunk, decode: codec.decodeChunk },
-        size,
+        { name: "ts", encode: codec.encodeChunk, decode: codec.decodeChunk },
+        size
       );
     }
 
-    if (codecName === 'rust-wasm') {
-      const { loadWasm, makeCodecImpl } = await import('./wasm-loader.js');
-      const wasmPath = pkgPath('wasm/o11ytsdb-rust.wasm');
+    if (codecName === "rust-wasm") {
+      const { loadWasm, makeCodecImpl } = await import("./wasm-loader.js");
+      const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
       const wasm = await loadWasm(wasmPath);
-      const impl = makeCodecImpl(wasm, 'rust', 'Rust→WASM');
+      const impl = makeCodecImpl(wasm, "rust", "Rust→WASM");
       return new ChunkedStore(
-        { name: 'rust-wasm', encode: impl.encode, decode: impl.decode },
-        size,
+        { name: "rust-wasm", encode: impl.encode, decode: impl.decode },
+        size
       );
     }
   }
@@ -523,65 +664,122 @@ async function freshBackend(name: string): Promise<StorageBackend> {
   if (columnMatch) {
     const [, codecName, sizeStr] = columnMatch;
     const size = parseInt(sizeStr!, 10);
-    const { ColumnStore } = await import(pkgPath('dist/column-store.js'));
-    const { loadWasm, makeValuesCodec, makeTimestampCodec, makeALPValuesCodec, makeALPRangeCodec } = await import('./wasm-loader.js');
-    const wasmPath = pkgPath('wasm/o11ytsdb-rust.wasm');
+    const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+    const { loadWasm, makeValuesCodec, makeTimestampCodec, makeALPValuesCodec, makeALPRangeCodec } =
+      await import("./wasm-loader.js");
+    const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
 
-    if (codecName === 'rust-wasm-values') {
+    if (codecName === "rust-wasm-values") {
       const wasmVals = makeValuesCodec(wasm);
       return new ColumnStore(
-        { name: 'rust-wasm-values', encodeValues: wasmVals.encodeValues, decodeValues: wasmVals.decodeValues, encodeValuesWithStats: wasmVals.encodeValuesWithStats },
-        size, () => 0,
+        {
+          name: "rust-wasm-values",
+          encodeValues: wasmVals.encodeValues,
+          decodeValues: wasmVals.decodeValues,
+          encodeValuesWithStats: wasmVals.encodeValuesWithStats,
+        },
+        size,
+        () => 0
       );
     }
 
-    if (codecName === 'rust-wasm-full') {
+    if (codecName === "rust-wasm-full") {
       const wasmVals = makeValuesCodec(wasm);
       const wasmTs = makeTimestampCodec(wasm);
       return new ColumnStore(
-        { name: 'rust-wasm-full', encodeValues: wasmVals.encodeValues, decodeValues: wasmVals.decodeValues, encodeValuesWithStats: wasmVals.encodeValuesWithStats },
-        size, () => 0, undefined,
-        { name: 'rust-wasm-ts', encodeTimestamps: wasmTs.encodeTimestamps, decodeTimestamps: wasmTs.decodeTimestamps },
+        {
+          name: "rust-wasm-full",
+          encodeValues: wasmVals.encodeValues,
+          decodeValues: wasmVals.decodeValues,
+          encodeValuesWithStats: wasmVals.encodeValuesWithStats,
+        },
+        size,
+        () => 0,
+        undefined,
+        {
+          name: "rust-wasm-ts",
+          encodeTimestamps: wasmTs.encodeTimestamps,
+          decodeTimestamps: wasmTs.decodeTimestamps,
+        }
       );
     }
 
-    if (codecName === 'alp-full') {
+    if (codecName === "alp-full") {
       const alpVals = makeALPValuesCodec(wasm);
       const wasmTs = makeTimestampCodec(wasm);
       return new ColumnStore(
-        { name: 'alp-full', encodeValues: alpVals.encodeValues, decodeValues: alpVals.decodeValues, encodeValuesWithStats: alpVals.encodeValuesWithStats, encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats, decodeBatchValues: alpVals.decodeBatchValues },
-        size, () => 0, undefined,
-        { name: 'rust-wasm-ts', encodeTimestamps: wasmTs.encodeTimestamps, decodeTimestamps: wasmTs.decodeTimestamps },
+        {
+          name: "alp-full",
+          encodeValues: alpVals.encodeValues,
+          decodeValues: alpVals.decodeValues,
+          encodeValuesWithStats: alpVals.encodeValuesWithStats,
+          encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats,
+          decodeBatchValues: alpVals.decodeBatchValues,
+        },
+        size,
+        () => 0,
+        undefined,
+        {
+          name: "rust-wasm-ts",
+          encodeTimestamps: wasmTs.encodeTimestamps,
+          decodeTimestamps: wasmTs.decodeTimestamps,
+        }
       );
     }
 
-    if (codecName === 'alp-range') {
+    if (codecName === "alp-range") {
       const alpVals = makeALPValuesCodec(wasm);
       const wasmTs = makeTimestampCodec(wasm);
       const rangeCodec = makeALPRangeCodec(wasm);
       return new ColumnStore(
-        { name: 'alp-range', encodeValues: alpVals.encodeValues, decodeValues: alpVals.decodeValues, encodeValuesWithStats: alpVals.encodeValuesWithStats, encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats, decodeBatchValues: alpVals.decodeBatchValues },
-        size, () => 0, undefined,
-        { name: 'rust-wasm-ts', encodeTimestamps: wasmTs.encodeTimestamps, decodeTimestamps: wasmTs.decodeTimestamps },
-        rangeCodec,
+        {
+          name: "alp-range",
+          encodeValues: alpVals.encodeValues,
+          decodeValues: alpVals.decodeValues,
+          encodeValuesWithStats: alpVals.encodeValuesWithStats,
+          encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats,
+          decodeBatchValues: alpVals.decodeBatchValues,
+        },
+        size,
+        () => 0,
+        undefined,
+        {
+          name: "rust-wasm-ts",
+          encodeTimestamps: wasmTs.encodeTimestamps,
+          decodeTimestamps: wasmTs.decodeTimestamps,
+        },
+        rangeCodec
       );
     }
 
     // Precision-quantized variants: alp-p{N}.
-    const precMatch = codecName!.match(/^alp-p(\d+)$/);
+    const precMatch = codecName?.match(/^alp-p(\d+)$/);
     if (precMatch) {
       const precision = parseInt(precMatch[1]!, 10);
       const alpVals = makeALPValuesCodec(wasm);
       const wasmTs = makeTimestampCodec(wasm);
       const rangeCodec = makeALPRangeCodec(wasm);
       return new ColumnStore(
-        { name: `alp-p${precision}`, encodeValues: alpVals.encodeValues, decodeValues: alpVals.decodeValues, encodeValuesWithStats: alpVals.encodeValuesWithStats, encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats, decodeBatchValues: alpVals.decodeBatchValues },
-        size, () => 0, undefined,
-        { name: 'rust-wasm-ts', encodeTimestamps: wasmTs.encodeTimestamps, decodeTimestamps: wasmTs.decodeTimestamps },
+        {
+          name: `alp-p${precision}`,
+          encodeValues: alpVals.encodeValues,
+          decodeValues: alpVals.decodeValues,
+          encodeValuesWithStats: alpVals.encodeValuesWithStats,
+          encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats,
+          decodeBatchValues: alpVals.decodeBatchValues,
+        },
+        size,
+        () => 0,
+        undefined,
+        {
+          name: "rust-wasm-ts",
+          encodeTimestamps: wasmTs.encodeTimestamps,
+          decodeTimestamps: wasmTs.decodeTimestamps,
+        },
         rangeCodec,
         undefined, // labelIndex
-        precision,
+        precision
       );
     }
   }
@@ -591,30 +789,58 @@ async function freshBackend(name: string): Promise<StorageBackend> {
   if (rgMatch) {
     const [, codecName, sizeStr] = rgMatch;
     const size = parseInt(sizeStr!, 10);
-    const { RowGroupStore } = await import(pkgPath('dist/row-group-store.js'));
-    const { loadWasm, makeALPValuesCodec, makeTimestampCodec, makeALPRangeCodec } = await import('./wasm-loader.js');
-    const wasmPath = pkgPath('wasm/o11ytsdb-rust.wasm');
+    const { RowGroupStore } = await import(pkgPath("dist/row-group-store.js"));
+    const { loadWasm, makeALPValuesCodec, makeTimestampCodec, makeALPRangeCodec } = await import(
+      "./wasm-loader.js"
+    );
+    const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
 
-    if (codecName === 'rg-alp-full') {
+    if (codecName === "rg-alp-full") {
       const alpVals = makeALPValuesCodec(wasm);
       const wasmTs = makeTimestampCodec(wasm);
       return new RowGroupStore(
-        { name: 'rg-alp-full', encodeValues: alpVals.encodeValues, decodeValues: alpVals.decodeValues, encodeValuesWithStats: alpVals.encodeValuesWithStats, encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats, decodeBatchValues: alpVals.decodeBatchValues },
-        size, () => 0, undefined,
-        { name: 'rust-wasm-ts', encodeTimestamps: wasmTs.encodeTimestamps, decodeTimestamps: wasmTs.decodeTimestamps },
+        {
+          name: "rg-alp-full",
+          encodeValues: alpVals.encodeValues,
+          decodeValues: alpVals.decodeValues,
+          encodeValuesWithStats: alpVals.encodeValuesWithStats,
+          encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats,
+          decodeBatchValues: alpVals.decodeBatchValues,
+        },
+        size,
+        () => 0,
+        undefined,
+        {
+          name: "rust-wasm-ts",
+          encodeTimestamps: wasmTs.encodeTimestamps,
+          decodeTimestamps: wasmTs.decodeTimestamps,
+        }
       );
     }
 
-    if (codecName === 'rg-alp-range') {
+    if (codecName === "rg-alp-range") {
       const alpVals = makeALPValuesCodec(wasm);
       const wasmTs = makeTimestampCodec(wasm);
       const rangeCodec = makeALPRangeCodec(wasm);
       return new RowGroupStore(
-        { name: 'rg-alp-range', encodeValues: alpVals.encodeValues, decodeValues: alpVals.decodeValues, encodeValuesWithStats: alpVals.encodeValuesWithStats, encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats, decodeBatchValues: alpVals.decodeBatchValues },
-        size, () => 0, undefined,
-        { name: 'rust-wasm-ts', encodeTimestamps: wasmTs.encodeTimestamps, decodeTimestamps: wasmTs.decodeTimestamps },
-        rangeCodec,
+        {
+          name: "rg-alp-range",
+          encodeValues: alpVals.encodeValues,
+          decodeValues: alpVals.decodeValues,
+          encodeValuesWithStats: alpVals.encodeValuesWithStats,
+          encodeBatchValuesWithStats: alpVals.encodeBatchValuesWithStats,
+          decodeBatchValues: alpVals.decodeBatchValues,
+        },
+        size,
+        () => 0,
+        undefined,
+        {
+          name: "rust-wasm-ts",
+          encodeTimestamps: wasmTs.encodeTimestamps,
+          decodeTimestamps: wasmTs.decodeTimestamps,
+        },
+        rangeCodec
       );
     }
   }

--- a/packages/o11ytsdb/bench/engine.bench.ts
+++ b/packages/o11ytsdb/bench/engine.bench.ts
@@ -477,8 +477,8 @@ export default async function (): Promise<BenchReport> {
       for (let s = 0; s < NUM_SERIES; s++) {
         fresh.appendBatch(
           ids[s]!,
-          data.timestamps[s]?.subarray(offset, end),
-          data.values[s]?.subarray(offset, end)
+          data.timestamps[s]!.subarray(offset, end),
+          data.values[s]!.subarray(offset, end)
         );
       }
     }

--- a/packages/o11ytsdb/bench/harness.ts
+++ b/packages/o11ytsdb/bench/harness.ts
@@ -132,7 +132,7 @@ export class Suite {
     runtime: Runtime,
     inputSamples: number,
     rawBytes: number,
-    compressedBytes: number,
+    compressedBytes: number
   ): void {
     this.compressions.push({
       name,
@@ -147,13 +147,7 @@ export class Suite {
   }
 
   /** Record a cross-validation result between two implementations. */
-  addValidation(
-    implA: Runtime,
-    implB: Runtime,
-    vector: string,
-    ok: boolean,
-    detail: string,
-  ): void {
+  addValidation(implA: Runtime, implB: Runtime, vector: string, ok: boolean, detail: string): void {
     this.validations.push({ implA, implB, vector, ok, detail });
   }
 
@@ -169,7 +163,7 @@ export class Suite {
     return {
       module: this.module,
       timestamp: new Date().toISOString(),
-      commit: process.env['GIT_SHA'] ?? 'local',
+      commit: process.env.GIT_SHA ?? "local",
       runtimes: [...this.runtimes],
       results,
       compression: this.compressions,
@@ -186,13 +180,13 @@ export class Suite {
 
 // ── Legacy API (for simple single-runtime benchmarks) ────────────────
 
-const legacySuite = new Suite('_legacy');
+const legacySuite = new Suite("_legacy");
 
 export function bench(name: string, fn: () => void, opts: BenchOptions = {}): void {
-  legacySuite.add(name, 'ts', fn, opts);
+  legacySuite.add(name, "ts", fn, opts);
 }
 
-export function runAll(module: string, runtime: Runtime = 'ts'): BenchReport {
+export function runAll(module: string, runtime: Runtime = "ts"): BenchReport {
   const report = legacySuite.run();
   report.module = module;
   // Override runtimes tag for legacy callers.
@@ -206,7 +200,7 @@ export function runAll(module: string, runtime: Runtime = 'ts'): BenchReport {
 function runOne(name: string, runtime: Runtime, fn: () => void, opts: BenchOptions): BenchResult {
   const warmup = opts.warmup ?? DEFAULT_WARMUP;
   const iterations = opts.iterations ?? DEFAULT_ITERATIONS;
-  const unit = opts.unit ?? 'ops/sec';
+  const unit = opts.unit ?? "ops/sec";
 
   // Warmup — let V8 JIT optimize.
   for (let i = 0; i < warmup; i++) fn();
@@ -277,15 +271,17 @@ function runOne(name: string, runtime: Runtime, fn: () => void, opts: BenchOptio
  */
 export function printReport(report: BenchReport): void {
   const w = 72;
-  console.log(`\n╔${'═'.repeat(w)}╗`);
-  console.log(`║  o11ytsdb bench — ${report.module} [${report.runtimes.join(', ')}]`.padEnd(w + 1) + '║');
-  console.log(`╚${'═'.repeat(w)}╝\n`);
+  console.log(`\n╔${"═".repeat(w)}╗`);
+  console.log(
+    `${`║  o11ytsdb bench — ${report.module} [${report.runtimes.join(", ")}]`.padEnd(w + 1)}║`
+  );
+  console.log(`╚${"═".repeat(w)}╝\n`);
 
   // ── Cross-validation ──
   if (report.crossValidation.length > 0) {
-    console.log('  ── Cross-validation ──\n');
+    console.log("  ── Cross-validation ──\n");
     for (const v of report.crossValidation) {
-      const mark = v.ok ? '✓' : '✗';
+      const mark = v.ok ? "✓" : "✗";
       console.log(`    ${mark} ${v.vector}: ${v.implA} ↔ ${v.implB} — ${v.detail}`);
     }
     console.log();
@@ -293,26 +289,26 @@ export function printReport(report: BenchReport): void {
 
   // ── Compression ──
   if (report.compression.length > 0) {
-    console.log('  ── Compression ──\n');
+    console.log("  ── Compression ──\n");
 
     // Group by vector name to show runtimes side by side.
-    const vectors = [...new Set(report.compression.map(c => c.name))];
+    const vectors = [...new Set(report.compression.map((c) => c.name))];
     const rts = report.runtimes;
 
     // Header.
-    let hdr = '    Vector'.padEnd(28);
+    let hdr = "    Vector".padEnd(28);
     for (const rt of rts) hdr += `  ${rt} bytes/pt`.padStart(14) + `  ${rt} ratio`.padStart(12);
     console.log(hdr);
-    console.log('    ' + '─'.repeat(hdr.length - 4));
+    console.log(`    ${"─".repeat(hdr.length - 4)}`);
 
     for (const vec of vectors) {
       let line = `    ${vec}`.padEnd(28);
       for (const rt of rts) {
-        const c = report.compression.find(x => x.name === vec && x.runtime === rt);
+        const c = report.compression.find((x) => x.name === vec && x.runtime === rt);
         if (c) {
           line += c.bytesPerPoint.toFixed(2).padStart(14) + `${c.ratio.toFixed(1)}x`.padStart(12);
         } else {
-          line += '—'.padStart(14) + '—'.padStart(12);
+          line += "—".padStart(14) + "—".padStart(12);
         }
       }
       console.log(line);
@@ -322,28 +318,28 @@ export function printReport(report: BenchReport): void {
 
   // ── Throughput ──
   if (report.results.length > 0) {
-    console.log('  ── Throughput ──\n');
+    console.log("  ── Throughput ──\n");
 
     // Group by bench name to show runtimes side by side.
-    const names = [...new Set(report.results.map(r => r.name))];
+    const names = [...new Set(report.results.map((r) => r.name))];
     const rts = report.runtimes;
 
-    let hdr = '    Benchmark'.padEnd(32);
+    let hdr = "    Benchmark".padEnd(32);
     for (const rt of rts) hdr += `  ${rt} p50`.padStart(14) + `  ${rt} p99`.padStart(14);
-    hdr += '  unit';
+    hdr += "  unit";
     console.log(hdr);
-    console.log('    ' + '─'.repeat(hdr.length - 4));
+    console.log(`    ${"─".repeat(hdr.length - 4)}`);
 
     for (const name of names) {
       let line = `    ${name}`.padEnd(32);
-      let unit = '';
+      let unit = "";
       for (const rt of rts) {
-        const r = report.results.find(x => x.name === name && x.runtime === rt);
+        const r = report.results.find((x) => x.name === name && x.runtime === rt);
         if (r) {
           line += fmt(r.p50).padStart(14) + fmt(r.p99).padStart(14);
           unit = r.unit;
         } else {
-          line += '—'.padStart(14) + '—'.padStart(14);
+          line += "—".padStart(14) + "—".padStart(14);
         }
       }
       line += `  ${unit}`;
@@ -353,24 +349,31 @@ export function printReport(report: BenchReport): void {
   }
 
   // ── Memory per benchmark ──
-  const withMem = report.results.filter(r => r.heapDeltaBytes > 0 || r.arrayBufferDeltaBytes > 0);
+  const withMem = report.results.filter((r) => r.heapDeltaBytes > 0 || r.arrayBufferDeltaBytes > 0);
   if (withMem.length > 0) {
-    console.log('  ── Memory (heap delta during benchmark) ──\n');
-    console.log('    Benchmark'.padEnd(32) + '  runtime'.padEnd(10) + '  heap Δ'.padStart(14) + '  arrayBuf Δ'.padStart(14));
-    console.log('    ' + '─'.repeat(66));
+    console.log("  ── Memory (heap delta during benchmark) ──\n");
+    console.log(
+      "    Benchmark".padEnd(32) +
+        "  runtime".padEnd(10) +
+        "  heap Δ".padStart(14) +
+        "  arrayBuf Δ".padStart(14)
+    );
+    console.log(`    ${"─".repeat(66)}`);
     for (const r of withMem) {
       console.log(
         `    ${r.name}`.padEnd(32) +
-        `  ${r.runtime}`.padEnd(10) +
-        fmtBytes(r.heapDeltaBytes).padStart(14) +
-        fmtBytes(r.arrayBufferDeltaBytes).padStart(14),
+          `  ${r.runtime}`.padEnd(10) +
+          fmtBytes(r.heapDeltaBytes).padStart(14) +
+          fmtBytes(r.arrayBufferDeltaBytes).padStart(14)
       );
     }
     console.log();
   }
 
   // ── Final snapshot ──
-  console.log(`  Memory snapshot: heap=${fmtBytes(report.memory.heapUsed)} / ${fmtBytes(report.memory.heapTotal)}`);
+  console.log(
+    `  Memory snapshot: heap=${fmtBytes(report.memory.heapUsed)} / ${fmtBytes(report.memory.heapTotal)}`
+  );
   console.log(`                   arrayBuffers=${fmtBytes(report.memory.arrayBuffers)}\n`);
 }
 
@@ -394,11 +397,11 @@ export function fmtBytes(n: number): string {
 export function compareReports(
   baseline: BenchReport,
   current: BenchReport,
-  threshold = 0.05,
+  threshold = 0.05
 ): { passed: boolean; regressions: string[] } {
   const regressions: string[] = [];
   const key = (r: BenchResult) => `${r.name}:${r.runtime}`;
-  const baseMap = new Map(baseline.results.map(r => [key(r), r]));
+  const baseMap = new Map(baseline.results.map((r) => [key(r), r]));
 
   for (const cur of current.results) {
     const base = baseMap.get(key(cur));
@@ -407,7 +410,7 @@ export function compareReports(
     if (delta > threshold) {
       regressions.push(
         `${cur.name} (${cur.runtime}): p50 regressed ${(delta * 100).toFixed(1)}% ` +
-        `(${fmt(base.p50)} → ${fmt(cur.p50)} ${cur.unit})`,
+          `(${fmt(base.p50)} → ${fmt(cur.p50)} ${cur.unit})`
       );
     }
   }

--- a/packages/o11ytsdb/bench/ingest.bench.ts
+++ b/packages/o11ytsdb/bench/ingest.bench.ts
@@ -1,14 +1,14 @@
-import { Suite, printReport, type BenchReport } from './harness.js';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { type BenchReport, printReport, Suite } from "./harness.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 function pkgPath(rel: string): string {
-  return join(__dirname, '..', '..', rel);
+  return join(__dirname, "..", "..", rel);
 }
 
-type OtlpMetric = import('@otlpkit/otlpjson').OtlpMetric;
-type OtlpMetricsDocument = import('@otlpkit/otlpjson').OtlpMetricsDocument;
+type OtlpMetric = import("@otlpkit/otlpjson").OtlpMetric;
+type OtlpMetricsDocument = import("@otlpkit/otlpjson").OtlpMetricsDocument;
 
 const METRIC_BATCHES = [100, 1_000, 10_000];
 
@@ -24,8 +24,8 @@ function buildSyntheticPayload(metricCount: number): OtlpMetricsDocument {
           {
             timeUnixNano: (baseTs + BigInt(i) * 1_000_000_000n).toString(),
             attributes: [
-              { key: 'host.name', value: { stringValue: `node-${i % 256}` } },
-              { key: 'cpu', value: { stringValue: String(i % 8) } },
+              { key: "host.name", value: { stringValue: `node-${i % 256}` } },
+              { key: "cpu", value: { stringValue: String(i % 8) } },
             ],
             asDouble: 0.25 + (i % 100) / 100,
           },
@@ -39,15 +39,15 @@ function buildSyntheticPayload(metricCount: number): OtlpMetricsDocument {
       {
         resource: {
           attributes: [
-            { key: 'service.name', value: { stringValue: 'o11ytsdb-ingest-bench' } },
-            { key: 'service.instance.id', value: { stringValue: 'bench-1' } },
+            { key: "service.name", value: { stringValue: "o11ytsdb-ingest-bench" } },
+            { key: "service.instance.id", value: { stringValue: "bench-1" } },
           ],
         },
         scopeMetrics: [
           {
             scope: {
-              name: 'bench.ingest',
-              version: '0.0.1',
+              name: "bench.ingest",
+              version: "0.0.1",
             },
             metrics,
           },
@@ -58,16 +58,16 @@ function buildSyntheticPayload(metricCount: number): OtlpMetricsDocument {
 }
 
 export default async function (): Promise<BenchReport> {
-  const suite = new Suite('ingest');
-  const { FlatStore } = await import(pkgPath('dist/flat-store.js'));
-  const { ingestOtlpJson } = await import(pkgPath('dist/ingest.js'));
+  const suite = new Suite("ingest");
+  const { FlatStore } = await import(pkgPath("dist/flat-store.js"));
+  const { ingestOtlpJson } = await import(pkgPath("dist/ingest.js"));
 
   for (const metricCount of METRIC_BATCHES) {
     const payload = buildSyntheticPayload(metricCount);
 
     suite.add(
       `ingest_${metricCount}_metrics`,
-      'ts',
+      "ts",
       () => {
         const storage = new FlatStore();
         ingestOtlpJson(payload, storage);
@@ -76,8 +76,8 @@ export default async function (): Promise<BenchReport> {
         warmup: 10,
         iterations: 30,
         itemsPerCall: metricCount,
-        unit: 'samples/sec',
-      },
+        unit: "samples/sec",
+      }
     );
   }
 

--- a/packages/o11ytsdb/bench/interner.bench.ts
+++ b/packages/o11ytsdb/bench/interner.bench.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { Suite, printReport } from "./harness.js";
+import { printReport, Suite } from "./harness.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgPath = (rel: string) => join(__dirname, "..", "..", rel);
@@ -20,16 +20,32 @@ export default async function runInternerBench() {
   const { Interner } = await import(pkgPath("dist/interner.js"));
   const tsInterner = new Interner();
 
-  suite.add("intern_10k", "ts", () => {
-    for (const s of strings) tsInterner.intern(s);
-  }, { iterations: 200, itemsPerCall: strings.length });
+  suite.add(
+    "intern_10k",
+    "ts",
+    () => {
+      for (const s of strings) tsInterner.intern(s);
+    },
+    { iterations: 200, itemsPerCall: strings.length }
+  );
 
-  suite.add("resolve_10k", "ts", () => {
-    for (let i = 0; i < strings.length; i++) tsInterner.resolve(i);
-  }, { iterations: 300, itemsPerCall: strings.length });
+  suite.add(
+    "resolve_10k",
+    "ts",
+    () => {
+      for (let i = 0; i < strings.length; i++) tsInterner.resolve(i);
+    },
+    { iterations: 300, itemsPerCall: strings.length }
+  );
 
   const rawUtf16Bytes = strings.reduce((sum, s) => sum + s.length * 2, 0);
-  suite.addCompression("string_memory", "ts", strings.length, rawUtf16Bytes, tsInterner.memoryBytes());
+  suite.addCompression(
+    "string_memory",
+    "ts",
+    strings.length,
+    rawUtf16Bytes,
+    tsInterner.memoryBytes()
+  );
 
   try {
     const wasmBytes = readFileSync(pkgPath("wasm/o11ytsdb-rust.wasm"));
@@ -42,14 +58,19 @@ export default async function runInternerBench() {
     if (wasm.internerReset && wasm.internerIntern) {
       const encoder = new TextEncoder();
       wasm.internerReset();
-      suite.add("intern_10k", "rust-wasm", () => {
-        const mem = new Uint8Array(wasm.memory.buffer);
-        for (const s of strings) {
-          const bytes = encoder.encode(s);
-          mem.set(bytes, 0);
-          wasm.internerIntern(0, bytes.length);
-        }
-      }, { iterations: 200, itemsPerCall: strings.length });
+      suite.add(
+        "intern_10k",
+        "rust-wasm",
+        () => {
+          const mem = new Uint8Array(wasm.memory.buffer);
+          for (const s of strings) {
+            const bytes = encoder.encode(s);
+            mem.set(bytes, 0);
+            wasm.internerIntern(0, bytes.length);
+          }
+        },
+        { iterations: 200, itemsPerCall: strings.length }
+      );
 
       const checkTs = new Interner();
       wasm.internerReset();
@@ -63,10 +84,22 @@ export default async function runInternerBench() {
           break;
         }
       }
-      suite.addValidation("ts", "rust-wasm", "same-id-sequence", valid, valid ? "matched" : "mismatch");
+      suite.addValidation(
+        "ts",
+        "rust-wasm",
+        "same-id-sequence",
+        valid,
+        valid ? "matched" : "mismatch"
+      );
     }
   } catch (err: any) {
-    suite.addValidation("ts", "rust-wasm", "same-id-sequence", false, `skipped: ${err.message ?? err}`);
+    suite.addValidation(
+      "ts",
+      "rust-wasm",
+      "same-id-sequence",
+      false,
+      `skipped: ${err.message ?? err}`
+    );
   }
 
   const report = suite.run();

--- a/packages/o11ytsdb/bench/load-otel.mjs
+++ b/packages/o11ytsdb/bench/load-otel.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * OTLP JSONL → benchmark data loader.
  *
@@ -15,11 +16,11 @@
  *   node bench/load-otel.mjs [path]   # prints summary
  */
 
-import { readFileSync, existsSync, createReadStream } from "node:fs";
-import { join, dirname, basename } from "node:path";
-import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
+import { createReadStream, existsSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -67,9 +68,7 @@ export async function loadOtelData(path, opts = {}) {
       console.log(`  Decompressing ${name} from testdata repo…`);
       execFileSync("zstd", ["-d", zst, "-o", path]);
     } else {
-      throw new Error(
-        `${path} not found. Run ./bench/fetch-testdata.sh to download testdata.`
-      );
+      throw new Error(`${path} not found. Run ./bench/fetch-testdata.sh to download testdata.`);
     }
   }
 
@@ -100,7 +99,10 @@ export async function loadOtelData(path, opts = {}) {
               const labels = new Map([["__name__", name]]);
               for (const a of attrs) {
                 const v = a.value;
-                labels.set(a.key, String(v.stringValue ?? v.intValue ?? v.doubleValue ?? v.boolValue ?? ""));
+                labels.set(
+                  a.key,
+                  String(v.stringValue ?? v.intValue ?? v.doubleValue ?? v.boolValue ?? "")
+                );
               }
               seriesMap.set(key, { labels, points: [] });
             }
@@ -157,7 +159,8 @@ export async function loadOtelData(path, opts = {}) {
   let globalMax = result[0].timestamps[result[0].timestamps.length - 1];
   for (const s of result) {
     if (s.timestamps[0] < globalMin) globalMin = s.timestamps[0];
-    if (s.timestamps[s.timestamps.length - 1] > globalMax) globalMax = s.timestamps[s.timestamps.length - 1];
+    if (s.timestamps[s.timestamps.length - 1] > globalMax)
+      globalMax = s.timestamps[s.timestamps.length - 1];
   }
   // Shift each repeat by (duration + 15s gap) so timestamps never overlap.
   const duration = globalMax - globalMin;
@@ -185,21 +188,23 @@ export async function loadOtelData(path, opts = {}) {
 
 // ── Standalone summary ───────────────────────────────────────────────
 
-if (process.argv[1] && process.argv[1].endsWith("load-otel.mjs")) {
+if (process.argv[1]?.endsWith("load-otel.mjs")) {
   const repeatIdx = process.argv.indexOf("--repeat");
   const repeat = repeatIdx >= 0 ? Number(process.argv[repeatIdx + 1]) : 1;
-  const args = process.argv.filter((a, i) => a !== "--repeat" && (repeatIdx < 0 || i !== repeatIdx + 1));
+  const args = process.argv.filter(
+    (a, i) => a !== "--repeat" && (repeatIdx < 0 || i !== repeatIdx + 1)
+  );
   const path = args[2] || join(__dirname, "data/host-metrics.jsonl");
   const series = await loadOtelData(path, { repeat });
 
   const totalPts = series.reduce((s, x) => s + x.timestamps.length, 0);
-  const ptsPerSeries = series.map(s => s.timestamps.length);
+  const ptsPerSeries = series.map((s) => s.timestamps.length);
   const minPts = Math.min(...ptsPerSeries);
   const maxPts = Math.max(...ptsPerSeries);
   const medPts = ptsPerSeries.sort((a, b) => a - b)[Math.floor(ptsPerSeries.length / 2)];
 
   // Unique metric names.
-  const metricNames = new Set(series.map(s => s.labels.get("__name__")));
+  const metricNames = new Set(series.map((s) => s.labels.get("__name__")));
 
   console.log(`\n  OTLP data loaded from: ${path}\n`);
   console.log(`  Series:       ${series.length}`);
@@ -212,7 +217,8 @@ if (process.argv[1] && process.argv[1].endsWith("load-otel.mjs")) {
   let globalMax = series[0].timestamps[series[0].timestamps.length - 1];
   for (const s of series) {
     if (s.timestamps[0] < globalMin) globalMin = s.timestamps[0];
-    if (s.timestamps[s.timestamps.length - 1] > globalMax) globalMax = s.timestamps[s.timestamps.length - 1];
+    if (s.timestamps[s.timestamps.length - 1] > globalMax)
+      globalMax = s.timestamps[s.timestamps.length - 1];
   }
   const durationMs = Number(globalMax - globalMin) / 1e6;
   const durationMin = durationMs / 60000;
@@ -228,14 +234,18 @@ if (process.argv[1] && process.argv[1].endsWith("load-otel.mjs")) {
   }
   console.log(`\n  Per-metric breakdown:`);
   for (const [name, info] of [...byName.entries()].sort((a, b) => b[1].pts - a[1].pts)) {
-    console.log(`    ${name.padEnd(45)} ${String(info.count).padStart(4)} series  ${info.pts.toLocaleString().padStart(8)} pts`);
+    console.log(
+      `    ${name.padEnd(45)} ${String(info.count).padStart(4)} series  ${info.pts.toLocaleString().padStart(8)} pts`
+    );
   }
 
   // Sample values from first few series.
   console.log(`\n  Sample values (first 3 series):`);
   for (const s of series.slice(0, 3)) {
     const name = s.labels.get("__name__");
-    const first5 = Array.from(s.values.slice(0, 5)).map(v => v.toFixed(4)).join(", ");
+    const first5 = Array.from(s.values.slice(0, 5))
+      .map((v) => v.toFixed(4))
+      .join(", ");
     console.log(`    ${name}: [${first5}, ...] (${s.timestamps.length} pts)`);
   }
   console.log("");

--- a/packages/o11ytsdb/bench/micro-agg.mjs
+++ b/packages/o11ytsdb/bench/micro-agg.mjs
@@ -45,7 +45,7 @@ bench("BigInt sub+div", () => {
 bench("Float64 div", () => {
   buckets.fill(Infinity);
   for (let i = 0; i < N; i++) {
-    const b = (tsF[i] - minTN) / stepN | 0;
+    const b = ((tsF[i] - minTN) / stepN) | 0;
     if (vals[i] < buckets[b]) buckets[b] = vals[i];
   }
 });
@@ -54,7 +54,7 @@ bench("Float64 div", () => {
 bench("Number(BigInt) inline", () => {
   buckets.fill(Infinity);
   for (let i = 0; i < N; i++) {
-    const b = (Number(ts[i]) - minTN) / stepN | 0;
+    const b = ((Number(ts[i]) - minTN) / stepN) | 0;
     if (vals[i] < buckets[b]) buckets[b] = vals[i];
   }
 });
@@ -65,7 +65,7 @@ bench("Batch convert + loop", () => {
   for (let i = 0; i < N; i++) tsN[i] = Number(ts[i]);
   buckets.fill(Infinity);
   for (let i = 0; i < N; i++) {
-    const b = (tsN[i] - minTN) / stepN | 0;
+    const b = ((tsN[i] - minTN) / stepN) | 0;
     if (vals[i] < buckets[b]) buckets[b] = vals[i];
   }
 });
@@ -89,7 +89,7 @@ bench("DataView i64->f64", () => {
   }
   buckets.fill(Infinity);
   for (let i = 0; i < N; i++) {
-    const b = (dst[i] - minTN) / stepN | 0;
+    const b = ((dst[i] - minTN) / stepN) | 0;
     if (vals[i] < buckets[b]) buckets[b] = vals[i];
   }
 });
@@ -99,7 +99,7 @@ bench("DataView i64->f64", () => {
 bench("Float64 pre-stored (best)", () => {
   buckets.fill(Infinity);
   for (let i = 0; i < N; i++) {
-    const b = (tsF[i] - minTN) / stepN | 0;
+    const b = ((tsF[i] - minTN) / stepN) | 0;
     if (vals[i] < buckets[b]) buckets[b] = vals[i];
   }
 });

--- a/packages/o11ytsdb/bench/postings.bench.ts
+++ b/packages/o11ytsdb/bench/postings.bench.ts
@@ -1,7 +1,7 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { Suite, printReport } from "./harness.js";
+import { printReport, Suite } from "./harness.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgPath = (rel: string) => join(__dirname, "..", "..", rel);
@@ -9,19 +9,21 @@ const pkgPath = (rel: string) => join(__dirname, "..", "..", rel);
 function makeSeriesLabels(n: number): Map<string, string>[] {
   const out: Map<string, string>[] = [];
   for (let i = 0; i < n; i++) {
-    out.push(new Map([
-      ["__name__", "http_requests_total"],
-      ["service", `svc-${i % 200}`],
-      ["region", `r-${i % 10}`],
-      ["env", i % 2 === 0 ? "prod" : "dev"],
-    ]));
+    out.push(
+      new Map([
+        ["__name__", "http_requests_total"],
+        ["service", `svc-${i % 200}`],
+        ["region", `r-${i % 10}`],
+        ["env", i % 2 === 0 ? "prod" : "dev"],
+      ])
+    );
   }
   return out;
 }
 
 function naiveIntersect(a: number[], b: number[]): number[] {
   const s = new Set(b);
-  return a.filter(x => s.has(x));
+  return a.filter((x) => s.has(x));
 }
 
 function makeSorted(size: number, stride: number): number[] {
@@ -38,9 +40,14 @@ export default async function runPostingsBench() {
   const postings = new MemPostings();
   labels.forEach((l, i) => postings.add(i, l));
 
-  suite.add("lookup_1_label", "ts", () => {
-    postings.get("env", "prod");
-  }, { iterations: 20_000 });
+  suite.add(
+    "lookup_1_label",
+    "ts",
+    () => {
+      postings.get("env", "prod");
+    },
+    { iterations: 20_000 }
+  );
 
   const sizes = [100, 1000, 10_000];
   for (const size of sizes) {
@@ -51,20 +58,30 @@ export default async function runPostingsBench() {
     suite.add(`intersect_naive_${size}`, "baseline", () => naiveIntersect(a, b), { iterations });
   }
 
-  suite.add("query_match_postings", "ts", () => {
-    const idsA = postings.get("__name__", "http_requests_total");
-    const idsB = postings.get("env", "prod");
-    postings.intersect(idsA, idsB);
-  }, { iterations: 20_000 });
+  suite.add(
+    "query_match_postings",
+    "ts",
+    () => {
+      const idsA = postings.get("__name__", "http_requests_total");
+      const idsB = postings.get("env", "prod");
+      postings.intersect(idsA, idsB);
+    },
+    { iterations: 20_000 }
+  );
 
-  suite.add("query_match_linear_scan", "baseline", () => {
-    const out: number[] = [];
-    for (let i = 0; i < labels.length; i++) {
-      const set = labels[i]!;
-      if (set.get("__name__") === "http_requests_total" && set.get("env") === "prod") out.push(i);
-    }
-    return out;
-  }, { iterations: 2_000 });
+  suite.add(
+    "query_match_linear_scan",
+    "baseline",
+    () => {
+      const out: number[] = [];
+      for (let i = 0; i < labels.length; i++) {
+        const set = labels[i]!;
+        if (set.get("__name__") === "http_requests_total" && set.get("env") === "prod") out.push(i);
+      }
+      return out;
+    },
+    { iterations: 2_000 }
+  );
 
   const report = suite.run();
   printReport(report);

--- a/packages/o11ytsdb/bench/profile-query.mjs
+++ b/packages/o11ytsdb/bench/profile-query.mjs
@@ -11,9 +11,9 @@
  */
 
 import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgDir = join(__dirname, "..");
@@ -24,10 +24,10 @@ const NUM_SERIES = 30;
 const POINTS_PER_SERIES = Math.ceil(5_000_000 / NUM_SERIES); // ~166,667 pts each → 5M total
 const TOTAL_SAMPLES = NUM_SERIES * POINTS_PER_SERIES;
 const CHUNK_SIZE = 512;
-const T0 = 1_700_000_000_000n;           // epoch ms
-const INTERVAL = 15_000n;                 // 15s scrape interval
+const T0 = 1_700_000_000_000n; // epoch ms
+const INTERVAL = 15_000n; // 15s scrape interval
 const REGIONS = ["us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1", "eu-central-1"];
-const AGG_STEP = 60_000n;                 // 1 minute aggregation step
+const AGG_STEP = 60_000n; // 1 minute aggregation step
 
 // ── Data generation (30 series across 5 regions) ─────────────────────
 
@@ -74,7 +74,9 @@ async function makeWasmCodecs(wasmBytes) {
       const outCap = n * 20;
       const outPtr = w.allocScratch(outCap);
       mem().set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valPtr);
-      return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeValuesALP(valPtr, n, outPtr, outCap)));
+      return new Uint8Array(
+        w.memory.buffer.slice(outPtr, outPtr + w.encodeValuesALP(valPtr, n, outPtr, outCap))
+      );
     },
     decodeValues(buf) {
       w.resetScratch();
@@ -98,7 +100,16 @@ async function makeWasmCodecs(wasmBytes) {
       const s = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + 64));
       return {
         compressed,
-        stats: { minV: s[0], maxV: s[1], sum: s[2], count: s[3], firstV: s[4], lastV: s[5], sumOfSquares: s[6], resetCount: s[7] },
+        stats: {
+          minV: s[0],
+          maxV: s[1],
+          sum: s[2],
+          count: s[3],
+          firstV: s[4],
+          lastV: s[5],
+          sumOfSquares: s[6],
+          resetCount: s[7],
+        },
       };
     },
     encodeBatchValuesWithStats(arrays) {
@@ -107,26 +118,48 @@ async function makeWasmCodecs(wasmBytes) {
       w.resetScratch();
       const valsPtr = w.allocScratch(numArrays * chunkSize * 8);
       for (let i = 0; i < numArrays; i++) {
-        mem().set(new Uint8Array(arrays[i].buffer, arrays[i].byteOffset, arrays[i].byteLength), valsPtr + i * chunkSize * 8);
+        mem().set(
+          new Uint8Array(arrays[i].buffer, arrays[i].byteOffset, arrays[i].byteLength),
+          valsPtr + i * chunkSize * 8
+        );
       }
       const outCap = numArrays * chunkSize * 20;
       const outPtr = w.allocScratch(outCap);
       const offsetsPtr = w.allocScratch(numArrays * 4);
       const sizesPtr = w.allocScratch(numArrays * 4);
       const statsPtr = w.allocScratch(numArrays * 64);
-      w.encodeBatchValuesALPWithStats(valsPtr, chunkSize, numArrays, outPtr, outCap, offsetsPtr, sizesPtr, statsPtr);
-      const offsets = new Uint32Array(w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4));
+      w.encodeBatchValuesALPWithStats(
+        valsPtr,
+        chunkSize,
+        numArrays,
+        outPtr,
+        outCap,
+        offsetsPtr,
+        sizesPtr,
+        statsPtr
+      );
+      const offsets = new Uint32Array(
+        w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4)
+      );
       const sizes = new Uint32Array(w.memory.buffer.slice(sizesPtr, sizesPtr + numArrays * 4));
       const allStats = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + numArrays * 64));
       const results = [];
       for (let i = 0; i < numArrays; i++) {
-        const compressed = new Uint8Array(w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i]));
+        const compressed = new Uint8Array(
+          w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i])
+        );
         const si = i * 8;
         results.push({
           compressed,
           stats: {
-            minV: allStats[si], maxV: allStats[si+1], sum: allStats[si+2], count: allStats[si+3],
-            firstV: allStats[si+4], lastV: allStats[si+5], sumOfSquares: allStats[si+6], resetCount: allStats[si+7],
+            minV: allStats[si],
+            maxV: allStats[si + 1],
+            sum: allStats[si + 2],
+            count: allStats[si + 3],
+            firstV: allStats[si + 4],
+            lastV: allStats[si + 5],
+            sumOfSquares: allStats[si + 6],
+            resetCount: allStats[si + 7],
           },
         });
       }
@@ -142,8 +175,13 @@ async function makeWasmCodecs(wasmBytes) {
       const tsPtr = w.allocScratch(n * 8);
       const outCap = n * 20;
       const outPtr = w.allocScratch(outCap);
-      mem().set(new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength), tsPtr);
-      return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeTimestamps(tsPtr, n, outPtr, outCap)));
+      mem().set(
+        new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength),
+        tsPtr
+      );
+      return new Uint8Array(
+        w.memory.buffer.slice(outPtr, outPtr + w.encodeTimestamps(tsPtr, n, outPtr, outCap))
+      );
     },
     decodeTimestamps(buf) {
       w.resetScratch();
@@ -167,11 +205,15 @@ async function makeWasmCodecs(wasmBytes) {
       const outTsPtr = w.allocScratch(maxSamples * 8);
       const outValPtr = w.allocScratch(maxSamples * 8);
       const n = w.rangeDecodeALP(
-        tsInPtr, compressedTs.length,
-        valInPtr, compressedVals.length,
-        startT, endT,
-        outTsPtr, outValPtr,
-        maxSamples,
+        tsInPtr,
+        compressedTs.length,
+        valInPtr,
+        compressedVals.length,
+        startT,
+        endT,
+        outTsPtr,
+        outValPtr,
+        maxSamples
       );
       if (n === 0) return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
       return {
@@ -186,12 +228,14 @@ async function makeWasmCodecs(wasmBytes) {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function gcAndSnap() {
+function _gcAndSnap() {
   if (global.gc) global.gc();
   return process.memoryUsage();
 }
 
-function fmtMs(n) { return `${n.toFixed(1)}ms`; }
+function fmtMs(n) {
+  return `${n.toFixed(1)}ms`;
+}
 function fmtRate(n) {
   if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
   if (n >= 1e3) return `${(n / 1e3).toFixed(0)}K`;
@@ -209,8 +253,12 @@ async function main() {
   const hasGC = typeof global.gc === "function";
   if (!hasGC) console.log("  ⚠ Run with --expose-gc for accurate memory\n");
 
-  console.log(`  Scenario: ${NUM_SERIES} series × ${POINTS_PER_SERIES.toLocaleString()} pts = ${TOTAL_SAMPLES.toLocaleString()} samples`);
-  console.log(`  Query: min agg, step=${Number(AGG_STEP)/1000}s, groupBy=[region], ${REGIONS.length} groups`);
+  console.log(
+    `  Scenario: ${NUM_SERIES} series × ${POINTS_PER_SERIES.toLocaleString()} pts = ${TOTAL_SAMPLES.toLocaleString()} samples`
+  );
+  console.log(
+    `  Query: min agg, step=${Number(AGG_STEP) / 1000}s, groupBy=[region], ${REGIONS.length} groups`
+  );
   console.log(`  Chunk size: ${CHUNK_SIZE}\n`);
 
   // ── Setup ──
@@ -222,8 +270,15 @@ async function main() {
   const { ScanEngine } = await import(join(pkgDir, "dist/query.js"));
 
   const backends = [
-    { name: "column-alp (no range)", make: () => new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec) },
-    { name: "column-alp-fused",      make: () => new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec) },
+    {
+      name: "column-alp (no range)",
+      make: () => new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec),
+    },
+    {
+      name: "column-alp-fused",
+      make: () =>
+        new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec),
+    },
   ];
 
   const engine = new ScanEngine();
@@ -237,14 +292,18 @@ async function main() {
 
     // Ingest
     const store = backend.make();
-    const ids = data.map(d => store.getOrCreateSeries(d.labels));
+    const ids = data.map((d) => store.getOrCreateSeries(d.labels));
     const tIngest0 = performance.now();
     for (let s = 0; s < data.length; s++) {
       store.appendBatch(ids[s], data[s].timestamps, data[s].values);
     }
     const tIngest1 = performance.now();
-    console.log(`    Ingest: ${fmtMs(tIngest1 - tIngest0)}  (${fmtRate(TOTAL_SAMPLES / (tIngest1 - tIngest0) * 1000)} samples/s)`);
-    console.log(`    Store:  ${fmtBytes(store.memoryBytes())}  (${(store.memoryBytes() / TOTAL_SAMPLES).toFixed(1)} B/pt)\n`);
+    console.log(
+      `    Ingest: ${fmtMs(tIngest1 - tIngest0)}  (${fmtRate((TOTAL_SAMPLES / (tIngest1 - tIngest0)) * 1000)} samples/s)`
+    );
+    console.log(
+      `    Store:  ${fmtBytes(store.memoryBytes())}  (${(store.memoryBytes() / TOTAL_SAMPLES).toFixed(1)} B/pt)\n`
+    );
 
     // ── Query 1: Raw read all series (no aggregation) ──
     if (hasGC) global.gc();
@@ -255,7 +314,9 @@ async function main() {
       readSamples += r.timestamps.length;
     }
     const tRead1 = performance.now();
-    console.log(`    Raw read (all series):    ${fmtMs(tRead1 - tRead0)}  ${fmtRate(readSamples / (tRead1 - tRead0) * 1000)} samples/s  (${readSamples.toLocaleString()} pts)`);
+    console.log(
+      `    Raw read (all series):    ${fmtMs(tRead1 - tRead0)}  ${fmtRate((readSamples / (tRead1 - tRead0)) * 1000)} samples/s  (${readSamples.toLocaleString()} pts)`
+    );
 
     // ── Query 2: ScanEngine with min agg + step + groupBy ──
     if (hasGC) global.gc();
@@ -270,21 +331,23 @@ async function main() {
     });
     const tAgg1 = performance.now();
     const outputPts = result.series.reduce((s, r) => s + r.timestamps.length, 0);
-    console.log(`    Agg query (min/1m/region): ${fmtMs(tAgg1 - tAgg0)}  scanned=${result.scannedSamples.toLocaleString()} → ${outputPts.toLocaleString()} output pts  (${result.series.length} groups)`);
+    console.log(
+      `    Agg query (min/1m/region): ${fmtMs(tAgg1 - tAgg0)}  scanned=${result.scannedSamples.toLocaleString()} → ${outputPts.toLocaleString()} output pts  (${result.series.length} groups)`
+    );
 
     // ── Break down the aggregation query into phases ──
     if (hasGC) global.gc();
 
     // Phase A: matchLabel
     const tMatch0 = performance.now();
-    let matchedIds = store.matchLabel("__name__", "cpu_usage");
+    const matchedIds = store.matchLabel("__name__", "cpu_usage");
     const tMatch1 = performance.now();
 
     // Phase B: Read all matching series (readParts when available)
     const useReadParts = typeof store.readParts === "function";
     const tReadPhase0 = performance.now();
-    const allParts = [];           // flat array of TimeRange parts
-    const partsPerSeries = [];     // count per series for groupBy
+    const allParts = []; // flat array of TimeRange parts
+    const partsPerSeries = []; // count per series for groupBy
     for (const id of matchedIds) {
       if (useReadParts) {
         const parts = store.readParts(id, qStart, qEnd);
@@ -341,7 +404,8 @@ async function main() {
         const vs = r.values;
         for (let i = 0, len = src.length; i < len; i++) {
           const off = i << 3;
-          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          const bucket =
+            ((dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN) | 0;
           if (vs[i] < values[bucket]) values[bucket] = vs[i];
         }
       }
@@ -349,12 +413,25 @@ async function main() {
     const tAggPhase1 = performance.now();
 
     console.log(`\n    Phase breakdown${useReadParts ? " (readParts)" : " (read+concat)"}:`);
-    console.log(`      matchLabel:    ${fmtMs(tMatch1 - tMatch0).padStart(10)}  (${matchedIds.length} series)`);
-    console.log(`      read():        ${fmtMs(tReadPhase1 - tReadPhase0).padStart(10)}  (${totalParts} parts, ${useReadParts ? "skip concat" : "concat"})`);
-    console.log(`      groupBy:       ${fmtMs(tGroup1 - tGroup0).padStart(10)}  (${groups.size} groups)`);
-    console.log(`      stepAggregate: ${fmtMs(tAggPhase1 - tAggPhase0).padStart(10)}  (fused DataView → bucket + min fold)`);
+    console.log(
+      `      matchLabel:    ${fmtMs(tMatch1 - tMatch0).padStart(10)}  (${matchedIds.length} series)`
+    );
+    console.log(
+      `      read():        ${fmtMs(tReadPhase1 - tReadPhase0).padStart(10)}  (${totalParts} parts, ${useReadParts ? "skip concat" : "concat"})`
+    );
+    console.log(
+      `      groupBy:       ${fmtMs(tGroup1 - tGroup0).padStart(10)}  (${groups.size} groups)`
+    );
+    console.log(
+      `      stepAggregate: ${fmtMs(tAggPhase1 - tAggPhase0).padStart(10)}  (fused DataView → bucket + min fold)`
+    );
 
-    const total = (tMatch1 - tMatch0) + (tReadPhase1 - tReadPhase0) + (tGroup1 - tGroup0) + (tAggPhase1 - tAggPhase0);
+    const total =
+      tMatch1 -
+      tMatch0 +
+      (tReadPhase1 - tReadPhase0) +
+      (tGroup1 - tGroup0) +
+      (tAggPhase1 - tAggPhase0);
     console.log(`      ─────────────────────`);
     console.log(`      total:         ${fmtMs(total).padStart(10)}`);
 
@@ -380,7 +457,7 @@ async function main() {
 
     // ── Stats-skip scenario: large step (4h) so chunks fit in 1 bucket ──
     // Chunk span ≈ 512 × 15s = 7,680s ≈ 128min.  4h step → most chunks skip decode.
-    const BIG_STEP = 14_400_000n;  // 4 hours
+    const BIG_STEP = 14_400_000n; // 4 hours
     if (hasGC) global.gc();
     const tBig0 = performance.now();
     const bigResult = engine.query(store, {
@@ -393,7 +470,9 @@ async function main() {
     });
     const tBig1 = performance.now();
     const bigPts = bigResult.series.reduce((s, r) => s + r.timestamps.length, 0);
-    console.log(`\n    Stats-skip query (min/4h/region): ${fmtMs(tBig1 - tBig0)}  scanned=${bigResult.scannedSamples.toLocaleString()} → ${bigPts.toLocaleString()} output pts`);
+    console.log(
+      `\n    Stats-skip query (min/4h/region): ${fmtMs(tBig1 - tBig0)}  scanned=${bigResult.scannedSamples.toLocaleString()} → ${bigPts.toLocaleString()} output pts`
+    );
 
     // Repeat 5x
     const bigRuns = [];
@@ -412,10 +491,15 @@ async function main() {
       bigRuns.push(t1 - t0);
     }
     bigRuns.sort((a, b) => a - b);
-    console.log(`    Repeated (5 runs): min=${fmtMs(bigRuns[0])}  median=${fmtMs(bigRuns[2])}  max=${fmtMs(bigRuns[4])}`);
+    console.log(
+      `    Repeated (5 runs): min=${fmtMs(bigRuns[0])}  median=${fmtMs(bigRuns[2])}  max=${fmtMs(bigRuns[4])}`
+    );
 
     console.log();
   }
 }
 
-main().catch(e => { console.error(e); process.exit(1); });
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/o11ytsdb/bench/profile.mjs
+++ b/packages/o11ytsdb/bench/profile.mjs
@@ -13,9 +13,9 @@
  */
 
 import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgDir = join(__dirname, "..");
@@ -39,10 +39,14 @@ function generateData() {
     for (let i = 0; i < POINTS_PER_SERIES; i++) {
       timestamps[i] = T0 + BigInt(i) * INTERVAL;
       // Realistic mix: counters, gauges, constant
-      if (s % 5 === 0) values[i] = 42.0; // constant
-      else if (s % 5 === 1) values[i] = i * 1.0; // monotonic counter
-      else if (s % 5 === 2) values[i] = Math.sin(i * 0.01) * 100; // smooth gauge
-      else if (s % 5 === 3) values[i] = Math.random() * 1000; // high variance
+      if (s % 5 === 0)
+        values[i] = 42.0; // constant
+      else if (s % 5 === 1)
+        values[i] = i * 1.0; // monotonic counter
+      else if (s % 5 === 2)
+        values[i] = Math.sin(i * 0.01) * 100; // smooth gauge
+      else if (s % 5 === 3)
+        values[i] = Math.random() * 1000; // high variance
       else values[i] = Math.floor(i / 100) * 10.0; // step function
     }
     const labels = new Map([
@@ -102,7 +106,16 @@ async function makeWasmCodecs(wasmBytes) {
       const s = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + 64));
       return {
         compressed,
-        stats: { minV: s[0], maxV: s[1], sum: s[2], count: s[3], firstV: s[4], lastV: s[5], sumOfSquares: s[6], resetCount: s[7] },
+        stats: {
+          minV: s[0],
+          maxV: s[1],
+          sum: s[2],
+          count: s[3],
+          firstV: s[4],
+          lastV: s[5],
+          sumOfSquares: s[6],
+          resetCount: s[7],
+        },
       };
     },
     encodeBatchValuesWithStats(arrays) {
@@ -113,30 +126,50 @@ async function makeWasmCodecs(wasmBytes) {
       const valsPtr = w.allocScratch(numArrays * chunkSize * 8);
       for (let i = 0; i < numArrays; i++) {
         const arr = arrays[i];
-        mem().set(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength), valsPtr + i * chunkSize * 8);
+        mem().set(
+          new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength),
+          valsPtr + i * chunkSize * 8
+        );
       }
       const outCap = numArrays * chunkSize * 20;
       const outPtr = w.allocScratch(outCap);
       const offsetsPtr = w.allocScratch(numArrays * 4);
       const sizesPtr = w.allocScratch(numArrays * 4);
       const statsPtr = w.allocScratch(numArrays * 64);
-      const totalBytes = w.encodeBatchValuesWithStats(
-        valsPtr, chunkSize, numArrays, outPtr, outCap, offsetsPtr, sizesPtr, statsPtr
+      const _totalBytes = w.encodeBatchValuesWithStats(
+        valsPtr,
+        chunkSize,
+        numArrays,
+        outPtr,
+        outCap,
+        offsetsPtr,
+        sizesPtr,
+        statsPtr
       );
       // Read back results.
-      const offsets = new Uint32Array(w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4));
+      const offsets = new Uint32Array(
+        w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4)
+      );
       const sizes = new Uint32Array(w.memory.buffer.slice(sizesPtr, sizesPtr + numArrays * 4));
       const allStats = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + numArrays * 64));
-      const outBuf = new Uint8Array(w.memory.buffer);
+      const _outBuf = new Uint8Array(w.memory.buffer);
       const results = [];
       for (let i = 0; i < numArrays; i++) {
-        const compressed = new Uint8Array(w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i]));
+        const compressed = new Uint8Array(
+          w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i])
+        );
         const si = i * 8;
         results.push({
           compressed,
           stats: {
-            minV: allStats[si], maxV: allStats[si+1], sum: allStats[si+2], count: allStats[si+3],
-            firstV: allStats[si+4], lastV: allStats[si+5], sumOfSquares: allStats[si+6], resetCount: allStats[si+7],
+            minV: allStats[si],
+            maxV: allStats[si + 1],
+            sum: allStats[si + 2],
+            count: allStats[si + 3],
+            firstV: allStats[si + 4],
+            lastV: allStats[si + 5],
+            sumOfSquares: allStats[si + 6],
+            resetCount: allStats[si + 7],
           },
         });
       }
@@ -152,7 +185,10 @@ async function makeWasmCodecs(wasmBytes) {
       const tsPtr = w.allocScratch(n * 8);
       const outCap = n * 20;
       const outPtr = w.allocScratch(outCap);
-      mem().set(new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength), tsPtr);
+      mem().set(
+        new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength),
+        tsPtr
+      );
       const bytesWritten = w.encodeTimestamps(tsPtr, n, outPtr, outCap);
       return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + bytesWritten));
     },
@@ -179,7 +215,9 @@ async function makeWasmCodecs(wasmBytes) {
       const m = mem();
       m.set(new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength), tsPtr);
       m.set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valPtr);
-      return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeChunk(tsPtr, valPtr, n, outPtr, outCap)));
+      return new Uint8Array(
+        w.memory.buffer.slice(outPtr, outPtr + w.encodeChunk(tsPtr, valPtr, n, outPtr, outCap))
+      );
     },
     decode(buf) {
       w.resetScratch();
@@ -230,7 +268,16 @@ async function makeWasmCodecs(wasmBytes) {
       const s = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + 64));
       return {
         compressed,
-        stats: { minV: s[0], maxV: s[1], sum: s[2], count: s[3], firstV: s[4], lastV: s[5], sumOfSquares: s[6], resetCount: s[7] },
+        stats: {
+          minV: s[0],
+          maxV: s[1],
+          sum: s[2],
+          count: s[3],
+          firstV: s[4],
+          lastV: s[5],
+          sumOfSquares: s[6],
+          resetCount: s[7],
+        },
       };
     },
     encodeBatchValuesWithStats(arrays) {
@@ -240,7 +287,10 @@ async function makeWasmCodecs(wasmBytes) {
       const valsPtr = w.allocScratch(numArrays * chunkSize * 8);
       for (let i = 0; i < numArrays; i++) {
         const arr = arrays[i];
-        mem().set(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength), valsPtr + i * chunkSize * 8);
+        mem().set(
+          new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength),
+          valsPtr + i * chunkSize * 8
+        );
       }
       const outCap = numArrays * chunkSize * 20;
       const outPtr = w.allocScratch(outCap);
@@ -248,20 +298,37 @@ async function makeWasmCodecs(wasmBytes) {
       const sizesPtr = w.allocScratch(numArrays * 4);
       const statsPtr = w.allocScratch(numArrays * 64);
       w.encodeBatchValuesALPWithStats(
-        valsPtr, chunkSize, numArrays, outPtr, outCap, offsetsPtr, sizesPtr, statsPtr
+        valsPtr,
+        chunkSize,
+        numArrays,
+        outPtr,
+        outCap,
+        offsetsPtr,
+        sizesPtr,
+        statsPtr
       );
-      const offsets = new Uint32Array(w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4));
+      const offsets = new Uint32Array(
+        w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4)
+      );
       const sizes = new Uint32Array(w.memory.buffer.slice(sizesPtr, sizesPtr + numArrays * 4));
       const allStats = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + numArrays * 64));
       const results = [];
       for (let i = 0; i < numArrays; i++) {
-        const compressed = new Uint8Array(w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i]));
+        const compressed = new Uint8Array(
+          w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i])
+        );
         const si = i * 8;
         results.push({
           compressed,
           stats: {
-            minV: allStats[si], maxV: allStats[si+1], sum: allStats[si+2], count: allStats[si+3],
-            firstV: allStats[si+4], lastV: allStats[si+5], sumOfSquares: allStats[si+6], resetCount: allStats[si+7],
+            minV: allStats[si],
+            maxV: allStats[si + 1],
+            sum: allStats[si + 2],
+            count: allStats[si + 3],
+            firstV: allStats[si + 4],
+            lastV: allStats[si + 5],
+            sumOfSquares: allStats[si + 6],
+            resetCount: allStats[si + 7],
           },
         });
       }
@@ -281,11 +348,15 @@ async function makeWasmCodecs(wasmBytes) {
       const outTsPtr = w.allocScratch(maxSamples * 8);
       const outValPtr = w.allocScratch(maxSamples * 8);
       const n = w.rangeDecodeALP(
-        tsInPtr, compressedTs.length,
-        valInPtr, compressedVals.length,
-        startT, endT,
-        outTsPtr, outValPtr,
-        maxSamples,
+        tsInPtr,
+        compressedTs.length,
+        valInPtr,
+        compressedVals.length,
+        startT,
+        endT,
+        outTsPtr,
+        outValPtr,
+        maxSamples
       );
       if (n === 0) {
         return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
@@ -359,7 +430,7 @@ async function profileBackend(name, makeStore, data, TOTAL_SAMPLES) {
   const ingestMs = tIngestEnd - tIngestStart;
   result.phases.ingest = {
     ms: ingestMs,
-    rate: TOTAL_SAMPLES / ingestMs * 1000,
+    rate: (TOTAL_SAMPLES / ingestMs) * 1000,
     mem: memDelta(snapCreate, snapIngest),
   };
 
@@ -383,7 +454,7 @@ async function profileBackend(name, makeStore, data, TOTAL_SAMPLES) {
   const snapQuery = gcAndSnap();
   result.phases.query = {
     ms: queryMs,
-    rate: totalRead / queryMs * 1000,
+    rate: (totalRead / queryMs) * 1000,
     mem: memDelta(snapIngest, snapQuery),
     samplesRead: totalRead,
   };
@@ -403,12 +474,16 @@ async function profileBackend(name, makeStore, data, TOTAL_SAMPLES) {
   if (ok) {
     for (let i = 0; i < expectedLen; i++) {
       if (r0.timestamps[i] !== data[0].timestamps[i]) {
-        console.log(`    ⚠ ts mismatch at [${i}]: expected ${data[0].timestamps[i]}, got ${r0.timestamps[i]} (diff=${Number(r0.timestamps[i] - data[0].timestamps[i])})`);
+        console.log(
+          `    ⚠ ts mismatch at [${i}]: expected ${data[0].timestamps[i]}, got ${r0.timestamps[i]} (diff=${Number(r0.timestamps[i] - data[0].timestamps[i])})`
+        );
         ok = false;
         break;
       }
       if (Math.abs(r0.values[i] - data[0].values[i]) > 1e-10) {
-        console.log(`    ⚠ val mismatch at [${i}]: expected ${data[0].values[i]}, got ${r0.values[i]}`);
+        console.log(
+          `    ⚠ val mismatch at [${i}]: expected ${data[0].values[i]}, got ${r0.values[i]}`
+        );
         ok = false;
         break;
       }
@@ -430,7 +505,10 @@ async function main() {
   const positional = [];
   for (let i = 2; i < process.argv.length; i++) {
     const a = process.argv[i];
-    if (a === "--repeat" || a === "--dataset") { i++; continue; }
+    if (a === "--repeat" || a === "--dataset") {
+      i++;
+      continue;
+    }
     if (a.startsWith("--")) continue;
     positional.push(a);
   }
@@ -450,13 +528,16 @@ async function main() {
     const { loadOtelData } = await import(join(__dirname, "load-otel.mjs"));
     data = await loadOtelData(otelPath, { repeat });
     TOTAL_SAMPLES = data.reduce((s, d) => s + d.timestamps.length, 0);
-    console.log(`  Data source: OTel ${dataset} (${data.length} series, ${TOTAL_SAMPLES.toLocaleString()} pts${repeat > 1 ? `, ×${repeat}` : ""})\n`);
+    console.log(
+      `  Data source: OTel ${dataset} (${data.length} series, ${TOTAL_SAMPLES.toLocaleString()} pts${repeat > 1 ? `, ×${repeat}` : ""})\n`
+    );
   } else {
     data = generateData();
     TOTAL_SAMPLES = NUM_SERIES * POINTS_PER_SERIES;
   }
   const wasmBytes = loadWasmSync();
-  const { valuesCodec, alpValuesCodec, tsCodec, fullCodec, alpRangeCodec } = await makeWasmCodecs(wasmBytes);
+  const { valuesCodec, alpValuesCodec, tsCodec, fullCodec, alpRangeCodec } =
+    await makeWasmCodecs(wasmBytes);
 
   const backends = [];
 
@@ -515,12 +596,22 @@ async function main() {
       name: `column-alp-fused-${CHUNK_SIZE}`,
       make: async () => {
         const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
-        return () => new ColumnStore(alpValuesCodec, CHUNK_SIZE, makeGrouper(), undefined, tsCodec, alpRangeCodec);
+        return () =>
+          new ColumnStore(
+            alpValuesCodec,
+            CHUNK_SIZE,
+            makeGrouper(),
+            undefined,
+            tsCodec,
+            alpRangeCodec
+          );
       },
     },
   ];
 
-  console.log(`\n  Profile: ${data.length} series, ${TOTAL_SAMPLES.toLocaleString()} samples (chunk=${CHUNK_SIZE})\n`);
+  console.log(
+    `\n  Profile: ${data.length} series, ${TOTAL_SAMPLES.toLocaleString()} samples (chunk=${CHUNK_SIZE})\n`
+  );
 
   for (const def of defs) {
     if (filter && !def.name.includes(filter)) continue;
@@ -531,9 +622,15 @@ async function main() {
 
   // ── Summary table ──
 
-  console.log("  ┌─────────────────────────────┬──────────┬──────────┬──────────┬────────┬───────┬────┐");
-  console.log("  │ Backend                     │  Ingest  │  Query   │   Mem    │ B/pt   │ Heap  │ OK │");
-  console.log("  ├─────────────────────────────┼──────────┼──────────┼──────────┼────────┼───────┼────┤");
+  console.log(
+    "  ┌─────────────────────────────┬──────────┬──────────┬──────────┬────────┬───────┬────┐"
+  );
+  console.log(
+    "  │ Backend                     │  Ingest  │  Query   │   Mem    │ B/pt   │ Heap  │ OK │"
+  );
+  console.log(
+    "  ├─────────────────────────────┼──────────┼──────────┼──────────┼────────┼───────┼────┤"
+  );
 
   for (const r of backends) {
     const ingestStr = `${fmtRate(r.phases.ingest.rate)}/s`.padStart(8);
@@ -542,20 +639,32 @@ async function main() {
     const bptStr = `${r.bPerPt.toFixed(1)}`.padStart(6);
     const heapStr = fmtBytes(r.totalMem.heap).padStart(5);
     const ok = r.correct ? "✓" : "✗";
-    console.log(`  │ ${r.name.padEnd(27)} │ ${ingestStr} │ ${queryStr} │ ${memStr} │ ${bptStr} │ ${heapStr} │ ${ok}  │`);
+    console.log(
+      `  │ ${r.name.padEnd(27)} │ ${ingestStr} │ ${queryStr} │ ${memStr} │ ${bptStr} │ ${heapStr} │ ${ok}  │`
+    );
   }
-  console.log("  └─────────────────────────────┴──────────┴──────────┴──────────┴────────┴───────┴────┘");
+  console.log(
+    "  └─────────────────────────────┴──────────┴──────────┴──────────┴────────┴───────┴────┘"
+  );
 
   // ── Detailed per-backend breakdown ──
 
   if (filter || backends.length === 1) {
     for (const r of backends) {
       console.log(`\n  ── ${r.name} detailed ──\n`);
-      console.log(`    Create:  ${r.phases.create.ms.toFixed(1)}ms  heap: ${fmtBytes(r.phases.create.mem.heap)}  ab: ${fmtBytes(r.phases.create.mem.ab)}`);
-      console.log(`    Ingest:  ${r.phases.ingest.ms.toFixed(1)}ms  ${fmtRate(r.phases.ingest.rate)} samples/s  heap: ${fmtBytes(r.phases.ingest.mem.heap)}  ab: ${fmtBytes(r.phases.ingest.mem.ab)}`);
-      console.log(`    Query:   ${r.phases.query.ms.toFixed(1)}ms  ${fmtRate(r.phases.query.rate)} samples/s  heap: ${fmtBytes(r.phases.query.mem.heap)}  ab: ${fmtBytes(r.phases.query.mem.ab)}`);
+      console.log(
+        `    Create:  ${r.phases.create.ms.toFixed(1)}ms  heap: ${fmtBytes(r.phases.create.mem.heap)}  ab: ${fmtBytes(r.phases.create.mem.ab)}`
+      );
+      console.log(
+        `    Ingest:  ${r.phases.ingest.ms.toFixed(1)}ms  ${fmtRate(r.phases.ingest.rate)} samples/s  heap: ${fmtBytes(r.phases.ingest.mem.heap)}  ab: ${fmtBytes(r.phases.ingest.mem.ab)}`
+      );
+      console.log(
+        `    Query:   ${r.phases.query.ms.toFixed(1)}ms  ${fmtRate(r.phases.query.rate)} samples/s  heap: ${fmtBytes(r.phases.query.mem.heap)}  ab: ${fmtBytes(r.phases.query.mem.ab)}`
+      );
       console.log(`    Store:   ${fmtBytes(r.storeMemory)}  (${r.bPerPt.toFixed(1)} B/pt)`);
-      console.log(`    Total:   rss=${fmtBytes(r.totalMem.rss)}  heap=${fmtBytes(r.totalMem.heap)}  ab=${fmtBytes(r.totalMem.ab)}`);
+      console.log(
+        `    Total:   rss=${fmtBytes(r.totalMem.rss)}  heap=${fmtBytes(r.totalMem.heap)}  ab=${fmtBytes(r.totalMem.ab)}`
+      );
     }
   }
 
@@ -563,17 +672,29 @@ async function main() {
 
   if (backends.length > 1) {
     console.log("\n  ── Phase timing breakdown (ms) ──\n");
-    console.log(`  ${"Backend".padEnd(28)} ${"Create".padStart(8)} ${"Ingest".padStart(8)} ${"Query".padStart(8)} ${"Total".padStart(8)}`);
-    console.log(`  ${"─".repeat(28)} ${"─".repeat(8)} ${"─".repeat(8)} ${"─".repeat(8)} ${"─".repeat(8)}`);
+    console.log(
+      `  ${"Backend".padEnd(28)} ${"Create".padStart(8)} ${"Ingest".padStart(8)} ${"Query".padStart(8)} ${"Total".padStart(8)}`
+    );
+    console.log(
+      `  ${"─".repeat(28)} ${"─".repeat(8)} ${"─".repeat(8)} ${"─".repeat(8)} ${"─".repeat(8)}`
+    );
     for (const r of backends) {
       const total = r.phases.create.ms + r.phases.ingest.ms + r.phases.query.ms;
-      console.log(`  ${r.name.padEnd(28)} ${r.phases.create.ms.toFixed(1).padStart(8)} ${r.phases.ingest.ms.toFixed(1).padStart(8)} ${r.phases.query.ms.toFixed(1).padStart(8)} ${total.toFixed(1).padStart(8)}`);
+      console.log(
+        `  ${r.name.padEnd(28)} ${r.phases.create.ms.toFixed(1).padStart(8)} ${r.phases.ingest.ms.toFixed(1).padStart(8)} ${r.phases.query.ms.toFixed(1).padStart(8)} ${total.toFixed(1).padStart(8)}`
+      );
     }
   }
 
   console.log("");
-  const anyFail = backends.some(r => !r.correct);
-  if (anyFail) { console.log("  CORRECTNESS FAILURE\n"); process.exit(1); }
+  const anyFail = backends.some((r) => !r.correct);
+  if (anyFail) {
+    console.log("  CORRECTNESS FAILURE\n");
+    process.exit(1);
+  }
 }
 
-main().catch(e => { console.error(e); process.exit(1); });
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/o11ytsdb/bench/query-sweep.mjs
+++ b/packages/o11ytsdb/bench/query-sweep.mjs
@@ -22,9 +22,9 @@
  */
 
 import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgDir = join(__dirname, "..");
@@ -35,8 +35,8 @@ const NUM_SERIES = 30;
 const POINTS_PER_SERIES = Math.ceil(5_000_000 / NUM_SERIES); // ~166,667
 const TOTAL_SAMPLES = NUM_SERIES * POINTS_PER_SERIES;
 const CHUNK_SIZE = 512;
-const T0 = 1_700_000_000_000n;           // epoch ms
-const INTERVAL = 15_000n;                 // 15s scrape interval
+const T0 = 1_700_000_000_000n; // epoch ms
+const INTERVAL = 15_000n; // 15s scrape interval
 const REGIONS = ["us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1", "eu-central-1"];
 
 const CHUNK_SPAN_MS = CHUNK_SIZE * Number(INTERVAL); // 7,680,000 ms = 128 min
@@ -47,16 +47,16 @@ const isQuick = args.includes("--quick");
 const filterIdx = args.indexOf("--filter");
 const filter = filterIdx >= 0 ? args[filterIdx + 1] : null;
 const WARMUP = isQuick ? 1 : 3;
-const RUNS   = isQuick ? 3 : 7;
+const RUNS = isQuick ? 3 : 7;
 
 // ── Sweep dimensions ─────────────────────────────────────────────────
 
 const STEPS = [
-  { name: "1min",  ms: 60_000n,      label: "60s"   },
-  { name: "5min",  ms: 300_000n,     label: "5m"    },
-  { name: "1h",    ms: 3_600_000n,   label: "1h"    },
-  { name: "6h",    ms: 21_600_000n,  label: "6h"    },
-  { name: "1d",    ms: 86_400_000n,  label: "1d"    },
+  { name: "1min", ms: 60_000n, label: "60s" },
+  { name: "5min", ms: 300_000n, label: "5m" },
+  { name: "1h", ms: 3_600_000n, label: "1h" },
+  { name: "6h", ms: 21_600_000n, label: "6h" },
+  { name: "1d", ms: 86_400_000n, label: "1d" },
 ];
 
 const AGG_FNS = ["min", "max", "sum", "avg", "count", "last"];
@@ -104,7 +104,9 @@ async function makeWasmCodecs() {
       const outCap = n * 20;
       const outPtr = w.allocScratch(outCap);
       mem().set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valPtr);
-      return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeValuesALP(valPtr, n, outPtr, outCap)));
+      return new Uint8Array(
+        w.memory.buffer.slice(outPtr, outPtr + w.encodeValuesALP(valPtr, n, outPtr, outCap))
+      );
     },
     decodeValues(buf) {
       w.resetScratch();
@@ -128,7 +130,16 @@ async function makeWasmCodecs() {
       const s = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + 64));
       return {
         compressed,
-        stats: { minV: s[0], maxV: s[1], sum: s[2], count: s[3], firstV: s[4], lastV: s[5], sumOfSquares: s[6], resetCount: s[7] },
+        stats: {
+          minV: s[0],
+          maxV: s[1],
+          sum: s[2],
+          count: s[3],
+          firstV: s[4],
+          lastV: s[5],
+          sumOfSquares: s[6],
+          resetCount: s[7],
+        },
       };
     },
     encodeBatchValuesWithStats(arrays) {
@@ -137,26 +148,48 @@ async function makeWasmCodecs() {
       w.resetScratch();
       const valsPtr = w.allocScratch(numArrays * chunkSize * 8);
       for (let i = 0; i < numArrays; i++) {
-        mem().set(new Uint8Array(arrays[i].buffer, arrays[i].byteOffset, arrays[i].byteLength), valsPtr + i * chunkSize * 8);
+        mem().set(
+          new Uint8Array(arrays[i].buffer, arrays[i].byteOffset, arrays[i].byteLength),
+          valsPtr + i * chunkSize * 8
+        );
       }
       const outCap = numArrays * chunkSize * 20;
       const outPtr = w.allocScratch(outCap);
       const offsetsPtr = w.allocScratch(numArrays * 4);
       const sizesPtr = w.allocScratch(numArrays * 4);
       const statsPtr = w.allocScratch(numArrays * 64);
-      w.encodeBatchValuesALPWithStats(valsPtr, chunkSize, numArrays, outPtr, outCap, offsetsPtr, sizesPtr, statsPtr);
-      const offsets = new Uint32Array(w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4));
+      w.encodeBatchValuesALPWithStats(
+        valsPtr,
+        chunkSize,
+        numArrays,
+        outPtr,
+        outCap,
+        offsetsPtr,
+        sizesPtr,
+        statsPtr
+      );
+      const offsets = new Uint32Array(
+        w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4)
+      );
       const sizes = new Uint32Array(w.memory.buffer.slice(sizesPtr, sizesPtr + numArrays * 4));
       const allStats = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + numArrays * 64));
       const results = [];
       for (let i = 0; i < numArrays; i++) {
-        const compressed = new Uint8Array(w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i]));
+        const compressed = new Uint8Array(
+          w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i])
+        );
         const si = i * 8;
         results.push({
           compressed,
           stats: {
-            minV: allStats[si], maxV: allStats[si+1], sum: allStats[si+2], count: allStats[si+3],
-            firstV: allStats[si+4], lastV: allStats[si+5], sumOfSquares: allStats[si+6], resetCount: allStats[si+7],
+            minV: allStats[si],
+            maxV: allStats[si + 1],
+            sum: allStats[si + 2],
+            count: allStats[si + 3],
+            firstV: allStats[si + 4],
+            lastV: allStats[si + 5],
+            sumOfSquares: allStats[si + 6],
+            resetCount: allStats[si + 7],
           },
         });
       }
@@ -172,8 +205,13 @@ async function makeWasmCodecs() {
       const tsPtr = w.allocScratch(n * 8);
       const outCap = n * 20;
       const outPtr = w.allocScratch(outCap);
-      mem().set(new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength), tsPtr);
-      return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeTimestamps(tsPtr, n, outPtr, outCap)));
+      mem().set(
+        new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength),
+        tsPtr
+      );
+      return new Uint8Array(
+        w.memory.buffer.slice(outPtr, outPtr + w.encodeTimestamps(tsPtr, n, outPtr, outCap))
+      );
     },
     decodeTimestamps(buf) {
       w.resetScratch();
@@ -197,11 +235,15 @@ async function makeWasmCodecs() {
       const outTsPtr = w.allocScratch(maxSamples * 8);
       const outValPtr = w.allocScratch(maxSamples * 8);
       const n = w.rangeDecodeALP(
-        tsInPtr, compressedTs.length,
-        valInPtr, compressedVals.length,
-        startT, endT,
-        outTsPtr, outValPtr,
-        maxSamples,
+        tsInPtr,
+        compressedTs.length,
+        valInPtr,
+        compressedVals.length,
+        startT,
+        endT,
+        outTsPtr,
+        outValPtr,
+        maxSamples
       );
       if (n === 0) return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
       return {
@@ -216,8 +258,10 @@ async function makeWasmCodecs() {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function fmtMs(n) { return n < 1 ? `${(n * 1000).toFixed(0)}µs` : `${n.toFixed(1)}ms`; }
-function fmtRate(n) {
+function _fmtMs(n) {
+  return n < 1 ? `${(n * 1000).toFixed(0)}µs` : `${n.toFixed(1)}ms`;
+}
+function _fmtRate(n) {
   if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M/s`;
   if (n >= 1e3) return `${(n / 1e3).toFixed(0)}K/s`;
   return `${n.toFixed(0)}/s`;
@@ -280,17 +324,32 @@ async function main() {
   const engine = new ScanEngine();
 
   console.log("  Ingesting into column-alp-fused store...");
-  const store = new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec);
-  const ids = data.map(d => store.getOrCreateSeries(d.labels));
+  const store = new ColumnStore(
+    alpValuesCodec,
+    CHUNK_SIZE,
+    () => 0,
+    undefined,
+    tsCodec,
+    alpRangeCodec
+  );
+  const ids = data.map((d) => store.getOrCreateSeries(d.labels));
   for (let s = 0; s < data.length; s++) {
     store.appendBatch(ids[s], data[s].timestamps, data[s].values);
   }
   const numChunksPerSeries = Math.ceil(POINTS_PER_SERIES / CHUNK_SIZE);
 
-  console.log(`\n  ${NUM_SERIES} series × ${POINTS_PER_SERIES.toLocaleString()} pts = ${TOTAL_SAMPLES.toLocaleString()} samples`);
-  console.log(`  Chunks: ${numChunksPerSeries}/series × ${NUM_SERIES} series = ${numChunksPerSeries * NUM_SERIES} total`);
-  console.log(`  Chunk span: ${(CHUNK_SPAN_MS / 60_000).toFixed(0)} min  |  Data span: ${(dataSpanMs / 86_400_000).toFixed(1)} days`);
-  console.log(`  Store: ${(store.memoryBytes() / 1024 / 1024).toFixed(1)} MB  (${(store.memoryBytes() / TOTAL_SAMPLES).toFixed(1)} B/pt)`);
+  console.log(
+    `\n  ${NUM_SERIES} series × ${POINTS_PER_SERIES.toLocaleString()} pts = ${TOTAL_SAMPLES.toLocaleString()} samples`
+  );
+  console.log(
+    `  Chunks: ${numChunksPerSeries}/series × ${NUM_SERIES} series = ${numChunksPerSeries * NUM_SERIES} total`
+  );
+  console.log(
+    `  Chunk span: ${(CHUNK_SPAN_MS / 60_000).toFixed(0)} min  |  Data span: ${(dataSpanMs / 86_400_000).toFixed(1)} days`
+  );
+  console.log(
+    `  Store: ${(store.memoryBytes() / 1024 / 1024).toFixed(1)} MB  (${(store.memoryBytes() / TOTAL_SAMPLES).toFixed(1)} B/pt)`
+  );
   console.log(`  Warmup: ${WARMUP}  Runs: ${RUNS}  ${filter ? `Filter: ${filter}` : ""}\n`);
 
   // ── Time ranges ──
@@ -302,8 +361,13 @@ async function main() {
   };
 
   const timeRanges = [
-    { name: "full", ...qFull,   pctLabel: "100%", expectedSamples: TOTAL_SAMPLES },
-    { name: "last10%", ...qLast10, pctLabel: "10%",  expectedSamples: Math.ceil(TOTAL_SAMPLES * 0.1) },
+    { name: "full", ...qFull, pctLabel: "100%", expectedSamples: TOTAL_SAMPLES },
+    {
+      name: "last10%",
+      ...qLast10,
+      pctLabel: "10%",
+      expectedSamples: Math.ceil(TOTAL_SAMPLES * 0.1),
+    },
   ];
 
   // ── Table header ──
@@ -359,9 +423,15 @@ async function main() {
         });
 
         const row = {
-          aggFn, step: step.name, range: range.name,
-          bucketCount, chunksPerBucket, statsSkipPossible,
-          ...stats, scanned, outputPts,
+          aggFn,
+          step: step.name,
+          range: range.name,
+          bucketCount,
+          chunksPerBucket,
+          statsSkipPossible,
+          ...stats,
+          scanned,
+          outputPts,
         };
         results.push(row);
 
@@ -399,20 +469,28 @@ async function main() {
   }
 
   // ChunkStats skip opportunity
-  const skipRows = results.filter(r => r.statsSkipPossible);
-  const noSkipRows = results.filter(r => !r.statsSkipPossible && CHUNK_STATS_ELIGIBLE.has(r.aggFn));
+  const skipRows = results.filter((r) => r.statsSkipPossible);
+  const noSkipRows = results.filter(
+    (r) => !r.statsSkipPossible && CHUNK_STATS_ELIGIBLE.has(r.aggFn)
+  );
   if (skipRows.length > 0 && noSkipRows.length > 0) {
     const skipMedian = skipRows.reduce((s, r) => s + r.median, 0) / skipRows.length;
     const noSkipMedian = noSkipRows.reduce((s, r) => s + r.median, 0) / noSkipRows.length;
     console.log(`  ChunkStats skip opportunity:`);
-    console.log(`    Eligible configs (chunk fits in 1 bucket):  ${skipRows.length} rows, avg median ${skipMedian.toFixed(1)}ms`);
-    console.log(`    Non-skip configs (chunk spans >1 bucket):   ${noSkipRows.length} rows, avg median ${noSkipMedian.toFixed(1)}ms`);
-    console.log(`    Potential savings: if stats-skip avoids decode for ${skipRows.length} configs,`);
+    console.log(
+      `    Eligible configs (chunk fits in 1 bucket):  ${skipRows.length} rows, avg median ${skipMedian.toFixed(1)}ms`
+    );
+    console.log(
+      `    Non-skip configs (chunk spans >1 bucket):   ${noSkipRows.length} rows, avg median ${noSkipMedian.toFixed(1)}ms`
+    );
+    console.log(
+      `    Potential savings: if stats-skip avoids decode for ${skipRows.length} configs,`
+    );
     console.log(`    read() phase (~50% of query time) could be largely eliminated\n`);
   }
 
   // Allocation pressure analysis
-  const fullRangeRows = results.filter(r => r.range === "full");
+  const fullRangeRows = results.filter((r) => r.range === "full");
   const avgHeap = fullRangeRows.reduce((s, r) => s + r.heapMedian, 0) / fullRangeRows.length;
   console.log(`  Allocation pressure (full-range queries):`);
   console.log(`    Average heap Δ per query: ${fmtBytes(avgHeap)}`);
@@ -421,10 +499,13 @@ async function main() {
   // Fastest/slowest per agg
   console.log(`  Per-agg median (full range, step=1min):`);
   for (const [agg, rows] of byAgg) {
-    const r = rows.find(r => r.step === "1min" && r.range === "full");
+    const r = rows.find((r) => r.step === "1min" && r.range === "full");
     if (r) console.log(`    ${agg.padEnd(6)} ${r.median.toFixed(1)}ms`);
   }
   console.log();
 }
 
-main().catch(e => { console.error(e); process.exit(1); });
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/o11ytsdb/bench/run.mjs
+++ b/packages/o11ytsdb/bench/run.mjs
@@ -13,33 +13,31 @@
  *   - JSON report to bench/results/{module}-{timestamp}.json
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const resultsDir = join(__dirname, 'results');
+const resultsDir = join(__dirname, "results");
 
 const args = process.argv.slice(2);
-const moduleFilter = args.find(a => !a.startsWith('--'));
-const compareFile = args.includes('--compare')
-  ? args[args.indexOf('--compare') + 1]
-  : undefined;
+const moduleFilter = args.find((a) => !a.startsWith("--"));
+const compareFile = args.includes("--compare") ? args[args.indexOf("--compare") + 1] : undefined;
 
 // Ensure results directory exists.
 if (!existsSync(resultsDir)) {
   mkdirSync(resultsDir, { recursive: true });
 }
 
-console.log('╔══════════════════════════════════════════════════════╗');
-console.log('║  o11ytsdb benchmark suite                           ║');
-console.log('╚══════════════════════════════════════════════════════╝');
+console.log("╔══════════════════════════════════════════════════════╗");
+console.log("║  o11ytsdb benchmark suite                           ║");
+console.log("╚══════════════════════════════════════════════════════╝");
 console.log();
 
 if (moduleFilter) {
   console.log(`  Filter: ${moduleFilter}`);
 } else {
-  console.log('  Running all modules');
+  console.log("  Running all modules");
 }
 console.log();
 
@@ -47,32 +45,32 @@ console.log();
 // Each value is a path to the compiled .js bench module in bench/dist/.
 // The module must export a default async function that returns a BenchReport.
 const modules = {
-  'codec': './dist/codec.bench.js',
-  'competitive': './dist/competitive.bench.js',
-  'engine': './dist/engine.bench.js',
-  'interner': './dist/interner.bench.js',
-  'postings': './dist/postings.bench.js',
-  'ingest': './dist/ingest.bench.js',
+  codec: "./dist/codec.bench.js",
+  competitive: "./dist/competitive.bench.js",
+  engine: "./dist/engine.bench.js",
+  interner: "./dist/interner.bench.js",
+  postings: "./dist/postings.bench.js",
+  ingest: "./dist/ingest.bench.js",
   // 'query': './dist/query.bench.js',
 };
 
 const available = Object.keys(modules);
 if (available.length === 0) {
-  console.log('  No benchmark modules registered yet.');
-  console.log('  Benchmarks will be added as each module passes its gate.');
+  console.log("  No benchmark modules registered yet.");
+  console.log("  Benchmarks will be added as each module passes its gate.");
   console.log();
-  console.log('  Harness is ready. Run `npm run bench:build` to compile bench files.');
+  console.log("  Harness is ready. Run `npm run bench:build` to compile bench files.");
   console.log();
-  console.log('  To add a benchmark module:');
-  console.log('    1. Create bench/<module>.bench.ts');
+  console.log("  To add a benchmark module:");
+  console.log("    1. Create bench/<module>.bench.ts");
   console.log('    2. Import { bench, runAll, printReport } from "./harness.js"');
-  console.log('    3. Register with `export default async function() { ... }`');
-  console.log('    4. Uncomment the entry in bench/run.mjs modules map');
+  console.log("    3. Register with `export default async function() { ... }`");
+  console.log("    4. Uncomment the entry in bench/run.mjs modules map");
   process.exit(0);
 }
 
 // Run each matching module.
-const { compareReports } = await import('./dist/harness.js');
+const { compareReports } = await import("./dist/harness.js");
 const allReports = [];
 
 for (const [name, path] of Object.entries(modules)) {
@@ -97,7 +95,7 @@ for (const [name, path] of Object.entries(modules)) {
 if (compareFile && allReports.length > 0) {
   console.log(`\n  ─── Comparison against ${compareFile} ───\n`);
   try {
-    const baseline = JSON.parse(readFileSync(compareFile, 'utf-8'));
+    const baseline = JSON.parse(readFileSync(compareFile, "utf-8"));
     for (const report of allReports) {
       const { passed, regressions } = compareReports(baseline, report);
       if (passed) {

--- a/packages/o11ytsdb/bench/smoke.mjs
+++ b/packages/o11ytsdb/bench/smoke.mjs
@@ -7,13 +7,13 @@
  * Target runtime: <2 seconds.
  */
 
-import { readFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { performance } from 'node:perf_hooks';
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const pkgDir = join(__dirname, '..');
+const pkgDir = join(__dirname, "..");
 
 // ── Config ───────────────────────────────────────────────────────────
 
@@ -34,7 +34,10 @@ function generateData() {
       timestamps[i] = T0 + BigInt(i) * INTERVAL;
       values[i] = Math.sin(i * 0.1) * 100 + s * 10;
     }
-    const labels = new Map([['__name__', `metric_${s}`], ['job', 'test']]);
+    const labels = new Map([
+      ["__name__", `metric_${s}`],
+      ["job", "test"],
+    ]);
     series.push({ labels, timestamps, values });
   }
   return series;
@@ -43,7 +46,7 @@ function generateData() {
 // ── WASM loader ──────────────────────────────────────────────────────
 
 async function loadWasmCodecs() {
-  const wasmPath = join(pkgDir, 'wasm/o11ytsdb-rust.wasm');
+  const wasmPath = join(pkgDir, "wasm/o11ytsdb-rust.wasm");
   const wasmBytes = readFileSync(wasmPath);
   const { instance } = await WebAssembly.instantiate(wasmBytes, { env: {} });
   const w = instance.exports;
@@ -51,7 +54,7 @@ async function loadWasmCodecs() {
   const mem = () => new Uint8Array(w.memory.buffer);
 
   const valuesCodec = {
-    name: 'rust-wasm',
+    name: "rust-wasm",
     encodeValues(values) {
       const n = values.length;
       w.resetScratch();
@@ -84,7 +87,16 @@ async function loadWasmCodecs() {
       const s = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + 64));
       return {
         compressed,
-        stats: { minV: s[0], maxV: s[1], sum: s[2], count: s[3], firstV: s[4], lastV: s[5], sumOfSquares: s[6], resetCount: s[7] },
+        stats: {
+          minV: s[0],
+          maxV: s[1],
+          sum: s[2],
+          count: s[3],
+          firstV: s[4],
+          lastV: s[5],
+          sumOfSquares: s[6],
+          resetCount: s[7],
+        },
       };
     },
     encodeBatchValuesWithStats(arrays) {
@@ -94,26 +106,48 @@ async function loadWasmCodecs() {
       const valsPtr = w.allocScratch(numArrays * chunkSize * 8);
       for (let i = 0; i < numArrays; i++) {
         const arr = arrays[i];
-        mem().set(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength), valsPtr + i * chunkSize * 8);
+        mem().set(
+          new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength),
+          valsPtr + i * chunkSize * 8
+        );
       }
       const outCap = numArrays * chunkSize * 20;
       const outPtr = w.allocScratch(outCap);
       const offsetsPtr = w.allocScratch(numArrays * 4);
       const sizesPtr = w.allocScratch(numArrays * 4);
       const statsPtr = w.allocScratch(numArrays * 64);
-      w.encodeBatchValuesWithStats(valsPtr, chunkSize, numArrays, outPtr, outCap, offsetsPtr, sizesPtr, statsPtr);
-      const offsets = new Uint32Array(w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4));
+      w.encodeBatchValuesWithStats(
+        valsPtr,
+        chunkSize,
+        numArrays,
+        outPtr,
+        outCap,
+        offsetsPtr,
+        sizesPtr,
+        statsPtr
+      );
+      const offsets = new Uint32Array(
+        w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4)
+      );
       const sizes = new Uint32Array(w.memory.buffer.slice(sizesPtr, sizesPtr + numArrays * 4));
       const allStats = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + numArrays * 64));
       const results = [];
       for (let i = 0; i < numArrays; i++) {
-        const compressed = new Uint8Array(w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i]));
+        const compressed = new Uint8Array(
+          w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i])
+        );
         const si = i * 8;
         results.push({
           compressed,
           stats: {
-            minV: allStats[si], maxV: allStats[si+1], sum: allStats[si+2], count: allStats[si+3],
-            firstV: allStats[si+4], lastV: allStats[si+5], sumOfSquares: allStats[si+6], resetCount: allStats[si+7],
+            minV: allStats[si],
+            maxV: allStats[si + 1],
+            sum: allStats[si + 2],
+            count: allStats[si + 3],
+            firstV: allStats[si + 4],
+            lastV: allStats[si + 5],
+            sumOfSquares: allStats[si + 6],
+            resetCount: allStats[si + 7],
           },
         });
       }
@@ -122,14 +156,17 @@ async function loadWasmCodecs() {
   };
 
   const tsCodec = {
-    name: 'rust-wasm-ts',
+    name: "rust-wasm-ts",
     encodeTimestamps(timestamps) {
       const n = timestamps.length;
       w.resetScratch();
       const tsPtr = w.allocScratch(n * 8);
       const outCap = n * 20;
       const outPtr = w.allocScratch(outCap);
-      mem().set(new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength), tsPtr);
+      mem().set(
+        new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength),
+        tsPtr
+      );
       const bytesWritten = w.encodeTimestamps(tsPtr, n, outPtr, outCap);
       return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + bytesWritten));
     },
@@ -145,7 +182,7 @@ async function loadWasmCodecs() {
   };
 
   const alpValuesCodec = {
-    name: 'rust-wasm-alp',
+    name: "rust-wasm-alp",
     encodeValues(values) {
       const n = values.length;
       w.resetScratch();
@@ -178,7 +215,16 @@ async function loadWasmCodecs() {
       const s = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + 64));
       return {
         compressed,
-        stats: { minV: s[0], maxV: s[1], sum: s[2], count: s[3], firstV: s[4], lastV: s[5], sumOfSquares: s[6], resetCount: s[7] },
+        stats: {
+          minV: s[0],
+          maxV: s[1],
+          sum: s[2],
+          count: s[3],
+          firstV: s[4],
+          lastV: s[5],
+          sumOfSquares: s[6],
+          resetCount: s[7],
+        },
       };
     },
     encodeBatchValuesWithStats(arrays) {
@@ -188,7 +234,10 @@ async function loadWasmCodecs() {
       const valsPtr = w.allocScratch(numArrays * chunkSize * 8);
       for (let i = 0; i < numArrays; i++) {
         const arr = arrays[i];
-        mem().set(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength), valsPtr + i * chunkSize * 8);
+        mem().set(
+          new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength),
+          valsPtr + i * chunkSize * 8
+        );
       }
       const outCap = numArrays * chunkSize * 20;
       const outPtr = w.allocScratch(outCap);
@@ -196,20 +245,37 @@ async function loadWasmCodecs() {
       const sizesPtr = w.allocScratch(numArrays * 4);
       const statsPtr = w.allocScratch(numArrays * 64);
       w.encodeBatchValuesALPWithStats(
-        valsPtr, chunkSize, numArrays, outPtr, outCap, offsetsPtr, sizesPtr, statsPtr
+        valsPtr,
+        chunkSize,
+        numArrays,
+        outPtr,
+        outCap,
+        offsetsPtr,
+        sizesPtr,
+        statsPtr
       );
-      const offsets = new Uint32Array(w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4));
+      const offsets = new Uint32Array(
+        w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4)
+      );
       const sizes = new Uint32Array(w.memory.buffer.slice(sizesPtr, sizesPtr + numArrays * 4));
       const allStats = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + numArrays * 64));
       const results = [];
       for (let i = 0; i < numArrays; i++) {
-        const compressed = new Uint8Array(w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i]));
+        const compressed = new Uint8Array(
+          w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i])
+        );
         const si = i * 8;
         results.push({
           compressed,
           stats: {
-            minV: allStats[si], maxV: allStats[si+1], sum: allStats[si+2], count: allStats[si+3],
-            firstV: allStats[si+4], lastV: allStats[si+5], sumOfSquares: allStats[si+6], resetCount: allStats[si+7],
+            minV: allStats[si],
+            maxV: allStats[si + 1],
+            sum: allStats[si + 2],
+            count: allStats[si + 3],
+            firstV: allStats[si + 4],
+            lastV: allStats[si + 5],
+            sumOfSquares: allStats[si + 6],
+            resetCount: allStats[si + 7],
           },
         });
       }
@@ -228,11 +294,15 @@ async function loadWasmCodecs() {
       const outTsPtr = w.allocScratch(maxSamples * 8);
       const outValPtr = w.allocScratch(maxSamples * 8);
       const n = w.rangeDecodeALP(
-        tsInPtr, compressedTs.length,
-        valInPtr, compressedVals.length,
-        startT, endT,
-        outTsPtr, outValPtr,
-        maxSamples,
+        tsInPtr,
+        compressedTs.length,
+        valInPtr,
+        compressedVals.length,
+        startT,
+        endT,
+        outTsPtr,
+        outValPtr,
+        maxSamples
       );
       if (n === 0) {
         return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
@@ -259,7 +329,7 @@ function testBackend(name, store, data) {
   }
   const ingestMs = performance.now() - t0;
   const totalSamples = NUM_SERIES * POINTS_PER_SERIES;
-  const ingestRate = (totalSamples / ingestMs * 1000).toFixed(0);
+  const ingestRate = ((totalSamples / ingestMs) * 1000).toFixed(0);
   const memKB = (store.memoryBytes() / 1024).toFixed(1);
   const bPerPt = (store.memoryBytes() / totalSamples).toFixed(1);
 
@@ -273,13 +343,21 @@ function testBackend(name, store, data) {
   let ok = result.timestamps.length === POINTS_PER_SERIES;
   if (ok) {
     for (let i = 0; i < POINTS_PER_SERIES; i++) {
-      if (result.timestamps[i] !== expected.timestamps[i]) { ok = false; break; }
-      if (Math.abs(result.values[i] - expected.values[i]) > 1e-10) { ok = false; break; }
+      if (result.timestamps[i] !== expected.timestamps[i]) {
+        ok = false;
+        break;
+      }
+      if (Math.abs(result.values[i] - expected.values[i]) > 1e-10) {
+        ok = false;
+        break;
+      }
     }
   }
 
-  const status = ok ? '✓' : '✗ FAIL';
-  console.log(`  ${name.padEnd(30)} ${ingestRate.padStart(8)} samples/s  ${memKB.padStart(7)} KB  ${bPerPt.padStart(5)} B/pt  ${status}`);
+  const status = ok ? "✓" : "✗ FAIL";
+  console.log(
+    `  ${name.padEnd(30)} ${ingestRate.padStart(8)} samples/s  ${memKB.padStart(7)} KB  ${bPerPt.padStart(5)} B/pt  ${status}`
+  );
   return ok;
 }
 
@@ -289,30 +367,36 @@ async function main() {
   const data = generateData();
   const { valuesCodec, alpValuesCodec, tsCodec, alpRangeCodec } = await loadWasmCodecs();
 
-  console.log(`\n  Smoke test: ${NUM_SERIES} series × ${POINTS_PER_SERIES} pts (chunk=${CHUNK_SIZE})\n`);
-  console.log(`  ${'Backend'.padEnd(30)} ${'Ingest'.padStart(8)}          ${'Mem'.padStart(7)}     ${'Eff'.padStart(5)}    OK?`);
-  console.log(`  ${'─'.repeat(30)} ${'─'.repeat(8)}          ${'─'.repeat(7)}     ${'─'.repeat(5)}    ${'─'.repeat(6)}`);
+  console.log(
+    `\n  Smoke test: ${NUM_SERIES} series × ${POINTS_PER_SERIES} pts (chunk=${CHUNK_SIZE})\n`
+  );
+  console.log(
+    `  ${"Backend".padEnd(30)} ${"Ingest".padStart(8)}          ${"Mem".padStart(7)}     ${"Eff".padStart(5)}    OK?`
+  );
+  console.log(
+    `  ${"─".repeat(30)} ${"─".repeat(8)}          ${"─".repeat(7)}     ${"─".repeat(5)}    ${"─".repeat(6)}`
+  );
 
   let allOk = true;
 
   // FlatStore.
   {
-    const { FlatStore } = await import(join(pkgDir, 'dist/flat-store.js'));
-    allOk = testBackend('flat', new FlatStore(), data) && allOk;
+    const { FlatStore } = await import(join(pkgDir, "dist/flat-store.js"));
+    allOk = testBackend("flat", new FlatStore(), data) && allOk;
   }
 
   // ChunkedStore + WASM.
   {
-    const { ChunkedStore } = await import(join(pkgDir, 'dist/chunked-store.js'));
-    const { encodeChunk, decodeChunk } = await import(join(pkgDir, 'dist/codec.js'));
+    const { ChunkedStore } = await import(join(pkgDir, "dist/chunked-store.js"));
+    const { encodeChunk, decodeChunk } = await import(join(pkgDir, "dist/codec.js"));
     // Use WASM codec via the wasm-loader.
-    const wasmPath = join(pkgDir, 'wasm/o11ytsdb-rust.wasm');
+    const wasmPath = join(pkgDir, "wasm/o11ytsdb-rust.wasm");
     const wasmBytes = readFileSync(wasmPath);
     const { instance } = await WebAssembly.instantiate(wasmBytes, { env: {} });
     const w = instance.exports;
     const mem = () => new Uint8Array(w.memory.buffer);
     const codec = {
-      name: 'rust-wasm',
+      name: "rust-wasm",
       encode(timestamps, values) {
         const n = timestamps.length;
         w.resetScratch();
@@ -321,9 +405,14 @@ async function main() {
         const outCap = n * 20;
         const outPtr = w.allocScratch(outCap);
         const m = mem();
-        m.set(new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength), tsPtr);
+        m.set(
+          new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength),
+          tsPtr
+        );
         m.set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valPtr);
-        return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeChunk(tsPtr, valPtr, n, outPtr, outCap)));
+        return new Uint8Array(
+          w.memory.buffer.slice(outPtr, outPtr + w.encodeChunk(tsPtr, valPtr, n, outPtr, outCap))
+        );
       },
       decode(buf) {
         w.resetScratch();
@@ -339,34 +428,53 @@ async function main() {
         };
       },
     };
-    allOk = testBackend('chunked-rust-wasm-128', new ChunkedStore(codec, CHUNK_SIZE), data) && allOk;
+    allOk =
+      testBackend("chunked-rust-wasm-128", new ChunkedStore(codec, CHUNK_SIZE), data) && allOk;
   }
 
   // ColumnStore + XOR values + WASM timestamps.
   {
-    const { ColumnStore } = await import(join(pkgDir, 'dist/column-store.js'));
-    allOk = testBackend('column-xor-full-128', new ColumnStore(valuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec), data) && allOk;
+    const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+    allOk =
+      testBackend(
+        "column-xor-full-128",
+        new ColumnStore(valuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec),
+        data
+      ) && allOk;
   }
 
   // ColumnStore + ALP values + WASM timestamps.
   {
-    const { ColumnStore } = await import(join(pkgDir, 'dist/column-store.js'));
-    allOk = testBackend('column-alp-full-128', new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec), data) && allOk;
+    const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+    allOk =
+      testBackend(
+        "column-alp-full-128",
+        new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec),
+        data
+      ) && allOk;
   }
 
   // ColumnStore + ALP fused range-decode.
   {
-    const { ColumnStore } = await import(join(pkgDir, 'dist/column-store.js'));
-    allOk = testBackend('column-alp-fused-128', new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec), data) && allOk;
+    const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+    allOk =
+      testBackend(
+        "column-alp-fused-128",
+        new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec),
+        data
+      ) && allOk;
   }
 
-  console.log('');
+  console.log("");
   if (allOk) {
-    console.log('  All backends passed ✓\n');
+    console.log("  All backends passed ✓\n");
   } else {
-    console.log('  SOME BACKENDS FAILED ✗\n');
+    console.log("  SOME BACKENDS FAILED ✗\n");
     process.exit(1);
   }
 }
 
-main().catch(e => { console.error(e); process.exit(1); });
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/o11ytsdb/bench/split-otel.mjs
+++ b/packages/o11ytsdb/bench/split-otel.mjs
@@ -11,8 +11,8 @@
  *   bench/data/infra.jsonl     — everything else (disk/mem/net/fs/paging/load)
  */
 import { createReadStream, createWriteStream } from "node:fs";
+import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
-import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -64,13 +64,15 @@ for await (const line of rl) {
     for (const [cat, scopeMetrics] of Object.entries(catMetrics)) {
       if (scopeMetrics.length === 0) continue;
       const out = {
-        resourceMetrics: [{
-          resource: rm.resource,
-          scopeMetrics,
-          schemaUrl: "https://opentelemetry.io/schemas/1.9.0",
-        }],
+        resourceMetrics: [
+          {
+            resource: rm.resource,
+            scopeMetrics,
+            schemaUrl: "https://opentelemetry.io/schemas/1.9.0",
+          },
+        ],
       };
-      writers[cat].write(JSON.stringify(out) + "\n");
+      writers[cat].write(`${JSON.stringify(out)}\n`);
       stats[cat]++;
     }
   }

--- a/packages/o11ytsdb/bench/sweep.mjs
+++ b/packages/o11ytsdb/bench/sweep.mjs
@@ -8,9 +8,9 @@
  */
 
 import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgDir = join(__dirname, "..");
@@ -23,12 +23,14 @@ const T0 = 1_700_000_000_000n;
 const INTERVAL = 15_000n;
 const TOTAL = NUM_SERIES * POINTS_PER_SERIES; // 1M
 
-const CHUNK_SIZES = [64, 128, 192, 256, 320, 384, 448, 512, 576, 640, 704, 768, 832, 896, 960, 1024];
+const CHUNK_SIZES = [
+  64, 128, 192, 256, 320, 384, 448, 512, 576, 640, 704, 768, 832, 896, 960, 1024,
+];
 
 // Narrow query: last 10% of the time range.
 const FULL_START = T0;
 const FULL_END = T0 + BigInt(POINTS_PER_SERIES) * INTERVAL;
-const NARROW_START = T0 + BigInt(POINTS_PER_SERIES) * INTERVAL * 9n / 10n;
+const NARROW_START = T0 + (BigInt(POINTS_PER_SERIES) * INTERVAL * 9n) / 10n;
 const NARROW_END = FULL_END;
 
 // ── Data generation ──────────────────────────────────────────────────
@@ -98,7 +100,16 @@ async function loadCodecs() {
       const s = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + 64));
       return {
         compressed,
-        stats: { minV: s[0], maxV: s[1], sum: s[2], count: s[3], firstV: s[4], lastV: s[5], sumOfSquares: s[6], resetCount: s[7] },
+        stats: {
+          minV: s[0],
+          maxV: s[1],
+          sum: s[2],
+          count: s[3],
+          firstV: s[4],
+          lastV: s[5],
+          sumOfSquares: s[6],
+          resetCount: s[7],
+        },
       };
     },
     encodeBatchValuesWithStats(arrays) {
@@ -108,7 +119,10 @@ async function loadCodecs() {
       const valsPtr = w.allocScratch(numArrays * chunkSize * 8);
       for (let i = 0; i < numArrays; i++) {
         const arr = arrays[i];
-        mem().set(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength), valsPtr + i * chunkSize * 8);
+        mem().set(
+          new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength),
+          valsPtr + i * chunkSize * 8
+        );
       }
       const outCap = numArrays * chunkSize * 20;
       const outPtr = w.allocScratch(outCap);
@@ -116,20 +130,37 @@ async function loadCodecs() {
       const sizesPtr = w.allocScratch(numArrays * 4);
       const statsPtr = w.allocScratch(numArrays * 64);
       w.encodeBatchValuesALPWithStats(
-        valsPtr, chunkSize, numArrays, outPtr, outCap, offsetsPtr, sizesPtr, statsPtr
+        valsPtr,
+        chunkSize,
+        numArrays,
+        outPtr,
+        outCap,
+        offsetsPtr,
+        sizesPtr,
+        statsPtr
       );
-      const offsets = new Uint32Array(w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4));
+      const offsets = new Uint32Array(
+        w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4)
+      );
       const sizes = new Uint32Array(w.memory.buffer.slice(sizesPtr, sizesPtr + numArrays * 4));
       const allStats = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + numArrays * 64));
       const results = [];
       for (let i = 0; i < numArrays; i++) {
-        const compressed = new Uint8Array(w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i]));
+        const compressed = new Uint8Array(
+          w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i])
+        );
         const si = i * 8;
         results.push({
           compressed,
           stats: {
-            minV: allStats[si], maxV: allStats[si+1], sum: allStats[si+2], count: allStats[si+3],
-            firstV: allStats[si+4], lastV: allStats[si+5], sumOfSquares: allStats[si+6], resetCount: allStats[si+7],
+            minV: allStats[si],
+            maxV: allStats[si + 1],
+            sum: allStats[si + 2],
+            count: allStats[si + 3],
+            firstV: allStats[si + 4],
+            lastV: allStats[si + 5],
+            sumOfSquares: allStats[si + 6],
+            resetCount: allStats[si + 7],
           },
         });
       }
@@ -145,7 +176,10 @@ async function loadCodecs() {
       const tsPtr = w.allocScratch(n * 8);
       const outCap = n * 20;
       const outPtr = w.allocScratch(outCap);
-      mem().set(new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength), tsPtr);
+      mem().set(
+        new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength),
+        tsPtr
+      );
       const bytesWritten = w.encodeTimestamps(tsPtr, n, outPtr, outCap);
       return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + bytesWritten));
     },
@@ -171,11 +205,15 @@ async function loadCodecs() {
       const outTsPtr = w.allocScratch(maxSamples * 8);
       const outValPtr = w.allocScratch(maxSamples * 8);
       const n = w.rangeDecodeALP(
-        tsInPtr, compressedTs.length,
-        valInPtr, compressedVals.length,
-        startT, endT,
-        outTsPtr, outValPtr,
-        maxSamples,
+        tsInPtr,
+        compressedTs.length,
+        valInPtr,
+        compressedVals.length,
+        startT,
+        endT,
+        outTsPtr,
+        outValPtr,
+        maxSamples
       );
       if (n === 0) return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
       return {
@@ -196,7 +234,9 @@ function fmtRate(n) {
   return `${n.toFixed(0)}`;
 }
 
-function fmtMs(n) { return n.toFixed(1); }
+function fmtMs(n) {
+  return n.toFixed(1);
+}
 
 // ── Run one configuration ────────────────────────────────────────────
 
@@ -249,17 +289,25 @@ async function runConfig(chunkSize, data, codecs, useFused, makeGrouper, totalPt
   let ok = r0.timestamps.length === expectedLen;
   if (!ok && !runConfig._diagShown) {
     runConfig._diagShown = true;
-    console.log(`  [DIAG] chunk=${chunkSize} fused=${useFused}: expected ${expectedLen} pts, got ${r0.timestamps.length}`);
+    console.log(
+      `  [DIAG] chunk=${chunkSize} fused=${useFused}: expected ${expectedLen} pts, got ${r0.timestamps.length}`
+    );
     console.log(`         query=[${qFullStart}, ${qFullEnd}]`);
-    console.log(`         series0 range=[${data[0].timestamps[0]}, ${data[0].timestamps[data[0].timestamps.length - 1]}]`);
+    console.log(
+      `         series0 range=[${data[0].timestamps[0]}, ${data[0].timestamps[data[0].timestamps.length - 1]}]`
+    );
     if (r0.timestamps.length > 0) {
-      console.log(`         result range=[${r0.timestamps[0]}, ${r0.timestamps[r0.timestamps.length - 1]}]`);
+      console.log(
+        `         result range=[${r0.timestamps[0]}, ${r0.timestamps[r0.timestamps.length - 1]}]`
+      );
     }
   }
   if (ok) {
     for (let i = 0; i < expectedLen; i++) {
-      if (r0.timestamps[i] !== data[0].timestamps[i] ||
-          Math.abs(r0.values[i] - data[0].values[i]) > 1e-10) {
+      if (
+        r0.timestamps[i] !== data[0].timestamps[i] ||
+        Math.abs(r0.values[i] - data[0].values[i]) > 1e-10
+      ) {
         ok = false;
         break;
       }
@@ -270,11 +318,11 @@ async function runConfig(chunkSize, data, codecs, useFused, makeGrouper, totalPt
     chunkSize,
     fused: useFused,
     ingestMs,
-    ingestRate: totalPts / ingestMs * 1000,
+    ingestRate: (totalPts / ingestMs) * 1000,
     fullMs,
-    fullRate: fullRead / fullMs * 1000,
+    fullRate: (fullRead / fullMs) * 1000,
     narrowMs,
-    narrowRate: narrowRead / narrowMs * 1000,
+    narrowRate: (narrowRead / narrowMs) * 1000,
     bPerPt: store.memoryBytes() / totalPts,
     correct: ok,
     fullRead,
@@ -302,13 +350,14 @@ async function main() {
     let maxT = data[0].timestamps[data[0].timestamps.length - 1];
     for (const d of data) {
       if (d.timestamps[0] < minT) minT = d.timestamps[0];
-      if (d.timestamps[d.timestamps.length - 1] > maxT) maxT = d.timestamps[d.timestamps.length - 1];
+      if (d.timestamps[d.timestamps.length - 1] > maxT)
+        maxT = d.timestamps[d.timestamps.length - 1];
     }
     const range = maxT - minT;
     queryRange = {
       fullStart: minT,
       fullEnd: maxT,
-      narrowStart: minT + range * 9n / 10n,
+      narrowStart: minT + (range * 9n) / 10n,
       narrowEnd: maxT,
     };
     // Group by metric name + series length (series must share timestamps to share a group).
@@ -328,7 +377,9 @@ async function main() {
       let idx = 0;
       return (_labels) => seriesGroupIds[idx++];
     };
-    console.log(`\n  Chunk-size sweep (OTel ${dataset}): ${data.length} series, ${totalPts.toLocaleString()} pts${repeat > 1 ? ` (×${repeat})` : ""}`);
+    console.log(
+      `\n  Chunk-size sweep (OTel ${dataset}): ${data.length} series, ${totalPts.toLocaleString()} pts${repeat > 1 ? ` (×${repeat})` : ""}`
+    );
   } else {
     data = generateData();
     totalPts = TOTAL;
@@ -339,7 +390,9 @@ async function main() {
       narrowEnd: NARROW_END,
     };
     makeGrouper = () => () => 0;
-    console.log(`\n  Chunk-size sweep: ${NUM_SERIES} series × ${POINTS_PER_SERIES.toLocaleString()} pts = ${TOTAL.toLocaleString()} samples`);
+    console.log(
+      `\n  Chunk-size sweep: ${NUM_SERIES} series × ${POINTS_PER_SERIES.toLocaleString()} pts = ${TOTAL.toLocaleString()} samples`
+    );
   }
   console.log(`  Narrow query: last 10% of range\n`);
 
@@ -360,9 +413,15 @@ async function main() {
 
   // ── Table output ──
 
-  console.log("  ┌───────┬───────┬──────────┬──────────┬──────────┬──────────┬──────────┬───────┬────┐");
-  console.log("  │ Chunk │ Fused │  Ingest  │  Full Q  │ Full ms  │ Narrow Q │ Narrw ms │ B/pt  │ OK │");
-  console.log("  ├───────┼───────┼──────────┼──────────┼──────────┼──────────┼──────────┼───────┼────┤");
+  console.log(
+    "  ┌───────┬───────┬──────────┬──────────┬──────────┬──────────┬──────────┬───────┬────┐"
+  );
+  console.log(
+    "  │ Chunk │ Fused │  Ingest  │  Full Q  │ Full ms  │ Narrow Q │ Narrw ms │ B/pt  │ OK │"
+  );
+  console.log(
+    "  ├───────┼───────┼──────────┼──────────┼──────────┼──────────┼──────────┼───────┼────┤"
+  );
 
   for (const r of results) {
     const cs = String(r.chunkSize).padStart(5);
@@ -374,29 +433,46 @@ async function main() {
     const narrowMs = `${fmtMs(r.narrowMs)}`.padStart(8);
     const bpt = `${r.bPerPt.toFixed(1)}`.padStart(5);
     const ok = r.correct ? "✓" : "✗";
-    console.log(`  │ ${cs} │ ${fused} │ ${ingest} │ ${fullQ} │ ${fullMs} │ ${narrowQ} │ ${narrowMs} │ ${bpt} │ ${ok}  │`);
+    console.log(
+      `  │ ${cs} │ ${fused} │ ${ingest} │ ${fullQ} │ ${fullMs} │ ${narrowQ} │ ${narrowMs} │ ${bpt} │ ${ok}  │`
+    );
   }
-  console.log("  └───────┴───────┴──────────┴──────────┴──────────┴──────────┴──────────┴───────┴────┘");
+  console.log(
+    "  └───────┴───────┴──────────┴──────────┴──────────┴──────────┴──────────┴───────┴────┘"
+  );
 
   // Summary — best configs.
-  const correct = results.filter(r => r.correct);
+  const correct = results.filter((r) => r.correct);
   if (correct.length > 0) {
-    const bestFull = correct.reduce((a, b) => a.fullRate > b.fullRate ? a : b);
-    const bestNarrow = correct.reduce((a, b) => a.narrowRate > b.narrowRate ? a : b);
-    const bestIngest = correct.reduce((a, b) => a.ingestRate > b.ingestRate ? a : b);
-    const bestCompress = correct.reduce((a, b) => a.bPerPt < b.bPerPt ? a : b);
-    console.log(`\n  Best full-range query:   chunk=${bestFull.chunkSize} fused=${bestFull.fused} → ${fmtRate(bestFull.fullRate)}/s (${fmtMs(bestFull.fullMs)}ms)`);
-    console.log(`  Best narrow query:       chunk=${bestNarrow.chunkSize} fused=${bestNarrow.fused} → ${fmtRate(bestNarrow.narrowRate)}/s (${fmtMs(bestNarrow.narrowMs)}ms)`);
-    console.log(`  Best ingest:             chunk=${bestIngest.chunkSize} fused=${bestIngest.fused} → ${fmtRate(bestIngest.ingestRate)}/s`);
-    console.log(`  Best compression:        chunk=${bestCompress.chunkSize} → ${bestCompress.bPerPt.toFixed(1)} B/pt`);
+    const bestFull = correct.reduce((a, b) => (a.fullRate > b.fullRate ? a : b));
+    const bestNarrow = correct.reduce((a, b) => (a.narrowRate > b.narrowRate ? a : b));
+    const bestIngest = correct.reduce((a, b) => (a.ingestRate > b.ingestRate ? a : b));
+    const bestCompress = correct.reduce((a, b) => (a.bPerPt < b.bPerPt ? a : b));
+    console.log(
+      `\n  Best full-range query:   chunk=${bestFull.chunkSize} fused=${bestFull.fused} → ${fmtRate(bestFull.fullRate)}/s (${fmtMs(bestFull.fullMs)}ms)`
+    );
+    console.log(
+      `  Best narrow query:       chunk=${bestNarrow.chunkSize} fused=${bestNarrow.fused} → ${fmtRate(bestNarrow.narrowRate)}/s (${fmtMs(bestNarrow.narrowMs)}ms)`
+    );
+    console.log(
+      `  Best ingest:             chunk=${bestIngest.chunkSize} fused=${bestIngest.fused} → ${fmtRate(bestIngest.ingestRate)}/s`
+    );
+    console.log(
+      `  Best compression:        chunk=${bestCompress.chunkSize} → ${bestCompress.bPerPt.toFixed(1)} B/pt`
+    );
   }
 
-  const failures = results.filter(r => !r.correct);
+  const failures = results.filter((r) => !r.correct);
   if (failures.length > 0) {
-    console.log(`\n  ⚠ CORRECTNESS FAILURES: ${failures.map(r => `chunk=${r.chunkSize} fused=${r.fused}`).join(", ")}`);
+    console.log(
+      `\n  ⚠ CORRECTNESS FAILURES: ${failures.map((r) => `chunk=${r.chunkSize} fused=${r.fused}`).join(", ")}`
+    );
   }
 
   console.log();
 }
 
-main().catch(e => { console.error(e); process.exit(1); });
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/o11ytsdb/bench/test-xor-exceptions.mjs
+++ b/packages/o11ytsdb/bench/test-xor-exceptions.mjs
@@ -3,14 +3,14 @@
  * Test XOR-delta exception encoding on high-precision float data
  * that produces 100% ALP exceptions (like cpu.utilization).
  */
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const pkgDir = join(__dirname, '..');
+const pkgDir = join(__dirname, "..");
 
-const { loadWasm, makeALPValuesCodec } = await import(join(__dirname, 'dist', 'wasm-loader.js'));
-const wasm = await loadWasm(join(pkgDir, 'wasm/o11ytsdb-rust.wasm'));
+const { loadWasm, makeALPValuesCodec } = await import(join(__dirname, "dist", "wasm-loader.js"));
+const wasm = await loadWasm(join(pkgDir, "wasm/o11ytsdb-rust.wasm"));
 const alp = makeALPValuesCodec(wasm);
 
 const N = 640;
@@ -61,22 +61,24 @@ function random(n) {
 }
 
 const patterns = [
-  { name: 'cpu.utilization', gen: cpuUtilization },
-  { name: 'memory.utilization', gen: memUtilization },
-  { name: 'fs.utilization', gen: fsUtilization },
-  { name: 'random (worst case)', gen: random },
+  { name: "cpu.utilization", gen: cpuUtilization },
+  { name: "memory.utilization", gen: memUtilization },
+  { name: "fs.utilization", gen: fsUtilization },
+  { name: "random (worst case)", gen: random },
 ];
 
 console.log(`ALP XOR-delta exception compression (${N} samples):\n`);
-console.log(`  ${'Pattern'.padEnd(28)} ${'Size'.padStart(8)} ${'B/pt'.padStart(8)} ${'Exceptions'.padStart(12)} ${'Old B/pt'.padStart(10)}  ${'Improvement'.padStart(12)}`);
-console.log(`  ${'─'.repeat(88)}`);
+console.log(
+  `  ${"Pattern".padEnd(28)} ${"Size".padStart(8)} ${"B/pt".padStart(8)} ${"Exceptions".padStart(12)} ${"Old B/pt".padStart(10)}  ${"Improvement".padStart(12)}`
+);
+console.log(`  ${"─".repeat(88)}`);
 
 for (const { name, gen } of patterns) {
   const vals = gen(N);
-  
+
   // Encode
   const { compressed, stats } = alp.encodeValuesWithStats(vals);
-  
+
   // Decode and verify round-trip
   const decoded = alp.decodeValues(compressed);
   let mismatches = 0;
@@ -87,15 +89,17 @@ for (const { name, gen } of patterns) {
       if (mismatches > 5) break;
     }
   }
-  
+
   // Parse header to count exceptions
   const excCount = (compressed[12] << 8) | compressed[13];
   const oldSize = 14 + 0 + excCount * 10; // old format: header + 0 bitpacked + exc_count * (2+8)
   const oldBpt = oldSize / N;
   const improvement = oldBpt / (compressed.byteLength / N);
-  
-  console.log(`  ${name.padEnd(28)} ${(compressed.byteLength + ' B').padStart(8)} ${(compressed.byteLength / N).toFixed(3).padStart(8)} ${(excCount + '/' + N).padStart(12)} ${oldBpt.toFixed(3).padStart(10)}  ${improvement.toFixed(1).padStart(11)}×`);
-  
+
+  console.log(
+    `  ${name.padEnd(28)} ${(`${compressed.byteLength} B`).padStart(8)} ${(compressed.byteLength / N).toFixed(3).padStart(8)} ${(`${excCount}/${N}`).padStart(12)} ${oldBpt.toFixed(3).padStart(10)}  ${improvement.toFixed(1).padStart(11)}×`
+  );
+
   if (mismatches > 0) {
     console.log(`  ⚠ ${mismatches} MISMATCHES!`);
   }
@@ -105,37 +109,45 @@ console.log();
 
 // Also test with real OTel data if available
 try {
-  const { loadOtelData } = await import(join(__dirname, 'load-otel.mjs'));
-  const series = await loadOtelData(join(__dirname, 'data/cpu.jsonl'));
-  
+  const { loadOtelData } = await import(join(__dirname, "load-otel.mjs"));
+  const series = await loadOtelData(join(__dirname, "data/cpu.jsonl"));
+
   // Find cpu.utilization series
-  const utilSeries = series.filter(s => s.labels.get('__name__') === 'system.cpu.utilization');
+  const utilSeries = series.filter((s) => s.labels.get("__name__") === "system.cpu.utilization");
   if (utilSeries.length > 0) {
     console.log(`Real OTel cpu.utilization (${utilSeries.length} series):\n`);
-    
-    let totalOld = 0, totalNew = 0, totalPts = 0;
-    for (const s of utilSeries.slice(0, 4)) { // first 4 series
+
+    let totalOld = 0,
+      totalNew = 0,
+      totalPts = 0;
+    for (const s of utilSeries.slice(0, 4)) {
+      // first 4 series
       const chunk = s.values.subarray(0, Math.min(640, s.values.length));
       const { compressed } = alp.encodeValuesWithStats(chunk);
       const decoded = alp.decodeValues(compressed);
-      
+
       let ok = true;
       for (let i = 0; i < chunk.length; i++) {
-        if (chunk[i] !== decoded[i]) { ok = false; break; }
+        if (chunk[i] !== decoded[i]) {
+          ok = false;
+          break;
+        }
       }
-      
+
       const excCount = (compressed[12] << 8) | compressed[13];
       const oldSize = 14 + excCount * 10;
-      
+
       totalOld += oldSize;
       totalNew += compressed.byteLength;
       totalPts += chunk.length;
-      
-      const state = s.labels.get('state') || '?';
-      const cpu = s.labels.get('cpu') || '?';
-      console.log(`  cpu=${cpu} state=${state}: ${chunk.length} pts, ${compressed.byteLength} B (${(compressed.byteLength / chunk.length).toFixed(2)} B/pt), exc=${excCount}, roundtrip=${ok ? '✓' : '✗'}`);
+
+      const state = s.labels.get("state") || "?";
+      const cpu = s.labels.get("cpu") || "?";
+      console.log(
+        `  cpu=${cpu} state=${state}: ${chunk.length} pts, ${compressed.byteLength} B (${(compressed.byteLength / chunk.length).toFixed(2)} B/pt), exc=${excCount}, roundtrip=${ok ? "✓" : "✗"}`
+      );
     }
-    
+
     console.log(`\n  Totals: ${totalPts} pts`);
     console.log(`    Old format: ${totalOld} B (${(totalOld / totalPts).toFixed(2)} B/pt)`);
     console.log(`    New format: ${totalNew} B (${(totalNew / totalPts).toFixed(2)} B/pt)`);

--- a/packages/o11ytsdb/bench/vectors.ts
+++ b/packages/o11ytsdb/bench/vectors.ts
@@ -78,7 +78,7 @@ export function constantGauge(n = 1024, t0 = 1_700_000_000_000n): ChunkData {
   const timestamps = makeTimes(n, t0);
   const values = new Float64Array(n);
   for (let i = 0; i < n; i++) values[i] = 42.0;
-  return { name: 'constant_gauge', timestamps, values };
+  return { name: "constant_gauge", timestamps, values };
 }
 
 /** Counter with small integer increments (disk_ops, net_packets). */
@@ -91,7 +91,7 @@ export function counterSmall(n = 1024, t0 = 1_700_000_000_000n, seed = 42): Chun
     if (rng.next() >= 0.4) counter += Math.floor(rng.next() * 10) + 1;
     values[i] = counter;
   }
-  return { name: 'counter_small', timestamps, values };
+  return { name: "counter_small", timestamps, values };
 }
 
 /** Counter with large integers (~10^10, like network bytes). */
@@ -104,7 +104,7 @@ export function counterLarge(n = 1024, t0 = 1_700_000_000_000n, seed = 42): Chun
     if (rng.next() >= 0.3) counter += Math.floor(rng.next() * 100000) + 1;
     values[i] = counter;
   }
-  return { name: 'counter_large', timestamps, values };
+  return { name: "counter_large", timestamps, values };
 }
 
 /** Gauge with 2 decimal places (cpu_time, load_average). */
@@ -118,7 +118,7 @@ export function gauge2dp(n = 1024, t0 = 1_700_000_000_000n, seed = 42): ChunkDat
     v = Math.max(0, v);
     values[i] = Math.round(v * 100) / 100;
   }
-  return { name: 'gauge_2dp', timestamps, values };
+  return { name: "gauge_2dp", timestamps, values };
 }
 
 /** Gauge with 3 decimal places (disk_io_time, operation_time). */
@@ -132,7 +132,7 @@ export function gauge3dp(n = 1024, t0 = 1_700_000_000_000n, seed = 42): ChunkDat
     v = Math.max(0, v);
     values[i] = Math.round(v * 1000) / 1000;
   }
-  return { name: 'gauge_3dp', timestamps, values };
+  return { name: "gauge_3dp", timestamps, values };
 }
 
 /** Gauge with 11 decimal places (memory.utilization). ALP-clean at e=11. */
@@ -146,7 +146,7 @@ export function gauge11dp(n = 1024, t0 = 1_700_000_000_000n, seed = 42): ChunkDa
     base = Math.max(0, Math.min(1, base));
     values[i] = Math.round(base * 1e11) / 1e11;
   }
-  return { name: 'gauge_11dp', timestamps, values };
+  return { name: "gauge_11dp", timestamps, values };
 }
 
 /** Gauge with 12 decimal places (filesystem.utilization). ALP-clean at e=12. */
@@ -160,7 +160,7 @@ export function gauge12dp(n = 1024, t0 = 1_700_000_000_000n, seed = 42): ChunkDa
     base = Math.max(0, Math.min(1, base));
     values[i] = Math.round(base * 1e12) / 1e12;
   }
-  return { name: 'gauge_12dp', timestamps, values };
+  return { name: "gauge_12dp", timestamps, values };
 }
 
 /**
@@ -179,7 +179,7 @@ export function highPrecisionRatio(n = 1024, t0 = 1_700_000_000_000n, seed = 42)
     totalTicks += 1000;
     values[i] = ticks / totalTicks;
   }
-  return { name: 'high_precision_ratio', timestamps, values };
+  return { name: "high_precision_ratio", timestamps, values };
 }
 
 /** High-variance gauge with 2dp (latency-like random walk). */
@@ -193,7 +193,7 @@ export function highVarianceGauge(n = 1024, t0 = 1_700_000_000_000n, seed = 42):
     v = Math.max(0, v);
     values[i] = Math.round(v * 100) / 100;
   }
-  return { name: 'high_variance_gauge', timestamps, values };
+  return { name: "high_variance_gauge", timestamps, values };
 }
 
 // ── Legacy generators (kept for backwards compatibility) ─────────────
@@ -201,7 +201,7 @@ export function highVarianceGauge(n = 1024, t0 = 1_700_000_000_000n, seed = 42):
 /** Slow-changing gauge (CPU %). @deprecated Use gauge2dp. */
 export function slowGauge(n = 1024, t0 = 1_700_000_000_000n, seed = 42): ChunkData {
   const data = gauge2dp(n, t0, seed);
-  return { ...data, name: 'slow_gauge' };
+  return { ...data, name: "slow_gauge" };
 }
 
 /** Monotonic counter. @deprecated Use counterSmall. */
@@ -214,7 +214,7 @@ export function monotonicCounter(n = 1024, t0 = 1_700_000_000_000n, seed = 42): 
     v += rng.int(10, 200);
     values[i] = v;
   }
-  return { name: 'monotonic_counter', timestamps, values };
+  return { name: "monotonic_counter", timestamps, values };
 }
 
 /** Spiky latency (5-2000ms). @deprecated Use highVarianceGauge. */
@@ -227,7 +227,7 @@ export function spikyLatency(n = 1024, t0 = 1_700_000_000_000n, seed = 42): Chun
     const spike = rng.next() < 0.05 ? rng.gaussian(500, 300) : 0;
     values[i] = Math.max(5, base + spike);
   }
-  return { name: 'spiky_latency', timestamps, values };
+  return { name: "spiky_latency", timestamps, values };
 }
 
 /** High entropy random. @deprecated */
@@ -236,7 +236,7 @@ export function highEntropy(n = 1024, t0 = 1_700_000_000_000n, seed = 42): Chunk
   const timestamps = makeTimes(n, t0);
   const values = new Float64Array(n);
   for (let i = 0; i < n; i++) values[i] = rng.next() * 1e6;
-  return { name: 'high_entropy', timestamps, values };
+  return { name: "high_entropy", timestamps, values };
 }
 
 /**
@@ -253,7 +253,7 @@ export function allGenerators(n = 1024): ChunkData[] {
     gauge11dp(n),
     gauge12dp(n),
     highPrecisionRatio(n),
-    { ...highPrecisionRatio(n, undefined, 99), name: 'high_precision_ratio_b' },
+    { ...highPrecisionRatio(n, undefined, 99), name: "high_precision_ratio_b" },
     highVarianceGauge(n),
   ];
 }
@@ -268,11 +268,7 @@ export interface LabelSet {
  * Generate N series with realistic label distributions.
  * Each series has `numLabels` labels. Values follow power-law cardinality.
  */
-export function generateLabelSets(
-  numSeries: number,
-  numLabels: number,
-  seed = 42,
-): LabelSet[] {
+export function generateLabelSets(numSeries: number, numLabels: number, seed = 42): LabelSet[] {
   const rng = new Rng(seed);
   const sets: LabelSet[] = [];
 

--- a/packages/o11ytsdb/bench/verify-stores.mjs
+++ b/packages/o11ytsdb/bench/verify-stores.mjs
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 

--- a/packages/o11ytsdb/bench/wasm-loader.ts
+++ b/packages/o11ytsdb/bench/wasm-loader.ts
@@ -10,25 +10,82 @@
  *   - memory: exported WebAssembly.Memory
  */
 
-import { readFileSync } from 'node:fs';
-import type { CodecImpl } from './codec.bench.js';
+import { readFileSync } from "node:fs";
+import type { CodecImpl } from "./codec.bench.js";
 
 export interface WasmExports {
   memory: WebAssembly.Memory;
   // XOR-delta (Gorilla) codec
-  encodeChunk: (ts_ptr: number, val_ptr: number, count: number, out_ptr: number, out_cap: number) => number;
-  decodeChunk: (in_ptr: number, in_len: number, ts_ptr: number, val_ptr: number, max_samples: number) => number;
-  encodeChunkWithStats: (ts_ptr: number, val_ptr: number, count: number, out_ptr: number, out_cap: number, stats_ptr: number) => number;
+  encodeChunk: (
+    ts_ptr: number,
+    val_ptr: number,
+    count: number,
+    out_ptr: number,
+    out_cap: number
+  ) => number;
+  decodeChunk: (
+    in_ptr: number,
+    in_len: number,
+    ts_ptr: number,
+    val_ptr: number,
+    max_samples: number
+  ) => number;
+  encodeChunkWithStats: (
+    ts_ptr: number,
+    val_ptr: number,
+    count: number,
+    out_ptr: number,
+    out_cap: number,
+    stats_ptr: number
+  ) => number;
   encodeValues: (val_ptr: number, count: number, out_ptr: number, out_cap: number) => number;
   decodeValues: (in_ptr: number, in_len: number, val_ptr: number, max_samples: number) => number;
-  encodeValuesWithStats: (val_ptr: number, count: number, out_ptr: number, out_cap: number, stats_ptr: number) => number;
+  encodeValuesWithStats: (
+    val_ptr: number,
+    count: number,
+    out_ptr: number,
+    out_cap: number,
+    stats_ptr: number
+  ) => number;
   // ALP (Adaptive Lossless floating-Point) codec
   encodeValuesALP: (val_ptr: number, count: number, out_ptr: number, out_cap: number) => number;
   decodeValuesALP: (in_ptr: number, in_len: number, val_ptr: number, max_samples: number) => number;
-  encodeValuesALPWithStats: (val_ptr: number, count: number, out_ptr: number, out_cap: number, stats_ptr: number) => number;
-  encodeBatchValuesALPWithStats: (vals_ptr: number, chunk_size: number, num_arrays: number, out_ptr: number, out_cap: number, offsets_ptr: number, sizes_ptr: number, stats_ptr: number) => number;
-  decodeBatchValuesALP: (blobs_ptr: number, offsets_ptr: number, sizes_ptr: number, num_blobs: number, out_ptr: number, chunk_size: number) => number;
-  rangeDecodeALP: (ts_ptr: number, ts_len: number, val_ptr: number, val_len: number, start_t: bigint, end_t: bigint, out_ts_ptr: number, out_val_ptr: number, max_out: number) => number;
+  encodeValuesALPWithStats: (
+    val_ptr: number,
+    count: number,
+    out_ptr: number,
+    out_cap: number,
+    stats_ptr: number
+  ) => number;
+  encodeBatchValuesALPWithStats: (
+    vals_ptr: number,
+    chunk_size: number,
+    num_arrays: number,
+    out_ptr: number,
+    out_cap: number,
+    offsets_ptr: number,
+    sizes_ptr: number,
+    stats_ptr: number
+  ) => number;
+  decodeBatchValuesALP: (
+    blobs_ptr: number,
+    offsets_ptr: number,
+    sizes_ptr: number,
+    num_blobs: number,
+    out_ptr: number,
+    chunk_size: number
+  ) => number;
+  rangeDecodeALP: (
+    ts_ptr: number,
+    ts_len: number,
+    val_ptr: number,
+    val_len: number,
+    start_t: bigint,
+    end_t: bigint,
+    out_ts_ptr: number,
+    out_val_ptr: number,
+    max_out: number
+  ) => number;
   // Timestamps
   encodeTimestamps: (ts_ptr: number, count: number, out_ptr: number, out_cap: number) => number;
   decodeTimestamps: (in_ptr: number, in_len: number, ts_ptr: number, max_samples: number) => number;
@@ -58,11 +115,7 @@ export async function loadWasm(wasmPath: string): Promise<WasmExports> {
  *   4. Call encode/decode
  *   5. Copy results back to JS typed arrays
  */
-export function makeCodecImpl(
-  wasm: WasmExports,
-  runtime: string,
-  name: string,
-): CodecImpl {
+export function makeCodecImpl(wasm: WasmExports, runtime: string, name: string): CodecImpl {
   const mem = () => new Uint8Array(wasm.memory.buffer);
 
   return {
@@ -74,8 +127,8 @@ export function makeCodecImpl(
       wasm.resetScratch();
 
       // Allocate input buffers in WASM memory.
-      const tsPtr = wasm.allocScratch(n * 8);   // i64 = 8 bytes
-      const valPtr = wasm.allocScratch(n * 8);   // f64 = 8 bytes
+      const tsPtr = wasm.allocScratch(n * 8); // i64 = 8 bytes
+      const valPtr = wasm.allocScratch(n * 8); // f64 = 8 bytes
       const outCap = n * 20; // generous: worst case ~18 bytes/point
       const outPtr = wasm.allocScratch(outCap);
 
@@ -126,14 +179,21 @@ export function makeCodecImpl(
  * Wrap WASM exports into a ValuesCodec for the ColumnStore.
  * Includes encodeValuesWithStats for fused compression + stats.
  */
-export function makeValuesCodec(
-  wasm: WasmExports,
-): {
+export function makeValuesCodec(wasm: WasmExports): {
   encodeValues(values: Float64Array): Uint8Array;
   decodeValues(buf: Uint8Array): Float64Array;
   encodeValuesWithStats(values: Float64Array): {
     compressed: Uint8Array;
-    stats: { minV: number; maxV: number; sum: number; count: number; firstV: number; lastV: number; sumOfSquares: number; resetCount: number };
+    stats: {
+      minV: number;
+      maxV: number;
+      sum: number;
+      count: number;
+      firstV: number;
+      lastV: number;
+      sumOfSquares: number;
+      resetCount: number;
+    };
   };
 } {
   const mem = () => new Uint8Array(wasm.memory.buffer);
@@ -207,9 +267,7 @@ export function makeValuesCodec(
  * Wrap WASM exports into a TimestampCodec for the ColumnStore.
  * Delta-of-delta encoding for shared timestamp columns.
  */
-export function makeTimestampCodec(
-  wasm: WasmExports,
-): {
+export function makeTimestampCodec(wasm: WasmExports): {
   encodeTimestamps(timestamps: BigInt64Array): Uint8Array;
   decodeTimestamps(buf: Uint8Array): BigInt64Array;
 } {
@@ -225,7 +283,10 @@ export function makeTimestampCodec(
       const outPtr = wasm.allocScratch(outCap);
 
       const wasmMem = mem();
-      wasmMem.set(new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength), tsPtr);
+      wasmMem.set(
+        new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength),
+        tsPtr
+      );
 
       const bytesWritten = wasm.encodeTimestamps(tsPtr, n, outPtr, outCap);
       return new Uint8Array(wasm.memory.buffer.slice(outPtr, outPtr + bytesWritten));
@@ -251,15 +312,27 @@ export function makeTimestampCodec(
 
 /** Stats shape returned by ALP and XOR encodeWithStats. */
 interface BlockStats {
-  minV: number; maxV: number; sum: number; count: number;
-  firstV: number; lastV: number; sumOfSquares: number; resetCount: number;
+  minV: number;
+  maxV: number;
+  sum: number;
+  count: number;
+  firstV: number;
+  lastV: number;
+  sumOfSquares: number;
+  resetCount: number;
 }
 
 function parseStats(wasm: WasmExports, statsPtr: number): BlockStats {
   const s = new Float64Array(wasm.memory.buffer.slice(statsPtr, statsPtr + 64));
   return {
-    minV: s[0]!, maxV: s[1]!, sum: s[2]!, count: s[3]!,
-    firstV: s[4]!, lastV: s[5]!, sumOfSquares: s[6]!, resetCount: s[7]!,
+    minV: s[0]!,
+    maxV: s[1]!,
+    sum: s[2]!,
+    count: s[3]!,
+    firstV: s[4]!,
+    lastV: s[5]!,
+    sumOfSquares: s[6]!,
+    resetCount: s[7]!,
   };
 }
 
@@ -268,13 +341,13 @@ function parseStats(wasm: WasmExports, statsPtr: number): BlockStats {
  * ALP (Adaptive Lossless floating-Point) — fixed-width bit-packing
  * that enables random access decode and range queries.
  */
-export function makeALPValuesCodec(
-  wasm: WasmExports,
-): {
+export function makeALPValuesCodec(wasm: WasmExports): {
   encodeValues(values: Float64Array): Uint8Array;
   decodeValues(buf: Uint8Array): Float64Array;
   encodeValuesWithStats(values: Float64Array): { compressed: Uint8Array; stats: BlockStats };
-  encodeBatchValuesWithStats(arrays: Float64Array[]): Array<{ compressed: Uint8Array; stats: BlockStats }>;
+  encodeBatchValuesWithStats(
+    arrays: Float64Array[]
+  ): Array<{ compressed: Uint8Array; stats: BlockStats }>;
   decodeBatchValues(blobs: Uint8Array[], chunkSize: number): Float64Array[];
 } {
   const mem = () => new Uint8Array(wasm.memory.buffer);
@@ -328,10 +401,10 @@ export function makeALPValuesCodec(
     encodeBatchValuesWithStats(arrays: Float64Array[]) {
       const numArrays = arrays.length;
       if (numArrays === 0) return [];
-      const chunkSize = arrays[0]!.length;
+      const chunkSize = arrays[0]?.length;
       for (let i = 1; i < numArrays; i++) {
-        if (arrays[i]!.length !== chunkSize) {
-          throw new RangeError('encodeBatchValuesWithStats requires equal-length arrays');
+        if (arrays[i]?.length !== chunkSize) {
+          throw new RangeError("encodeBatchValuesWithStats requires equal-length arrays");
         }
       }
       wasm.resetScratch();
@@ -341,7 +414,10 @@ export function makeALPValuesCodec(
       const wasmMem = mem();
       for (let i = 0; i < numArrays; i++) {
         const arr = arrays[i]!;
-        wasmMem.set(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength), valsPtr + i * chunkSize * 8);
+        wasmMem.set(
+          new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength),
+          valsPtr + i * chunkSize * 8
+        );
       }
 
       const outCap = numArrays * chunkSize * 20;
@@ -351,22 +427,41 @@ export function makeALPValuesCodec(
       const statsPtr = wasm.allocScratch(numArrays * 64);
 
       wasm.encodeBatchValuesALPWithStats(
-        valsPtr, chunkSize, numArrays, outPtr, outCap, offsetsPtr, sizesPtr, statsPtr,
+        valsPtr,
+        chunkSize,
+        numArrays,
+        outPtr,
+        outCap,
+        offsetsPtr,
+        sizesPtr,
+        statsPtr
       );
 
-      const offsets = new Uint32Array(wasm.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4));
+      const offsets = new Uint32Array(
+        wasm.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4)
+      );
       const sizes = new Uint32Array(wasm.memory.buffer.slice(sizesPtr, sizesPtr + numArrays * 4));
 
       const results: Array<{ compressed: Uint8Array; stats: BlockStats }> = [];
-      const allStats = new Float64Array(wasm.memory.buffer.slice(statsPtr, statsPtr + numArrays * 64));
+      const allStats = new Float64Array(
+        wasm.memory.buffer.slice(statsPtr, statsPtr + numArrays * 64)
+      );
       for (let i = 0; i < numArrays; i++) {
-        const compressed = new Uint8Array(wasm.memory.buffer.slice(outPtr + offsets[i]!, outPtr + offsets[i]! + sizes[i]!));
+        const compressed = new Uint8Array(
+          wasm.memory.buffer.slice(outPtr + offsets[i]!, outPtr + offsets[i]! + sizes[i]!)
+        );
         const si = i * 8;
         results.push({
           compressed,
           stats: {
-            minV: allStats[si]!, maxV: allStats[si + 1]!, sum: allStats[si + 2]!, count: allStats[si + 3]!,
-            firstV: allStats[si + 4]!, lastV: allStats[si + 5]!, sumOfSquares: allStats[si + 6]!, resetCount: allStats[si + 7]!,
+            minV: allStats[si]!,
+            maxV: allStats[si + 1]!,
+            sum: allStats[si + 2]!,
+            count: allStats[si + 3]!,
+            firstV: allStats[si + 4]!,
+            lastV: allStats[si + 5]!,
+            sumOfSquares: allStats[si + 6]!,
+            resetCount: allStats[si + 7]!,
           },
         });
       }
@@ -405,7 +500,11 @@ export function makeALPValuesCodec(
 
       const results: Float64Array[] = [];
       for (let i = 0; i < numBlobs; i++) {
-        results.push(new Float64Array(wasm.memory.buffer.slice(outPtr + i * chunkSize * 8, outPtr + (i + 1) * chunkSize * 8)));
+        results.push(
+          new Float64Array(
+            wasm.memory.buffer.slice(outPtr + i * chunkSize * 8, outPtr + (i + 1) * chunkSize * 8)
+          )
+        );
       }
       return results;
     },
@@ -419,14 +518,12 @@ export function makeALPValuesCodec(
  * Fused decode + binary search in WASM — decodes only the samples
  * within [startT, endT] without materializing the full chunk.
  */
-export function makeALPRangeCodec(
-  wasm: WasmExports,
-): {
+export function makeALPRangeCodec(wasm: WasmExports): {
   rangeDecodeValues(
     compressedTimestamps: Uint8Array,
     compressedValues: Uint8Array,
     startT: bigint,
-    endT: bigint,
+    endT: bigint
   ): { timestamps: BigInt64Array; values: Float64Array };
 } {
   const mem = () => new Uint8Array(wasm.memory.buffer);
@@ -436,7 +533,7 @@ export function makeALPRangeCodec(
       compressedTimestamps: Uint8Array,
       compressedValues: Uint8Array,
       startT: bigint,
-      endT: bigint,
+      endT: bigint
     ) {
       wasm.resetScratch();
 
@@ -451,11 +548,15 @@ export function makeALPRangeCodec(
       const outValPtr = wasm.allocScratch(maxSamples * 8);
 
       const n = wasm.rangeDecodeALP(
-        tsInPtr, compressedTimestamps.length,
-        valInPtr, compressedValues.length,
-        startT, endT,
-        outTsPtr, outValPtr,
-        maxSamples,
+        tsInPtr,
+        compressedTimestamps.length,
+        valInPtr,
+        compressedValues.length,
+        startT,
+        endT,
+        outTsPtr,
+        outValPtr,
+        maxSamples
       );
 
       if (n === 0) {

--- a/packages/o11ytsdb/bench/worker-transfer.bench.ts
+++ b/packages/o11ytsdb/bench/worker-transfer.bench.ts
@@ -1,7 +1,6 @@
-import { Worker } from 'node:worker_threads';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
 
 interface MetricRow {
   strategy: TransferStrategy;
@@ -13,46 +12,56 @@ interface MetricRow {
 
 const SIZES = [1_000, 10_000, 100_000, 1_000_000] as const;
 
-type TransferStrategy = 'structured-clone' | 'transferable' | 'shared-array-buffer';
+type TransferStrategy = "structured-clone" | "transferable" | "shared-array-buffer";
 
 interface RequestEnvelope {
   id: number;
-  kind: 'request';
-  payload: {
-    type: 'init';
-    chunkSize?: number;
-  } | {
-    type: 'ingest';
-    labels: Array<[string, string]>;
-    timestamps: BigInt64Array;
-    values: Float64Array;
-  } | {
-    type: 'query';
-    opts: { metric: string; start: bigint; end: bigint };
-  } | {
-    type: 'close';
-  } | {
-    type: 'echo';
-    payload: Uint8Array;
-  };
+  kind: "request";
+  payload:
+    | {
+        type: "init";
+        chunkSize?: number;
+      }
+    | {
+        type: "ingest";
+        labels: Array<[string, string]>;
+        timestamps: BigInt64Array;
+        values: Float64Array;
+      }
+    | {
+        type: "query";
+        opts: { metric: string; start: bigint; end: bigint };
+      }
+    | {
+        type: "close";
+      }
+    | {
+        type: "echo";
+        payload: Uint8Array;
+      };
   meta?: { strategy?: TransferStrategy; sentAt?: number };
 }
 
 interface ResponseEnvelope {
   id: number;
-  kind: 'response';
-  payload: { ok: false; type: 'error'; error: string }
-    | { ok: true; type: 'init'; backend: string }
-    | { ok: true; type: 'ingest'; seriesId: number; ingestedSamples: number }
-    | { ok: true; type: 'query'; result: { series: unknown[] } }
-    | { ok: true; type: 'stats'; stats: { seriesCount: number; sampleCount: number; memoryBytes: number } }
-    | { ok: true; type: 'echo'; bytes: number }
-    | { ok: true; type: 'close' };
+  kind: "response";
+  payload:
+    | { ok: false; type: "error"; error: string }
+    | { ok: true; type: "init"; backend: string }
+    | { ok: true; type: "ingest"; seriesId: number; ingestedSamples: number }
+    | { ok: true; type: "query"; result: { series: unknown[] } }
+    | {
+        ok: true;
+        type: "stats";
+        stats: { seriesCount: number; sampleCount: number; memoryBytes: number };
+      }
+    | { ok: true; type: "echo"; bytes: number }
+    | { ok: true; type: "close" };
 }
 const ITERATIONS = 12;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const workerPath = join(__dirname, '../../dist/worker.js');
+const workerPath = join(__dirname, "../../dist/worker.js");
 
 type Pending = {
   resolve: (response: ResponseEnvelope) => void;
@@ -66,14 +75,14 @@ class BenchWorkerClient {
 
   constructor(path: string) {
     this.worker = new Worker(path);
-    this.worker.on('message', (raw: unknown) => {
+    this.worker.on("message", (raw: unknown) => {
       const message = raw as ResponseEnvelope;
       const handlers = this.pending.get(message.id);
       if (!handlers) return;
       this.pending.delete(message.id);
       handlers.resolve(message);
     });
-    this.worker.on('error', (error) => {
+    this.worker.on("error", (error) => {
       for (const [, handlers] of this.pending) {
         handlers.reject(error);
       }
@@ -82,14 +91,14 @@ class BenchWorkerClient {
   }
 
   async request(
-    payload: RequestEnvelope['payload'],
+    payload: RequestEnvelope["payload"],
     strategy: TransferStrategy,
-    transfer: ArrayBuffer[] = [],
+    transfer: ArrayBuffer[] = []
   ): Promise<ResponseEnvelope> {
     const id = this.nextId++;
     const envelope: RequestEnvelope = {
       id,
-      kind: 'request',
+      kind: "request",
       payload,
       meta: { strategy, sentAt: performance.now() },
     };
@@ -106,7 +115,7 @@ class BenchWorkerClient {
 }
 
 function supportsSharedArrayBuffer(): boolean {
-  return typeof SharedArrayBuffer !== 'undefined';
+  return typeof SharedArrayBuffer !== "undefined";
 }
 
 function p50(values: number[]): number {
@@ -114,9 +123,12 @@ function p50(values: number[]): number {
   return sorted[Math.floor(sorted.length * 0.5)] ?? 0;
 }
 
-function makePayload(strategy: TransferStrategy, samples: number): { payload: Uint8Array; transfer: ArrayBuffer[] } {
+function makePayload(
+  strategy: TransferStrategy,
+  samples: number
+): { payload: Uint8Array; transfer: ArrayBuffer[] } {
   const totalBytes = samples * 16; // mimic ts + value columns
-  if (strategy === 'shared-array-buffer') {
+  if (strategy === "shared-array-buffer") {
     const sab = new SharedArrayBuffer(totalBytes);
     const view = new Uint8Array(sab);
     for (let i = 0; i < view.length; i++) view[i] = i & 0xff;
@@ -125,15 +137,13 @@ function makePayload(strategy: TransferStrategy, samples: number): { payload: Ui
 
   const payload = new Uint8Array(totalBytes);
   for (let i = 0; i < payload.length; i++) payload[i] = i & 0xff;
-  if (strategy === 'transferable') {
+  if (strategy === "transferable") {
     return { payload, transfer: [payload.buffer] };
   }
   return { payload, transfer: [] };
 }
 
-async function measureMainThreadBlocking(
-  run: () => Promise<void>,
-): Promise<number> {
+async function measureMainThreadBlocking(run: () => Promise<void>): Promise<number> {
   return await new Promise((resolve, reject) => {
     const startedAt = performance.now();
     let finished = false;
@@ -151,7 +161,7 @@ async function measureMainThreadBlocking(
 async function benchmarkStrategy(strategy: TransferStrategy, samples: number): Promise<MetricRow> {
   const client = new BenchWorkerClient(workerPath);
 
-  const initResponse = await client.request({ type: 'init', chunkSize: 1024 }, strategy);
+  const initResponse = await client.request({ type: "init", chunkSize: 1024 }, strategy);
   if (!initResponse.payload.ok) {
     throw new Error(`init failed: ${initResponse.payload.error}`);
   }
@@ -167,7 +177,7 @@ async function benchmarkStrategy(strategy: TransferStrategy, samples: number): P
 
     const blockMs = await measureMainThreadBlocking(async () => {
       const t0 = performance.now();
-      const response = await client.request({ type: 'echo', payload }, strategy, transfer);
+      const response = await client.request({ type: "echo", payload }, strategy, transfer);
       const t1 = performance.now();
       if (!response.payload.ok) {
         throw new Error(`echo failed: ${response.payload.error}`);
@@ -180,9 +190,10 @@ async function benchmarkStrategy(strategy: TransferStrategy, samples: number): P
 
   if (global.gc) global.gc();
   const after = process.memoryUsage();
-  const memoryDeltaBytes = (after.arrayBuffers + after.heapUsed) - (before.arrayBuffers + before.heapUsed);
+  const memoryDeltaBytes =
+    after.arrayBuffers + after.heapUsed - (before.arrayBuffers + before.heapUsed);
 
-  await client.request({ type: 'close' }, strategy);
+  await client.request({ type: "close" }, strategy);
   await client.terminate();
 
   return {
@@ -196,7 +207,7 @@ async function benchmarkStrategy(strategy: TransferStrategy, samples: number): P
 
 async function runIngestQueryProof(): Promise<void> {
   const client = new BenchWorkerClient(workerPath);
-  const init = await client.request({ type: 'init', chunkSize: 1024 }, 'structured-clone');
+  const init = await client.request({ type: "init", chunkSize: 1024 }, "structured-clone");
   if (!init.payload.ok) throw new Error(`init failed: ${init.payload.error}`);
 
   const n = 2_048;
@@ -207,59 +218,70 @@ async function runIngestQueryProof(): Promise<void> {
     values[i] = Math.sin(i / 32);
   }
 
-  const ingest = await client.request({
-    type: 'ingest',
-    labels: [['__name__', 'cpu_usage'], ['service', 'bench']],
-    timestamps,
-    values,
-  }, 'structured-clone');
+  const ingest = await client.request(
+    {
+      type: "ingest",
+      labels: [
+        ["__name__", "cpu_usage"],
+        ["service", "bench"],
+      ],
+      timestamps,
+      values,
+    },
+    "structured-clone"
+  );
   if (!ingest.payload.ok) throw new Error(`ingest failed: ${ingest.payload.error}`);
 
-  const query = await client.request({
-    type: 'query',
-    opts: {
-      metric: 'cpu_usage',
-      start: timestamps[0]!,
-      end: timestamps[n - 1]!,
+  const query = await client.request(
+    {
+      type: "query",
+      opts: {
+        metric: "cpu_usage",
+        start: timestamps[0]!,
+        end: timestamps[n - 1]!,
+      },
     },
-  }, 'structured-clone');
+    "structured-clone"
+  );
 
   if (!query.payload.ok) throw new Error(`query failed: ${query.payload.error}`);
-  if (query.payload.type !== 'query') throw new Error(`unexpected response: ${query.payload.type}`);
+  if (query.payload.type !== "query") throw new Error(`unexpected response: ${query.payload.type}`);
   if (query.payload.result.series.length !== 1) {
     throw new Error(`expected 1 series, got ${query.payload.result.series.length}`);
   }
 
-  await client.request({ type: 'close' }, 'structured-clone');
+  await client.request({ type: "close" }, "structured-clone");
   await client.terminate();
 }
 
 function printRows(rows: MetricRow[]): void {
   const header = [
-    'strategy'.padEnd(20),
-    'samples'.padStart(10),
-    'p50 RTT (ms)'.padStart(14),
-    'p50 block (ms)'.padStart(16),
-    'mem delta (KB)'.padStart(15),
-  ].join(' | ');
+    "strategy".padEnd(20),
+    "samples".padStart(10),
+    "p50 RTT (ms)".padStart(14),
+    "p50 block (ms)".padStart(16),
+    "mem delta (KB)".padStart(15),
+  ].join(" | ");
   console.log(header);
-  console.log('-'.repeat(header.length));
+  console.log("-".repeat(header.length));
   for (const row of rows) {
-    console.log([
-      row.strategy.padEnd(20),
-      String(row.samples).padStart(10),
-      row.roundTripMs.toFixed(3).padStart(14),
-      row.mainThreadBlockMs.toFixed(3).padStart(16),
-      (row.memoryDeltaBytes / 1024).toFixed(1).padStart(15),
-    ].join(' | '));
+    console.log(
+      [
+        row.strategy.padEnd(20),
+        String(row.samples).padStart(10),
+        row.roundTripMs.toFixed(3).padStart(14),
+        row.mainThreadBlockMs.toFixed(3).padStart(16),
+        (row.memoryDeltaBytes / 1024).toFixed(1).padStart(15),
+      ].join(" | ")
+    );
   }
 }
 
 async function main(): Promise<void> {
   await runIngestQueryProof();
 
-  const strategies: TransferStrategy[] = ['structured-clone', 'transferable'];
-  if (supportsSharedArrayBuffer()) strategies.push('shared-array-buffer');
+  const strategies: TransferStrategy[] = ["structured-clone", "transferable"];
+  if (supportsSharedArrayBuffer()) strategies.push("shared-array-buffer");
 
   const rows: MetricRow[] = [];
   for (const strategy of strategies) {
@@ -276,7 +298,7 @@ async function main(): Promise<void> {
     rows,
     sharedArrayBufferAvailable: supportsSharedArrayBuffer(),
   };
-  console.log('\nJSON summary:');
+  console.log("\nJSON summary:");
   console.log(JSON.stringify(summary, null, 2));
 }
 

--- a/packages/o11ytsdb/src/binary-search.ts
+++ b/packages/o11ytsdb/src/binary-search.ts
@@ -3,6 +3,7 @@ import type { TimeRange } from "./types.js";
 export function lowerBound(arr: BigInt64Array, target: bigint, lo: number, hi: number): number {
   while (lo < hi) {
     const mid = (lo + hi) >>> 1;
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     if (arr[mid]! < target) lo = mid + 1;
     else hi = mid;
   }
@@ -12,6 +13,7 @@ export function lowerBound(arr: BigInt64Array, target: bigint, lo: number, hi: n
 export function upperBound(arr: BigInt64Array, target: bigint, lo: number, hi: number): number {
   while (lo < hi) {
     const mid = (lo + hi) >>> 1;
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     if (arr[mid]! <= target) lo = mid + 1;
     else hi = mid;
   }
@@ -22,6 +24,7 @@ export function concatRanges(parts: TimeRange[]): TimeRange {
   if (parts.length === 0) {
     return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
   }
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   if (parts.length === 1) return parts[0]!;
 
   let total = 0;

--- a/packages/o11ytsdb/src/chunked-store.ts
+++ b/packages/o11ytsdb/src/chunked-store.ts
@@ -10,11 +10,9 @@
  * with. Smaller chunks = less decode work per query but more overhead.
  */
 
-import type {
-  Codec, Labels, SeriesId, StorageBackend, TimeRange,
-} from './types.js';
-import { LabelIndex } from './label-index.js';
-import { concatRanges, lowerBound, upperBound } from './binary-search.js';
+import { concatRanges, lowerBound, upperBound } from "./binary-search.js";
+import { LabelIndex } from "./label-index.js";
+import type { Codec, Labels, SeriesId, StorageBackend, TimeRange } from "./types.js";
 
 interface FrozenChunk {
   compressed: Uint8Array;
@@ -67,6 +65,7 @@ export class ChunkedStore implements StorageBackend {
   }
 
   append(id: SeriesId, timestamp: bigint, value: number): void {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.series[id]!;
     const hot = s.hot;
     hot.timestamps[hot.count] = timestamp;
@@ -80,6 +79,7 @@ export class ChunkedStore implements StorageBackend {
   }
 
   appendBatch(id: SeriesId, timestamps: BigInt64Array, values: Float64Array): void {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.series[id]!;
     let offset = 0;
     const len = timestamps.length;
@@ -108,6 +108,7 @@ export class ChunkedStore implements StorageBackend {
   }
 
   read(id: SeriesId, start: bigint, end: bigint): TimeRange {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.series[id]!;
     const parts: TimeRange[] = [];
 
@@ -147,8 +148,12 @@ export class ChunkedStore implements StorageBackend {
 
   // ── Stats ──
 
-  get seriesCount(): number { return this.series.length; }
-  get sampleCount(): number { return this._sampleCount; }
+  get seriesCount(): number {
+    return this.series.length;
+  }
+  get sampleCount(): number {
+    return this._sampleCount;
+  }
 
   memoryBytes(): number {
     let bytes = 0;
@@ -171,7 +176,9 @@ export class ChunkedStore implements StorageBackend {
     const compressed = this.codec.encode(ts, vals);
     s.frozen.push({
       compressed,
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       minT: ts[0]!,
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       maxT: ts[hot.count - 1]!,
       count: hot.count,
     });

--- a/packages/o11ytsdb/src/chunked-store.ts
+++ b/packages/o11ytsdb/src/chunked-store.ts
@@ -79,6 +79,10 @@ export class ChunkedStore implements StorageBackend {
   }
 
   appendBatch(id: SeriesId, timestamps: BigInt64Array, values: Float64Array): void {
+    if (timestamps.length !== values.length) {
+      throw new RangeError(`appendBatch: timestamps.length (${timestamps.length}) !== values.length (${values.length})`);
+    }
+    if (timestamps.length === 0) return;
     // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.series[id]!;
     let offset = 0;

--- a/packages/o11ytsdb/src/codec.ts
+++ b/packages/o11ytsdb/src/codec.ts
@@ -32,6 +32,7 @@ export class BitWriter {
   writeBit(bit: number): void {
     if (this.bytePos >= this.buf.length) this.grow();
     if (bit) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       this.buf[this.bytePos]! |= 0x80 >>> this.bitPos;
     }
     this.bitPos++;
@@ -86,6 +87,7 @@ export class BitReader {
 
   /** Read a single bit. */
   readBit(): number {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const byte = this.buf[this.bytePos]!;
     const bit = (byte >>> (7 - this.bitPos)) & 1;
     this.bitPos++;
@@ -128,8 +130,8 @@ function floatToBits(f: number): bigint {
 }
 
 function bitsToFloat(bits: bigint): number {
-  const hi = Number((bits >> 32n) & 0xFFFFFFFFn);
-  const lo = Number(bits & 0xFFFFFFFFn);
+  const hi = Number((bits >> 32n) & 0xffffffffn);
+  const lo = Number(bits & 0xffffffffn);
   f64View.setUint32(0, hi, false);
   f64View.setUint32(4, lo, false);
   return f64View.getFloat64(0, false);
@@ -139,12 +141,29 @@ function bitsToFloat(bits: bigint): number {
 function clz64(x: bigint): number {
   if (x === 0n) return 64;
   let n = 0;
-  if ((x & 0xFFFFFFFF00000000n) === 0n) { n += 32; x <<= 32n; }
-  if ((x & 0xFFFF000000000000n) === 0n) { n += 16; x <<= 16n; }
-  if ((x & 0xFF00000000000000n) === 0n) { n += 8; x <<= 8n; }
-  if ((x & 0xF000000000000000n) === 0n) { n += 4; x <<= 4n; }
-  if ((x & 0xC000000000000000n) === 0n) { n += 2; x <<= 2n; }
-  if ((x & 0x8000000000000000n) === 0n) { n += 1; }
+  if ((x & 0xffffffff00000000n) === 0n) {
+    n += 32;
+    x <<= 32n;
+  }
+  if ((x & 0xffff000000000000n) === 0n) {
+    n += 16;
+    x <<= 16n;
+  }
+  if ((x & 0xff00000000000000n) === 0n) {
+    n += 8;
+    x <<= 8n;
+  }
+  if ((x & 0xf000000000000000n) === 0n) {
+    n += 4;
+    x <<= 4n;
+  }
+  if ((x & 0xc000000000000000n) === 0n) {
+    n += 2;
+    x <<= 2n;
+  }
+  if ((x & 0x8000000000000000n) === 0n) {
+    n += 1;
+  }
   return n;
 }
 
@@ -152,12 +171,29 @@ function clz64(x: bigint): number {
 function ctz64(x: bigint): number {
   if (x === 0n) return 64;
   let n = 0;
-  if ((x & 0xFFFFFFFFn) === 0n) { n += 32; x >>= 32n; }
-  if ((x & 0xFFFFn) === 0n) { n += 16; x >>= 16n; }
-  if ((x & 0xFFn) === 0n) { n += 8; x >>= 8n; }
-  if ((x & 0xFn) === 0n) { n += 4; x >>= 4n; }
-  if ((x & 0x3n) === 0n) { n += 2; x >>= 2n; }
-  if ((x & 0x1n) === 0n) { n += 1; }
+  if ((x & 0xffffffffn) === 0n) {
+    n += 32;
+    x >>= 32n;
+  }
+  if ((x & 0xffffn) === 0n) {
+    n += 16;
+    x >>= 16n;
+  }
+  if ((x & 0xffn) === 0n) {
+    n += 8;
+    x >>= 8n;
+  }
+  if ((x & 0xfn) === 0n) {
+    n += 4;
+    x >>= 4n;
+  }
+  if ((x & 0x3n) === 0n) {
+    n += 2;
+    x >>= 2n;
+  }
+  if ((x & 0x1n) === 0n) {
+    n += 1;
+  }
   return n;
 }
 
@@ -187,36 +223,38 @@ function ctz64(x: bigint): number {
  *       - Otherwise:         write '11' + 6 bits leading + 6 bits
  *                            meaningful-length + meaningful bits
  */
-export function encodeChunk(
-  timestamps: BigInt64Array,
-  values: Float64Array,
-): Uint8Array {
+export function encodeChunk(timestamps: BigInt64Array, values: Float64Array): Uint8Array {
   const n = timestamps.length;
   if (n === 0) return new Uint8Array(0);
-  if (n > 65535) throw new RangeError('Chunk exceeds 65535 samples');
+  if (n > 65535) throw new RangeError("Chunk exceeds 65535 samples");
   if (timestamps.length !== values.length) {
-    throw new RangeError('timestamps and values must have the same length');
+    throw new RangeError("timestamps and values must have the same length");
   }
 
   const w = new BitWriter(n * 2); // rough estimate
 
   // Header: count + first sample.
   w.writeBitsNum(n, 16);
-  w.writeBits(BigInt(timestamps[0]!) & 0xFFFFFFFFFFFFFFFFn, 64);
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
+  w.writeBits(BigInt(timestamps[0]!) & 0xffffffffffffffffn, 64);
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   w.writeBits(floatToBits(values[0]!), 64);
 
   if (n === 1) return w.finish();
 
   // State for delta-of-delta timestamps.
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   let prevTs = timestamps[0]!;
   let prevDelta = 0n;
 
   // State for XOR values.
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   let prevValBits = floatToBits(values[0]!);
   let prevLeading = 64; // force full write on first XOR
   let prevTrailing = 0;
 
   for (let i = 1; i < n; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const ts = timestamps[i]!;
     const delta = ts - prevTs;
     const dod = delta - prevDelta;
@@ -228,20 +266,29 @@ export function encodeChunk(
       // Zigzag encode for signed values.
       const absDod = dod < 0n ? -dod : dod;
       if (absDod <= 64n) {
-        w.writeBit(1); w.writeBit(0);
+        w.writeBit(1);
+        w.writeBit(0);
         // 7-bit zigzag: (dod << 1) ^ (dod >> 63)
-        const zz = Number((dod << 1n) ^ (dod >> 63n)) & 0x7F;
+        const zz = Number((dod << 1n) ^ (dod >> 63n)) & 0x7f;
         w.writeBitsNum(zz, 7);
       } else if (absDod <= 256n) {
-        w.writeBit(1); w.writeBit(1); w.writeBit(0);
-        const zz = Number((dod << 1n) ^ (dod >> 63n)) & 0x1FF;
+        w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(0);
+        const zz = Number((dod << 1n) ^ (dod >> 63n)) & 0x1ff;
         w.writeBitsNum(zz, 9);
       } else if (absDod <= 2048n) {
-        w.writeBit(1); w.writeBit(1); w.writeBit(1); w.writeBit(0);
-        const zz = Number((dod << 1n) ^ (dod >> 63n)) & 0xFFF;
+        w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(0);
+        const zz = Number((dod << 1n) ^ (dod >> 63n)) & 0xfff;
         w.writeBitsNum(zz, 12);
       } else {
-        w.writeBit(1); w.writeBit(1); w.writeBit(1); w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(1);
         // Raw 64-bit BigInt.
         w.writeBits(BigInt.asUintN(64, dod), 64);
       }
@@ -251,6 +298,7 @@ export function encodeChunk(
     prevTs = ts;
 
     // ── Value: XOR encoding ──
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const valBits = floatToBits(values[i]!);
     const xor = prevValBits ^ valBits;
 
@@ -263,13 +311,15 @@ export function encodeChunk(
 
       if (leading >= prevLeading && trailing >= prevTrailing) {
         // Reuse previous window.
-        w.writeBit(1); w.writeBit(0);
+        w.writeBit(1);
+        w.writeBit(0);
         const prevMeaningful = 64 - prevLeading - prevTrailing;
         const shifted = xor >> BigInt(prevTrailing);
         w.writeBits(shifted, prevMeaningful);
       } else {
         // New window.
-        w.writeBit(1); w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(1);
         w.writeBitsNum(leading, 6);
         // meaningful length: 0 means 64 (can't have 0 meaningful bits
         // when xor != 0), so store (meaningful - 1) in 6 bits.
@@ -314,8 +364,10 @@ export function decodeChunk(buf: Uint8Array): DecodedChunk {
 
   if (n === 1) return { timestamps, values };
 
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   let prevTs = timestamps[0]!;
   let prevDelta = 0n;
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   let prevValBits = floatToBits(values[0]!);
   let prevLeading = 0;
   let prevTrailing = 0;
@@ -325,14 +377,17 @@ export function decodeChunk(buf: Uint8Array): DecodedChunk {
     let dod: bigint;
     if (r.readBit() === 0) {
       dod = 0n;
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
     } else if (r.readBit() === 0) {
       // 7-bit zigzag
       const zz = r.readBitsNum(7);
       dod = BigInt.asIntN(64, BigInt((zz >>> 1) ^ -(zz & 1)));
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
     } else if (r.readBit() === 0) {
       // 9-bit zigzag
       const zz = r.readBitsNum(9);
       dod = BigInt.asIntN(64, BigInt((zz >>> 1) ^ -(zz & 1)));
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
     } else if (r.readBit() === 0) {
       // 12-bit zigzag
       const zz = r.readBitsNum(12);
@@ -352,6 +407,7 @@ export function decodeChunk(buf: Uint8Array): DecodedChunk {
     if (r.readBit() === 0) {
       // Same as previous.
       values[i] = bitsToFloat(prevValBits);
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
     } else if (r.readBit() === 0) {
       // Reuse previous leading/trailing window.
       const meaningful = 64 - prevLeading - prevTrailing;

--- a/packages/o11ytsdb/src/codec.ts
+++ b/packages/o11ytsdb/src/codec.ts
@@ -87,7 +87,10 @@ export class BitReader {
 
   /** Read a single bit. */
   readBit(): number {
-    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
+    if (this.bytePos >= this.buf.length) {
+      throw new RangeError(`BitReader: read past end of buffer (bytePos=${this.bytePos}, length=${this.buf.length})`);
+    }
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked above
     const byte = this.buf[this.bytePos]!;
     const bit = (byte >>> (7 - this.bitPos)) & 1;
     this.bitPos++;

--- a/packages/o11ytsdb/src/column-store.ts
+++ b/packages/o11ytsdb/src/column-store.ts
@@ -127,6 +127,9 @@ export class ColumnStore implements StorageBackend {
     if (!isNew) return id;
 
     const groupId = this.groupResolver(labels);
+    if (!Number.isInteger(groupId) || groupId < 0) {
+      throw new RangeError(`groupResolver must return a non-negative integer, got ${groupId}`);
+    }
 
     // Ensure group exists.
     while (this.groups.length <= groupId) {
@@ -177,6 +180,10 @@ export class ColumnStore implements StorageBackend {
   }
 
   appendBatch(id: SeriesId, timestamps: BigInt64Array, values: Float64Array): void {
+    if (timestamps.length !== values.length) {
+      throw new RangeError(`appendBatch: timestamps.length (${timestamps.length}) !== values.length (${values.length})`);
+    }
+    if (timestamps.length === 0) return;
     // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.allSeries[id]!;
     // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction

--- a/packages/o11ytsdb/src/column-store.ts
+++ b/packages/o11ytsdb/src/column-store.ts
@@ -15,12 +15,19 @@
  * to near-zero cost as group size grows.
  */
 
-import type {
-  ChunkStats, Labels, RangeDecodeCodec, SeriesId, StorageBackend, TimeRange, TimestampCodec, ValuesCodec,
-} from "./types.js";
+import { concatRanges, lowerBound, upperBound } from "./binary-search.js";
 import { LabelIndex } from "./label-index.js";
 import { computeStats } from "./stats.js";
-import { concatRanges, lowerBound, upperBound } from "./binary-search.js";
+import type {
+  ChunkStats,
+  Labels,
+  RangeDecodeCodec,
+  SeriesId,
+  StorageBackend,
+  TimeRange,
+  TimestampCodec,
+  ValuesCodec,
+} from "./types.js";
 
 // ── Internal types ───────────────────────────────────────────────────
 
@@ -96,7 +103,7 @@ export class ColumnStore implements StorageBackend {
     tsCodec?: TimestampCodec,
     rangeCodec?: RangeDecodeCodec,
     labelIndex?: LabelIndex,
-    precision?: number,
+    precision?: number
   ) {
     if (!Number.isFinite(chunkSize) || !Number.isInteger(chunkSize) || chunkSize < 1) {
       throw new RangeError(`chunkSize must be a finite integer >= 1, got ${chunkSize}`);
@@ -131,6 +138,7 @@ export class ColumnStore implements StorageBackend {
       });
     }
 
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const group = this.groups[groupId]!;
     group.members.push(id);
 
@@ -143,7 +151,9 @@ export class ColumnStore implements StorageBackend {
   }
 
   append(id: SeriesId, timestamp: bigint, value: number): void {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.allSeries[id]!;
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const group = this.groups[s.groupId]!;
 
     // Write timestamp to shared group buffer.
@@ -167,7 +177,9 @@ export class ColumnStore implements StorageBackend {
   }
 
   appendBatch(id: SeriesId, timestamps: BigInt64Array, values: Float64Array): void {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.allSeries[id]!;
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const group = this.groups[s.groupId]!;
     let offset = 0;
     const len = timestamps.length;
@@ -209,6 +221,7 @@ export class ColumnStore implements StorageBackend {
       if (this.quantize) {
         const q = this.quantize;
         for (let i = 0; i < batch; i++) {
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           s.hot.values[s.hot.count + i] = q(values[offset + i]!);
         }
       } else {
@@ -238,6 +251,7 @@ export class ColumnStore implements StorageBackend {
     const parts = this.readParts(id, start, end);
     // Resolve stats-only parts so concatRanges gets full sample data.
     for (let i = 0; i < parts.length; i++) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       const p = parts[i]!;
       if (p.timestamps.length === 0 && p.decode) {
         parts[i] = p.decode();
@@ -247,13 +261,16 @@ export class ColumnStore implements StorageBackend {
   }
 
   readParts(id: SeriesId, start: bigint, end: bigint): TimeRange[] {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.allSeries[id]!;
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const group = this.groups[s.groupId]!;
     const parts: TimeRange[] = [];
 
     // ── Path A: Fused range-decode (best — ts decode + binary search + partial values decode in one WASM call) ──
     if (this.rangeCodec && this.tsCodec) {
       for (const chunk of s.frozen) {
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const tsChunk = group.frozenTimestamps[chunk.tsChunkIndex]!;
         if (tsChunk.maxT < start || tsChunk.minT > end) continue;
 
@@ -264,6 +281,7 @@ export class ColumnStore implements StorageBackend {
         // spans multiple aggregation buckets and needs sample iteration.
         if (tsChunk.minT >= start && tsChunk.maxT <= end) {
           const rc = this.rangeCodec;
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           const tc = tsChunk.compressed!;
           const cv = chunk.compressedValues;
           parts.push({
@@ -278,13 +296,18 @@ export class ColumnStore implements StorageBackend {
         }
 
         const result = this.rangeCodec.rangeDecodeValues(
-          tsChunk.compressed!, chunk.compressedValues, start, end,
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
+          tsChunk.compressed!,
+          chunk.compressedValues,
+          start,
+          end
         );
         if (result.timestamps.length > 0) {
           parts.push(result);
 
           // Cache decoded timestamps if not already cached.
           if (!tsChunk.timestamps) {
+            // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
             tsChunk.timestamps = this.tsCodec.decodeTimestamps(tsChunk.compressed!);
           }
         }
@@ -292,6 +315,7 @@ export class ColumnStore implements StorageBackend {
     } else {
       // ── Path B: Individual decode (batch decode amortized by caller if needed) ──
       for (const chunk of s.frozen) {
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const tsChunk = group.frozenTimestamps[chunk.tsChunkIndex]!;
         if (tsChunk.maxT < start || tsChunk.minT > end) continue;
 
@@ -309,8 +333,10 @@ export class ColumnStore implements StorageBackend {
             chunkMaxT: tsChunk.maxT,
             decode: () => {
               if (!tsChunk.timestamps && tsc) {
+                // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
                 tsChunk.timestamps = tsc.decodeTimestamps(tcc!);
               }
+              // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
               const ts = tsChunk.timestamps!;
               const vs = vc.decodeValues(cv);
               return { timestamps: ts, values: vs };
@@ -320,8 +346,10 @@ export class ColumnStore implements StorageBackend {
         }
 
         // Decompress timestamps if needed.
-        const timestamps = tsChunk.timestamps
-          ?? (tsChunk.timestamps = this.tsCodec!.decodeTimestamps(tsChunk.compressed!));
+        const timestamps =
+          tsChunk.timestamps ??
+          // biome-ignore lint/style/noNonNullAssertion lint/suspicious/noAssignInExpressions: bounds-checked by construction
+          (tsChunk.timestamps = this.tsCodec!.decodeTimestamps(tsChunk.compressed!));
 
         const values = this.valuesCodec.decodeValues(chunk.compressedValues);
         const lo = lowerBound(timestamps, start, 0, tsChunk.count);
@@ -356,8 +384,12 @@ export class ColumnStore implements StorageBackend {
 
   // ── Stats ──
 
-  get seriesCount(): number { return this.allSeries.length; }
-  get sampleCount(): number { return this._sampleCount; }
+  get seriesCount(): number {
+    return this.allSeries.length;
+  }
+  get sampleCount(): number {
+    return this._sampleCount;
+  }
 
   memoryBytes(): number {
     let bytes = 0;
@@ -394,6 +426,7 @@ export class ColumnStore implements StorageBackend {
     // Find the minimum sample count across all group members.
     let minCount = Infinity;
     for (const memberId of group.members) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       const c = this.allSeries[memberId]!.hot.count;
       if (c < minCount) minCount = c;
     }
@@ -402,8 +435,8 @@ export class ColumnStore implements StorageBackend {
     const chunksToFreeze = Math.floor(minCount / this.chunkSize);
     if (chunksToFreeze === 0) return;
 
-    const hasBatch = typeof this.valuesCodec.encodeBatchValuesWithStats === 'function';
-    const hasWasmStats = typeof this.valuesCodec.encodeValuesWithStats === 'function';
+    const hasBatch = typeof this.valuesCodec.encodeBatchValuesWithStats === "function";
+    const hasWasmStats = typeof this.valuesCodec.encodeValuesWithStats === "function";
 
     for (let c = 0; c < chunksToFreeze; c++) {
       const chunkStart = c * this.chunkSize;
@@ -416,14 +449,18 @@ export class ColumnStore implements StorageBackend {
         const compressed = this.tsCodec.encodeTimestamps(ts);
         group.frozenTimestamps.push({
           compressed,
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           minT: ts[0]!,
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           maxT: ts[this.chunkSize - 1]!,
           count: this.chunkSize,
         });
       } else {
         group.frozenTimestamps.push({
           timestamps: ts,
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           minT: ts[0]!,
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           maxT: ts[this.chunkSize - 1]!,
           count: this.chunkSize,
         });
@@ -436,12 +473,16 @@ export class ColumnStore implements StorageBackend {
           const bEnd = Math.min(bStart + BATCH_CAP, group.members.length);
           const arrays: Float64Array[] = [];
           for (let m = bStart; m < bEnd; m++) {
+            // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
             const s = this.allSeries[group.members[m]!]!;
             arrays.push(s.hot.values.subarray(chunkStart, chunkStart + this.chunkSize));
           }
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           const results = this.valuesCodec.encodeBatchValuesWithStats!(arrays);
           for (let m = 0; m < results.length; m++) {
+            // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
             const s = this.allSeries[group.members[bStart + m]!]!;
+            // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
             const { compressed, stats } = results[m]!;
             s.frozen.push({ compressedValues: compressed, tsChunkIndex, stats });
           }
@@ -449,12 +490,14 @@ export class ColumnStore implements StorageBackend {
       } else {
         // Fallback: encode each member individually.
         for (const memberId of group.members) {
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           const s = this.allSeries[memberId]!;
           const vals = s.hot.values.subarray(chunkStart, chunkStart + this.chunkSize);
 
           let compressedValues: Uint8Array;
           let stats: ChunkStats;
           if (hasWasmStats) {
+            // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
             const result = this.valuesCodec.encodeValuesWithStats!(vals);
             compressedValues = result.compressed;
             stats = result.stats;
@@ -471,6 +514,7 @@ export class ColumnStore implements StorageBackend {
     // Shift remaining hot data back to the start (reuse buffers when possible).
     const frozenSamples = chunksToFreeze * this.chunkSize;
     for (const memberId of group.members) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       const s = this.allSeries[memberId]!;
       const remaining = s.hot.count - frozenSamples;
       if (remaining > 0) {
@@ -492,4 +536,3 @@ export class ColumnStore implements StorageBackend {
     }
   }
 }
-

--- a/packages/o11ytsdb/src/flat-store.ts
+++ b/packages/o11ytsdb/src/flat-store.ts
@@ -9,9 +9,9 @@
  * baseline. Everything else should beat it on memory.
  */
 
-import type { Labels, SeriesId, StorageBackend, TimeRange } from './types.js';
-import { LabelIndex } from './label-index.js';
-import { lowerBound, upperBound } from './binary-search.js';
+import { lowerBound, upperBound } from "./binary-search.js";
+import { LabelIndex } from "./label-index.js";
+import type { Labels, SeriesId, StorageBackend, TimeRange } from "./types.js";
 
 interface FlatSeries {
   timestamps: BigInt64Array;
@@ -26,7 +26,7 @@ export class FlatStore implements StorageBackend {
   private labelIndex: LabelIndex;
   private _sampleCount = 0;
 
-  constructor(name = 'flat', labelIndex?: LabelIndex) {
+  constructor(name = "flat", labelIndex?: LabelIndex) {
     this.name = name;
     this.labelIndex = labelIndex ?? new LabelIndex();
   }
@@ -46,6 +46,7 @@ export class FlatStore implements StorageBackend {
   }
 
   append(id: SeriesId, timestamp: bigint, value: number): void {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.series[id]!;
     if (s.count === s.timestamps.length) {
       this.grow(s);
@@ -57,6 +58,7 @@ export class FlatStore implements StorageBackend {
   }
 
   appendBatch(id: SeriesId, timestamps: BigInt64Array, values: Float64Array): void {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.series[id]!;
     const need = s.count + timestamps.length;
     while (need > s.timestamps.length) {
@@ -75,18 +77,26 @@ export class FlatStore implements StorageBackend {
   }
 
   read(id: SeriesId, start: bigint, end: bigint): TimeRange {
-    return this.readParts(id, start, end)[0] ?? { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
+    return (
+      this.readParts(id, start, end)[0] ?? {
+        timestamps: new BigInt64Array(0),
+        values: new Float64Array(0),
+      }
+    );
   }
 
   readParts(id: SeriesId, start: bigint, end: bigint): TimeRange[] {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.series[id]!;
     const lo = lowerBound(s.timestamps, start, 0, s.count);
     const hi = upperBound(s.timestamps, end, lo, s.count);
     if (hi <= lo) return [];
-    return [{
-      timestamps: s.timestamps.slice(lo, hi),
-      values: s.values.slice(lo, hi),
-    }];
+    return [
+      {
+        timestamps: s.timestamps.slice(lo, hi),
+        values: s.values.slice(lo, hi),
+      },
+    ];
   }
 
   labels(id: SeriesId): Labels | undefined {
@@ -95,8 +105,12 @@ export class FlatStore implements StorageBackend {
 
   // ── Stats ──
 
-  get seriesCount(): number { return this.series.length; }
-  get sampleCount(): number { return this._sampleCount; }
+  get seriesCount(): number {
+    return this.series.length;
+  }
+  get sampleCount(): number {
+    return this._sampleCount;
+  }
 
   memoryBytes(): number {
     let bytes = 0;

--- a/packages/o11ytsdb/src/index.ts
+++ b/packages/o11ytsdb/src/index.ts
@@ -4,50 +4,62 @@
  * Public API surface.
  */
 
+export { ChunkedStore } from "./chunked-store.js";
+export type { DecodedChunk } from "./codec.js";
 // Codec — XOR-delta (Gorilla) compression
 export {
-  encodeChunk,
-  decodeChunk,
-  BitWriter,
   BitReader,
-} from './codec.js';
-export type { DecodedChunk } from './codec.js';
-
-// Core types — pluggable interfaces for storage, codecs, and queries
-export type {
-  Labels, SeriesId, TimeRange, Codec, ValuesCodec, TimestampCodec, ChunkStats,
-  RangeDecodeCodec, RangeDecodeResult,
-  StorageBackend, QueryEngine, QueryOpts, QueryResult,
-  SeriesResult, AggFn, Matcher,
-} from './types.js';
-
+  BitWriter,
+  decodeChunk,
+  encodeChunk,
+} from "./codec.js";
+export { ColumnStore } from "./column-store.js";
 // Storage backends
-export { FlatStore } from './flat-store.js';
-export { ChunkedStore } from './chunked-store.js';
-export { ColumnStore } from './column-store.js';
-export { computeStats } from './stats.js';
-
-// Query engine
-export { ScanEngine } from './query.js';
+export { FlatStore } from "./flat-store.js";
+export type {
+  IngestResult,
+  OtlpMetricsDocument,
+  ParsedOtlpResult,
+  PendingSeriesSamples,
+} from "./ingest.js";
+// OTLP ingest pipeline
+export { flushSamplesToStorage, ingestOtlpJson, parseOtlpToSamples } from "./ingest.js";
+export type { InternId } from "./interner.js";
 
 // String interner + inverted index
-export { Interner } from './interner.js';
-export type { InternId } from './interner.js';
-export { MemPostings } from './postings.js';
-
+export { Interner } from "./interner.js";
 // Label index — shared label management for storage backends
-export { LabelIndex } from './label-index.js';
-
-// OTLP ingest pipeline
-export { ingestOtlpJson, parseOtlpToSamples, flushSamplesToStorage } from './ingest.js';
-export type { IngestResult, ParsedOtlpResult, PendingSeriesSamples, OtlpMetricsDocument } from './ingest.js';
+export { LabelIndex } from "./label-index.js";
+export { MemPostings } from "./postings.js";
+// Query engine
+export { ScanEngine } from "./query.js";
+export { computeStats } from "./stats.js";
+// Core types — pluggable interfaces for storage, codecs, and queries
+export type {
+  AggFn,
+  ChunkStats,
+  Codec,
+  Labels,
+  Matcher,
+  QueryEngine,
+  QueryOpts,
+  QueryResult,
+  RangeDecodeCodec,
+  RangeDecodeResult,
+  SeriesId,
+  SeriesResult,
+  StorageBackend,
+  TimeRange,
+  TimestampCodec,
+  ValuesCodec,
+} from "./types.js";
 
 // Worker isolation + transfer protocol
-export { WorkerClient } from './worker-client.js';
+export { WorkerClient } from "./worker-client.js";
 export type {
-  TransferStrategy,
   RequestEnvelope,
   ResponseEnvelope,
+  TransferStrategy,
   WorkerRequest,
   WorkerResponse,
-} from './worker-protocol.js';
+} from "./worker-protocol.js";

--- a/packages/o11ytsdb/src/ingest.ts
+++ b/packages/o11ytsdb/src/ingest.ts
@@ -4,10 +4,10 @@ import type {
   OtlpKeyValue,
   OtlpMetricsDocument,
   OtlpSummaryDataPoint,
-} from '@otlpkit/otlpjson';
-import { detectSignal, flattenAttributes, isMetricsDocument, toNumber } from '@otlpkit/otlpjson';
+} from "@otlpkit/otlpjson";
+import { detectSignal, flattenAttributes, isMetricsDocument, toNumber } from "@otlpkit/otlpjson";
 
-import type { Labels, StorageBackend } from './types.js';
+import type { Labels, StorageBackend } from "./types.js";
 
 export interface IngestResult {
   pointsSeen: number;
@@ -36,11 +36,11 @@ export interface ParsedOtlpResult {
   result: IngestResult;
 }
 
-const SCOPE_NAME_LABEL = 'otel.scope.name';
-const SCOPE_VERSION_LABEL = 'otel.scope.version';
-const ATTR_PREFIX_RESOURCE = 'resource.';
-const ATTR_PREFIX_SCOPE = 'scope_attr.';
-const ATTR_PREFIX_POINT = 'attr.';
+const SCOPE_NAME_LABEL = "otel.scope.name";
+const SCOPE_VERSION_LABEL = "otel.scope.version";
+const ATTR_PREFIX_RESOURCE = "resource.";
+const ATTR_PREFIX_SCOPE = "scope_attr.";
+const ATTR_PREFIX_POINT = "attr.";
 
 /**
  * Parse an OTLP metrics payload into pending samples without touching storage.
@@ -64,7 +64,7 @@ export function parseOtlpToSamples(payload: unknown): ParsedOtlpResult {
   };
 
   let document: unknown = payload;
-  if (typeof payload === 'string') {
+  if (typeof payload === "string") {
     try {
       document = JSON.parse(payload) as unknown;
     } catch {
@@ -74,7 +74,7 @@ export function parseOtlpToSamples(payload: unknown): ParsedOtlpResult {
     }
   }
 
-  if (detectSignal(document) !== 'metrics' || !isMetricsDocument(document)) {
+  if (detectSignal(document) !== "metrics" || !isMetricsDocument(document)) {
     result.errors++;
     result.dropped++;
     return { pending: new Map(), result };
@@ -91,8 +91,8 @@ export function parseOtlpToSamples(payload: unknown): ParsedOtlpResult {
 
       for (const metric of scopeMetrics.metrics ?? []) {
         const baseLabels = new Map<string, string>();
-        baseLabels.set(SCOPE_NAME_LABEL, scope?.name ?? '');
-        baseLabels.set(SCOPE_VERSION_LABEL, scope?.version ?? '');
+        baseLabels.set(SCOPE_NAME_LABEL, scope?.name ?? "");
+        baseLabels.set(SCOPE_VERSION_LABEL, scope?.version ?? "");
         addAttributeLabels(baseLabels, resourceAttrs, ATTR_PREFIX_RESOURCE);
         addAttributeLabels(baseLabels, scopeAttrs, ATTR_PREFIX_SCOPE);
 
@@ -108,7 +108,13 @@ export function parseOtlpToSamples(payload: unknown): ParsedOtlpResult {
 
         if (metric.histogram?.dataPoints) {
           result.metricTypeCounts.histogram++;
-          ingestHistogramPoints(metric.name, metric.histogram.dataPoints, baseLabels, pending, result);
+          ingestHistogramPoints(
+            metric.name,
+            metric.histogram.dataPoints,
+            baseLabels,
+            pending,
+            result
+          );
         }
 
         if (metric.summary?.dataPoints) {
@@ -123,7 +129,7 @@ export function parseOtlpToSamples(payload: unknown): ParsedOtlpResult {
             metric.exponentialHistogram.dataPoints,
             baseLabels,
             pending,
-            result,
+            result
           );
         }
       }
@@ -141,7 +147,11 @@ export function ingestOtlpJson(payload: unknown, storage: StorageBackend): Inges
 }
 
 /** Flush parsed samples to a storage backend. */
-export function flushSamplesToStorage(pending: Map<string, PendingSeriesSamples>, storage: StorageBackend, result: IngestResult): void {
+export function flushSamplesToStorage(
+  pending: Map<string, PendingSeriesSamples>,
+  storage: StorageBackend,
+  result: IngestResult
+): void {
   const beforeSeries = storage.seriesCount;
 
   for (const batch of pending.values()) {
@@ -157,10 +167,15 @@ export function flushSamplesToStorage(pending: Map<string, PendingSeriesSamples>
 
 function ingestNumberPoints(
   metricName: string,
-  points: readonly { timeUnixNano?: string | number; attributes?: readonly OtlpKeyValue[]; asDouble?: number; asInt?: string | number }[],
+  points: readonly {
+    timeUnixNano?: string | number;
+    attributes?: readonly OtlpKeyValue[];
+    asDouble?: number;
+    asInt?: string | number;
+  }[],
   baseLabels: Map<string, string>,
   pending: Map<string, PendingSeriesSamples>,
-  result: IngestResult,
+  result: IngestResult
 ): void {
   for (const point of points) {
     result.pointsSeen++;
@@ -183,7 +198,7 @@ function ingestHistogramPoints(
   points: readonly OtlpHistogramDataPoint[],
   baseLabels: Map<string, string>,
   pending: Map<string, PendingSeriesSamples>,
-  result: IngestResult,
+  result: IngestResult
 ): void {
   for (const point of points) {
     result.pointsSeen++;
@@ -200,12 +215,13 @@ function ingestHistogramPoints(
 
     let cumulative = 0;
     const bucketLabels = new Map(pointLabels);
-    bucketLabels.set('__name__', `${metricName}_bucket`);
+    bucketLabels.set("__name__", `${metricName}_bucket`);
 
     const commonCount = Math.min(bucketCounts.length, bounds.length + 1);
     for (let i = 0; i < commonCount; i++) {
       cumulative += bucketCounts[i] ?? 0;
-      bucketLabels.set('le', i < bounds.length ? numericLabel(bounds[i]!) : '+Inf');
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
+      bucketLabels.set("le", i < bounds.length ? numericLabel(bounds[i]!) : "+Inf");
       queueSample(pending, bucketLabels, ts, cumulative);
       result.pointsAccepted++;
     }
@@ -213,7 +229,7 @@ function ingestHistogramPoints(
     const count = toNumber(point.count ?? null);
     if (count !== null) {
       const countLabels = new Map(pointLabels);
-      countLabels.set('__name__', `${metricName}_count`);
+      countLabels.set("__name__", `${metricName}_count`);
       queueSample(pending, countLabels, ts, count);
       result.pointsAccepted++;
     }
@@ -221,7 +237,7 @@ function ingestHistogramPoints(
     const sum = toNumber(point.sum ?? null);
     if (sum !== null) {
       const sumLabels = new Map(pointLabels);
-      sumLabels.set('__name__', `${metricName}_sum`);
+      sumLabels.set("__name__", `${metricName}_sum`);
       queueSample(pending, sumLabels, ts, sum);
       result.pointsAccepted++;
     }
@@ -238,7 +254,7 @@ function ingestSummaryPoints(
   points: readonly OtlpSummaryDataPoint[],
   baseLabels: Map<string, string>,
   pending: Map<string, PendingSeriesSamples>,
-  result: IngestResult,
+  result: IngestResult
 ): void {
   for (const point of points) {
     result.pointsSeen++;
@@ -257,7 +273,7 @@ function ingestSummaryPoints(
       const value = toNumber(qv.value ?? null);
       if (quantile === null || value === null) continue;
       const qLabels = new Map(pointLabels);
-      qLabels.set('quantile', numericLabel(quantile));
+      qLabels.set("quantile", numericLabel(quantile));
       queueSample(pending, qLabels, ts, value);
       inserted++;
     }
@@ -265,7 +281,7 @@ function ingestSummaryPoints(
     const count = toNumber(point.count ?? null);
     if (count !== null) {
       const countLabels = new Map(pointLabels);
-      countLabels.set('__name__', `${metricName}_count`);
+      countLabels.set("__name__", `${metricName}_count`);
       queueSample(pending, countLabels, ts, count);
       inserted++;
     }
@@ -273,7 +289,7 @@ function ingestSummaryPoints(
     const sum = toNumber(point.sum ?? null);
     if (sum !== null) {
       const sumLabels = new Map(pointLabels);
-      sumLabels.set('__name__', `${metricName}_sum`);
+      sumLabels.set("__name__", `${metricName}_sum`);
       queueSample(pending, sumLabels, ts, sum);
       inserted++;
     }
@@ -293,7 +309,7 @@ function ingestExponentialHistogramPoints(
   points: readonly OtlpExponentialHistogramDataPoint[],
   baseLabels: Map<string, string>,
   pending: Map<string, PendingSeriesSamples>,
-  result: IngestResult,
+  result: IngestResult
 ): void {
   for (const point of points) {
     result.pointsSeen++;
@@ -308,14 +324,30 @@ function ingestExponentialHistogramPoints(
     const pointLabels = withPointLabels(metricName, baseLabels, point.attributes);
     let inserted = 0;
 
-    inserted += ingestExpBuckets(metricName, pointLabels, ts, scale, 'positive', point.positive, pending);
-    inserted += ingestExpBuckets(metricName, pointLabels, ts, scale, 'negative', point.negative, pending);
+    inserted += ingestExpBuckets(
+      metricName,
+      pointLabels,
+      ts,
+      scale,
+      "positive",
+      point.positive,
+      pending
+    );
+    inserted += ingestExpBuckets(
+      metricName,
+      pointLabels,
+      ts,
+      scale,
+      "negative",
+      point.negative,
+      pending
+    );
 
     const zeroCount = toNumber(point.zeroCount ?? null);
     if (zeroCount !== null) {
       const zeroLabels = new Map(pointLabels);
-      zeroLabels.set('__name__', `${metricName}_bucket`);
-      zeroLabels.set('exp_bucket', 'zero');
+      zeroLabels.set("__name__", `${metricName}_bucket`);
+      zeroLabels.set("exp_bucket", "zero");
       queueSample(pending, zeroLabels, ts, zeroCount);
       inserted++;
     }
@@ -323,7 +355,7 @@ function ingestExponentialHistogramPoints(
     const count = toNumber(point.count ?? null);
     if (count !== null) {
       const countLabels = new Map(pointLabels);
-      countLabels.set('__name__', `${metricName}_count`);
+      countLabels.set("__name__", `${metricName}_count`);
       queueSample(pending, countLabels, ts, count);
       inserted++;
     }
@@ -331,7 +363,7 @@ function ingestExponentialHistogramPoints(
     const sum = toNumber(point.sum ?? null);
     if (sum !== null) {
       const sumLabels = new Map(pointLabels);
-      sumLabels.set('__name__', `${metricName}_sum`);
+      sumLabels.set("__name__", `${metricName}_sum`);
       queueSample(pending, sumLabels, ts, sum);
       inserted++;
     }
@@ -351,9 +383,9 @@ function ingestExpBuckets(
   labels: Map<string, string>,
   ts: bigint,
   scale: number | null,
-  side: 'positive' | 'negative',
+  side: "positive" | "negative",
   buckets: { offset?: string | number; bucketCounts?: readonly (string | number)[] } | undefined,
-  pending: Map<string, PendingSeriesSamples>,
+  pending: Map<string, PendingSeriesSamples>
 ): number {
   const offset = toNumber(buckets?.offset ?? null) ?? 0;
   const counts = parseNumberArray(buckets?.bucketCounts);
@@ -364,10 +396,10 @@ function ingestExpBuckets(
     const value = counts[i] ?? 0;
     const bucketIndex = offset + i;
     const bucketLabels = new Map(labels);
-    bucketLabels.set('__name__', `${metricName}_bucket`);
-    bucketLabels.set('exp_side', side);
-    bucketLabels.set('exp_bucket', numericLabel(bucketIndex));
-    if (scale !== null) bucketLabels.set('exp_scale', numericLabel(scale));
+    bucketLabels.set("__name__", `${metricName}_bucket`);
+    bucketLabels.set("exp_side", side);
+    bucketLabels.set("exp_bucket", numericLabel(bucketIndex));
+    if (scale !== null) bucketLabels.set("exp_scale", numericLabel(scale));
     queueSample(pending, bucketLabels, ts, value);
     inserted++;
   }
@@ -377,25 +409,29 @@ function ingestExpBuckets(
 function withPointLabels(
   metricName: string,
   baseLabels: Map<string, string>,
-  pointAttributes: readonly OtlpKeyValue[] | undefined,
+  pointAttributes: readonly OtlpKeyValue[] | undefined
 ): Map<string, string> {
   const labels = new Map(baseLabels);
-  labels.set('__name__', metricName);
+  labels.set("__name__", metricName);
   const point = flattenAttributes(pointAttributes);
   addAttributeLabels(labels, point, ATTR_PREFIX_POINT);
   return labels;
 }
 
-function addAttributeLabels(labels: Map<string, string>, attrs: Record<string, unknown>, prefix: string): void {
+function addAttributeLabels(
+  labels: Map<string, string>,
+  attrs: Record<string, unknown>,
+  prefix: string
+): void {
   for (const [key, value] of Object.entries(attrs)) {
     labels.set(`${prefix}${sanitizeLabelKey(key)}`, attributeValueToLabel(value));
   }
 }
 
 function attributeValueToLabel(value: unknown): string {
-  if (value == null) return '';
-  if (typeof value === 'string') return value;
-  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
     return String(value);
   }
   return JSON.stringify(value);
@@ -405,7 +441,7 @@ function queueSample(
   pending: Map<string, PendingSeriesSamples>,
   labels: Labels,
   timestamp: bigint,
-  value: number,
+  value: number
 ): void {
   const key = seriesKey(labels);
   let batch = pending.get(key);
@@ -420,14 +456,16 @@ function queueSample(
 
 function seriesKey(labels: Labels): string {
   const entries = [...labels.entries()].sort((a, b) => (a[0] < b[0] ? -1 : 1));
-  return entries.map(([k, v]) => `${k}=${v}`).join(',');
+  return entries.map(([k, v]) => `${k}=${v}`).join(",");
 }
 
 function numericLabel(v: number): string {
-  return Number.isInteger(v) ? String(v) : v.toPrecision(12).replace(/\.0+$/u, '');
+  return Number.isInteger(v) ? String(v) : v.toPrecision(12).replace(/\.0+$/u, "");
 }
 
-function parseNumberArray(values: readonly (string | number)[] | readonly number[] | undefined): number[] {
+function parseNumberArray(
+  values: readonly (string | number)[] | readonly number[] | undefined
+): number[] {
   if (!values || values.length === 0) return [];
   const out: number[] = [];
   for (const value of values) {
@@ -438,16 +476,16 @@ function parseNumberArray(values: readonly (string | number)[] | readonly number
 }
 
 function sanitizeLabelKey(key: string): string {
-  return key.replace(/[^a-zA-Z0-9_]/gu, '_');
+  return key.replace(/[^a-zA-Z0-9_]/gu, "_");
 }
 
 function normalizeTimestamp(value: unknown): bigint | null {
-  if (typeof value === 'bigint') return normalizeMagnitude(value);
-  if (typeof value === 'number') {
+  if (typeof value === "bigint") return normalizeMagnitude(value);
+  if (typeof value === "number") {
     if (!Number.isFinite(value)) return null;
     return normalizeMagnitude(BigInt(Math.trunc(value)));
   }
-  if (typeof value === 'string') {
+  if (typeof value === "string") {
     if (!value) return null;
     if (/^\d+$/u.test(value)) return normalizeMagnitude(BigInt(value));
     const ms = Date.parse(value);

--- a/packages/o11ytsdb/src/interner.ts
+++ b/packages/o11ytsdb/src/interner.ts
@@ -6,10 +6,14 @@ const MAX_LOAD = 0.7;
 const DEFAULT_MAX_CARDINALITY = 1_000_000;
 
 export class Interner {
-  private readonly encoder = new ((globalThis as unknown) as { TextEncoder: new () => { encode(input: string): Uint8Array } }).TextEncoder();
-  private readonly decoder = new ((globalThis as unknown) as {
-    TextDecoder: new () => { decode(input: Uint8Array): string };
-  }).TextDecoder();
+  private readonly encoder = new (
+    globalThis as unknown as { TextEncoder: new () => { encode(input: string): Uint8Array } }
+  ).TextEncoder();
+  private readonly decoder = new (
+    globalThis as unknown as {
+      TextDecoder: new () => { decode(input: Uint8Array): string };
+    }
+  ).TextDecoder();
 
   private bytes = new Uint8Array(1024);
   private bytesUsed = 0;
@@ -34,6 +38,7 @@ export class Interner {
   bulkIntern(strings: string[]): Uint32Array {
     const ids = new Uint32Array(strings.length);
     for (let i = 0; i < strings.length; i++) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       ids[i] = this.intern(strings[i]!);
     }
     return ids;
@@ -43,7 +48,9 @@ export class Interner {
     if (id < 0 || id >= this.count) {
       throw new RangeError(`invalid intern id: ${id}`);
     }
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const start = this.offsets[id]!;
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const end = this.offsets[id + 1]!;
     return this.decoder.decode(this.bytes.subarray(start, end));
   }
@@ -53,7 +60,12 @@ export class Interner {
   }
 
   memoryBytes(): number {
-    return this.bytes.byteLength + this.offsets.byteLength + this.slots.byteLength + this.hashes.byteLength;
+    return (
+      this.bytes.byteLength +
+      this.offsets.byteLength +
+      this.slots.byteLength +
+      this.hashes.byteLength
+    );
   }
 
   private internBytes(encoded: Uint8Array): InternId {
@@ -63,13 +75,14 @@ export class Interner {
     const hash = fnv1a(encoded) || 1;
     let slot = hash & this.mask;
     while (true) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       const existing = this.slots[slot]!;
       if (existing === 0) {
         if (this.count >= this.maxCardinality) {
           throw new RangeError(
             `Interner cardinality limit reached (${this.maxCardinality}). ` +
-            'This likely indicates high-entropy label values (e.g. request IDs, timestamps). ' +
-            'Increase maxCardinality if this is intentional.',
+              "This likely indicates high-entropy label values (e.g. request IDs, timestamps). " +
+              "Increase maxCardinality if this is intentional."
           );
         }
         return this.insert(slot, hash, encoded);
@@ -83,7 +96,9 @@ export class Interner {
   }
 
   private equalsBytes(id: number, candidate: Uint8Array): boolean {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const start = this.offsets[id]!;
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const end = this.offsets[id + 1]!;
     if (end - start !== candidate.length) return false;
     for (let i = 0; i < candidate.length; i++) {
@@ -131,8 +146,10 @@ export class Interner {
     const hashes = new Uint32Array(newSize);
     const mask = newSize - 1;
     for (let i = 0; i < this.slots.length; i++) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       const entry = this.slots[i]!;
       if (entry === 0) continue;
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       const hash = this.hashes[i]!;
       let slot = hash & mask;
       while (slots[slot] !== 0) slot = (slot + 1) & mask;
@@ -148,6 +165,7 @@ export class Interner {
 export function fnv1a(input: Uint8Array): number {
   let hash = FNV_OFFSET >>> 0;
   for (let i = 0; i < input.length; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     hash ^= input[i]!;
     hash = Math.imul(hash, FNV_PRIME) >>> 0;
   }

--- a/packages/o11ytsdb/src/label-index.ts
+++ b/packages/o11ytsdb/src/label-index.ts
@@ -6,9 +6,9 @@
  * that was previously copied across FlatStore, ChunkedStore, and ColumnStore.
  */
 
-import { Interner } from './interner.js';
-import { MemPostings } from './postings.js';
-import type { Labels, SeriesId } from './types.js';
+import { Interner } from "./interner.js";
+import { MemPostings } from "./postings.js";
+import type { Labels, SeriesId } from "./types.js";
 
 export class LabelIndex {
   readonly interner: Interner;
@@ -50,6 +50,7 @@ export class LabelIndex {
     if (!pairs) return undefined;
     const out = new Map<string, string>();
     for (let i = 0; i < pairs.length; i += 2) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       out.set(this.interner.resolve(pairs[i]!), this.interner.resolve(pairs[i + 1]!));
     }
     return out;
@@ -71,9 +72,10 @@ function internLabels(labels: Labels, interner: Interner): Uint32Array {
   for (const [k, v] of labels) {
     pairs.push([interner.intern(k), interner.intern(v)]);
   }
-  pairs.sort((a, b) => (a[0] - b[0]) || (a[1] - b[1]));
+  pairs.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
   const encoded = new Uint32Array(pairs.length * 2);
   for (let i = 0; i < pairs.length; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const [k, v] = pairs[i]!;
     encoded[i * 2] = k;
     encoded[i * 2 + 1] = v;
@@ -86,5 +88,5 @@ function seriesKeyFromPairs(labelPairs: Uint32Array): string {
   for (let i = 0; i < labelPairs.length; i += 2) {
     parts.push(`${labelPairs[i]}:${labelPairs[i + 1]}`);
   }
-  return parts.join(',');
+  return parts.join(",");
 }

--- a/packages/o11ytsdb/src/postings.ts
+++ b/packages/o11ytsdb/src/postings.ts
@@ -1,5 +1,5 @@
-import type { Labels, SeriesId } from './types.js';
-import { Interner } from './interner.js';
+import { Interner } from "./interner.js";
+import type { Labels, SeriesId } from "./types.js";
 
 export class MemPostings {
   private readonly byLabel = new Map<number, Map<number, SeriesId[]>>();
@@ -41,6 +41,7 @@ export class MemPostings {
     const out: SeriesId[] = [];
     let j = 0;
     for (let i = 0; i < small.length; i++) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       const v = small[i]!;
       j = gallopLowerBound(big, v, j);
       if (j >= big.length) break;
@@ -54,7 +55,9 @@ export class MemPostings {
     let i = 0;
     let j = 0;
     while (i < a.length && j < b.length) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       const av = a[i]!;
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       const bv = b[j]!;
       if (av === bv) {
         out.push(av);
@@ -68,7 +71,9 @@ export class MemPostings {
         j++;
       }
     }
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     while (i < a.length) out.push(a[i++]!);
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     while (j < b.length) out.push(b[j++]!);
     return out;
   }
@@ -96,10 +101,12 @@ export class MemPostings {
 
 function gallopLowerBound(arr: number[], target: number, from: number): number {
   if (from >= arr.length) return arr.length;
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   if (arr[from]! >= target) return from;
   let step = 1;
   let lo = from + 1;
   let hi = lo;
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   while (hi < arr.length && arr[hi]! < target) {
     lo = hi + 1;
     step <<= 1;
@@ -110,6 +117,7 @@ function gallopLowerBound(arr: number[], target: number, from: number): number {
   let right = hi;
   while (left <= right) {
     const mid = (left + right) >>> 1;
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     if (arr[mid]! < target) left = mid + 1;
     else right = mid - 1;
   }

--- a/packages/o11ytsdb/src/query.ts
+++ b/packages/o11ytsdb/src/query.ts
@@ -7,20 +7,26 @@
  */
 
 import type {
-  AggFn, Labels, QueryEngine, QueryOpts, QueryResult,
-  SeriesResult, StorageBackend, TimeRange,
-} from './types.js';
+  AggFn,
+  Labels,
+  QueryEngine,
+  QueryOpts,
+  QueryResult,
+  SeriesResult,
+  StorageBackend,
+  TimeRange,
+} from "./types.js";
 
 export class ScanEngine implements QueryEngine {
-  readonly name = 'scan';
+  readonly name = "scan";
 
   query(storage: StorageBackend, opts: QueryOpts): QueryResult {
     // Find matching series.
-    let ids = storage.matchLabel('__name__', opts.metric);
+    let ids = storage.matchLabel("__name__", opts.metric);
     if (opts.matchers) {
       for (const m of opts.matchers) {
         const mIds = new Set(storage.matchLabel(m.label, m.value));
-        ids = ids.filter(id => mIds.has(id));
+        ids = ids.filter((id) => mIds.has(id));
       }
     }
 
@@ -57,13 +63,13 @@ export class ScanEngine implements QueryEngine {
       for (const p of parts) scannedSamples += p.timestamps.length || p.stats?.count || 0;
       const labels = storage.labels(id) ?? new Map();
       const groupKey = opts.groupBy
-        ? opts.groupBy.map(k => labels.get(k) ?? '').join('\0')
-        : '__all__';
+        ? opts.groupBy.map((k) => labels.get(k) ?? "").join("\0")
+        : "__all__";
 
       let group = groups.get(groupKey);
       if (!group) {
         const groupLabels = new Map<string, string>();
-        groupLabels.set('__name__', opts.metric);
+        groupLabels.set("__name__", opts.metric);
         if (opts.groupBy) {
           for (const k of opts.groupBy) {
             const v = labels.get(k);
@@ -95,27 +101,35 @@ export class ScanEngine implements QueryEngine {
 
 /** Initial accumulator value for a given aggregation function. */
 function aggInit(fn: AggFn): number {
-  if (fn === 'min') return Infinity;
-  if (fn === 'max') return -Infinity;
+  if (fn === "min") return Infinity;
+  if (fn === "max") return -Infinity;
   return 0;
 }
 
 /** Fold a new value into an accumulator for the given agg function. */
 function aggAccumulate(accum: number, v: number, fn: AggFn): number {
   switch (fn) {
-    case 'sum': case 'avg': return accum + v;
-    case 'min': return v < accum ? v : accum;
-    case 'max': return v > accum ? v : accum;
-    case 'count': return accum + 1;
-    case 'last': return v;
-    default: return accum;
+    case "sum":
+    case "avg":
+      return accum + v;
+    case "min":
+      return v < accum ? v : accum;
+    case "max":
+      return v > accum ? v : accum;
+    case "count":
+      return accum + 1;
+    case "last":
+      return v;
+    default:
+      return accum;
   }
 }
 
 /** Finalize aggregated buckets (e.g. divide by count for avg). */
 function aggFinalize(values: Float64Array, counts: Float64Array, fn: AggFn): void {
-  if (fn === 'avg') {
+  if (fn === "avg") {
     for (let i = 0; i < values.length; i++) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       if (counts[i]! > 0) values[i]! /= counts[i]!;
     }
   }
@@ -137,6 +151,7 @@ function aggregate(ranges: TimeRange[], fn: AggFn, step?: bigint): TimeRange {
 
 function pointAggregate(ranges: TimeRange[], fn: AggFn): TimeRange {
   // Use the longest series as the timestamp base.
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   let longest = ranges[0]!;
   for (const r of ranges) {
     if (r.timestamps.length > longest.timestamps.length) longest = r;
@@ -145,11 +160,14 @@ function pointAggregate(ranges: TimeRange[], fn: AggFn): TimeRange {
   const timestamps = longest.timestamps;
   const values = new Float64Array(timestamps.length);
 
-  if (fn === 'rate') {
+  if (fn === "rate") {
     // Rate only makes sense per-series; use first.
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const src = ranges[0]!;
     for (let i = 1; i < src.timestamps.length; i++) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       const dt = Number(src.timestamps[i]! - src.timestamps[i - 1]!) / 1000; // ms → sec
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       values[i] = dt > 0 ? (src.values[i]! - src.values[i - 1]!) / dt : 0;
     }
     return { timestamps, values };
@@ -162,7 +180,9 @@ function pointAggregate(ranges: TimeRange[], fn: AggFn): TimeRange {
     // Simple: assume aligned timestamps. Real engine would merge-sort.
     const len = Math.min(r.values.length, timestamps.length);
     for (let i = 0; i < len; i++) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       values[i] = aggAccumulate(values[i]!, r.values[i]!, fn);
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       counts[i]!++;
     }
   }
@@ -178,12 +198,15 @@ const _le = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
 
 function stepAggregate(ranges: TimeRange[], fn: AggFn, step: bigint): TimeRange {
   // Find time bounds (account for both sample-bearing and stats-only parts).
-  let minT = BigInt('9223372036854775807');
+  let minT = BigInt("9223372036854775807");
   let maxT = -minT;
   for (const r of ranges) {
     if (r.timestamps.length > 0) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       if (r.timestamps[0]! < minT) minT = r.timestamps[0]!;
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       if (r.timestamps[r.timestamps.length - 1]! > maxT)
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         maxT = r.timestamps[r.timestamps.length - 1]!;
     } else if (r.stats && r.chunkMinT !== undefined && r.chunkMaxT !== undefined) {
       if (r.chunkMinT < minT) minT = r.chunkMinT;
@@ -212,33 +235,40 @@ function stepAggregate(ranges: TimeRange[], fn: AggFn, step: bigint): TimeRange 
   // ── Stats-skip: fold pre-computed chunk stats when the chunk fits in one bucket ──
   // Remaining ranges that need sample-level iteration.
   let sampleRanges: TimeRange[];
-  if (fn !== 'rate') {
+  if (fn !== "rate") {
     sampleRanges = [];
     for (let ri = 0; ri < ranges.length; ri++) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       const r = ranges[ri]!;
       if (r.stats && r.chunkMinT !== undefined && r.chunkMaxT !== undefined) {
-        const bucketLo = Number(r.chunkMinT - minT) / stepN | 0;
-        const bucketHi = Number(r.chunkMaxT - minT) / stepN | 0;
+        const bucketLo = (Number(r.chunkMinT - minT) / stepN) | 0;
+        const bucketHi = (Number(r.chunkMaxT - minT) / stepN) | 0;
         if (bucketLo === bucketHi) {
           // Entire chunk maps to one bucket — fold stats directly.
           const st = r.stats;
           switch (fn) {
-            case 'min':
+            case "min":
+              // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
               if (st.minV < values[bucketLo]!) values[bucketLo] = st.minV;
               break;
-            case 'max':
+            case "max":
+              // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
               if (st.maxV > values[bucketLo]!) values[bucketLo] = st.maxV;
               break;
-            case 'sum': case 'avg':
+            case "sum":
+            case "avg":
+              // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
               values[bucketLo]! += st.sum;
               break;
-            case 'count':
+            case "count":
+              // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
               values[bucketLo]! += st.count;
               break;
-            case 'last':
+            case "last":
               values[bucketLo] = st.lastV;
               break;
           }
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           counts[bucketLo]! += st.count;
           continue;
         }
@@ -252,9 +282,7 @@ function stepAggregate(ranges: TimeRange[], fn: AggFn, step: bigint): TimeRange 
     }
   } else {
     // Rate needs per-sample timestamps — always decode stats-only parts.
-    sampleRanges = ranges.map(r =>
-      r.timestamps.length === 0 && r.decode ? r.decode() : r,
-    );
+    sampleRanges = ranges.map((r) => (r.timestamps.length === 0 && r.decode ? r.decode() : r));
   }
 
   // Fused DataView + bucket assignment: read BigInt64 timestamps directly
@@ -262,103 +290,148 @@ function stepAggregate(ranges: TimeRange[], fn: AggFn, step: bigint): TimeRange 
   // allocation per range.  Each range creates one lightweight DataView
   // instead of a full Float64Array copy.
   switch (fn) {
-    case 'min':
+    case "min":
       for (let ri = 0; ri < sampleRanges.length; ri++) {
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const src = sampleRanges[ri]!.timestamps;
         const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const vs = sampleRanges[ri]!.values;
         for (let i = 0, len = src.length; i < len; i++) {
           const off = i << 3;
-          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          const bucket =
+            ((dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN) | 0;
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           if (vs[i]! < values[bucket]!) values[bucket] = vs[i]!;
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           counts[bucket]!++;
         }
       }
       break;
-    case 'max':
+    case "max":
       for (let ri = 0; ri < sampleRanges.length; ri++) {
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const src = sampleRanges[ri]!.timestamps;
         const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const vs = sampleRanges[ri]!.values;
         for (let i = 0, len = src.length; i < len; i++) {
           const off = i << 3;
-          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          const bucket =
+            ((dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN) | 0;
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           if (vs[i]! > values[bucket]!) values[bucket] = vs[i]!;
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           counts[bucket]!++;
         }
       }
       break;
-    case 'sum': case 'avg':
+    case "sum":
+    case "avg":
       for (let ri = 0; ri < sampleRanges.length; ri++) {
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const src = sampleRanges[ri]!.timestamps;
         const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const vs = sampleRanges[ri]!.values;
         for (let i = 0, len = src.length; i < len; i++) {
           const off = i << 3;
-          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          const bucket =
+            ((dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN) | 0;
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           values[bucket]! += vs[i]!;
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           counts[bucket]!++;
         }
       }
       break;
-    case 'count':
+    case "count":
       for (let ri = 0; ri < sampleRanges.length; ri++) {
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const src = sampleRanges[ri]!.timestamps;
         const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
         for (let i = 0, len = src.length; i < len; i++) {
           const off = i << 3;
-          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          const bucket =
+            ((dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN) | 0;
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           values[bucket]!++;
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           counts[bucket]!++;
         }
       }
       break;
-    case 'last':
+    case "last":
       for (let ri = 0; ri < sampleRanges.length; ri++) {
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const src = sampleRanges[ri]!.timestamps;
         const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const vs = sampleRanges[ri]!.values;
         for (let i = 0, len = src.length; i < len; i++) {
           const off = i << 3;
-          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          const bucket =
+            ((dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN) | 0;
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           values[bucket] = vs[i]!;
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           counts[bucket]!++;
         }
       }
       break;
-    case 'rate': {
+    case "rate": {
       const firstTs = new Float64Array(bucketCount).fill(Infinity);
       const firstVal = new Float64Array(bucketCount);
       const lastTs = new Float64Array(bucketCount).fill(-Infinity);
       const lastVal = new Float64Array(bucketCount);
       for (let ri = 0; ri < sampleRanges.length; ri++) {
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const src = sampleRanges[ri]!.timestamps;
         const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const vs = sampleRanges[ri]!.values;
         for (let i = 0, len = src.length; i < len; i++) {
           const off = i << 3;
           const t = dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le);
-          const bucket = (t - minTN) / stepN | 0;
+          const bucket = ((t - minTN) / stepN) | 0;
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           counts[bucket]!++;
-          if (t < firstTs[bucket]!) { firstTs[bucket] = t; firstVal[bucket] = vs[i]!; }
-          if (t >= lastTs[bucket]!) { lastTs[bucket] = t; lastVal[bucket] = vs[i]!; }
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
+          if (t < firstTs[bucket]!) {
+            firstTs[bucket] = t;
+            // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
+            firstVal[bucket] = vs[i]!;
+          }
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
+          if (t >= lastTs[bucket]!) {
+            lastTs[bucket] = t;
+            // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
+            lastVal[bucket] = vs[i]!;
+          }
         }
       }
       for (let i = 0; i < bucketCount; i++) {
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const dt = (lastTs[i]! - firstTs[i]!) / 1000;
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         values[i] = dt > 0 ? (lastVal[i]! - firstVal[i]!) / dt : 0;
       }
       break;
     }
     default:
       for (let ri = 0; ri < sampleRanges.length; ri++) {
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const src = sampleRanges[ri]!.timestamps;
         const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const vs = sampleRanges[ri]!.values;
         for (let i = 0; i < src.length; i++) {
           const off = i << 3;
-          const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+          const bucket =
+            ((dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN) | 0;
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           values[bucket] = aggAccumulate(values[bucket]!, vs[i]!, fn);
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           counts[bucket]!++;
         }
       }
@@ -368,8 +441,9 @@ function stepAggregate(ranges: TimeRange[], fn: AggFn, step: bigint): TimeRange 
 
   // Replace init-value sentinels with NaN in empty buckets so consumers
   // see "no data" instead of Infinity / -Infinity / 0.
-  if (fn !== 'sum' && fn !== 'count') {
+  if (fn !== "sum" && fn !== "count") {
     for (let i = 0; i < bucketCount; i++) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       if (counts[i]! === 0) values[i] = NaN;
     }
   }

--- a/packages/o11ytsdb/src/row-group-store.ts
+++ b/packages/o11ytsdb/src/row-group-store.ts
@@ -133,6 +133,7 @@ export class RowGroupStore implements StorageBackend {
       });
     }
 
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const group = this.groups[groupId]!;
     const memberIndex = group.members.length;
     group.members.push(id);
@@ -146,7 +147,9 @@ export class RowGroupStore implements StorageBackend {
   }
 
   append(id: SeriesId, timestamp: bigint, value: number): void {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.allSeries[id]!;
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const group = this.groups[s.groupId]!;
 
     if (s.hot.count === group.hotCount) {
@@ -167,7 +170,9 @@ export class RowGroupStore implements StorageBackend {
   }
 
   appendBatch(id: SeriesId, timestamps: BigInt64Array, values: Float64Array): void {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.allSeries[id]!;
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const group = this.groups[s.groupId]!;
     let offset = 0;
     const len = timestamps.length;
@@ -204,6 +209,7 @@ export class RowGroupStore implements StorageBackend {
       if (this.quantize) {
         const q = this.quantize;
         for (let i = 0; i < batch; i++) {
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           s.hot.values[s.hot.count + i] = q(values[offset + i]!);
         }
       } else {
@@ -230,22 +236,28 @@ export class RowGroupStore implements StorageBackend {
   }
 
   read(id: SeriesId, start: bigint, end: bigint): TimeRange {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.allSeries[id]!;
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const group = this.groups[s.groupId]!;
     const parts: TimeRange[] = [];
 
     if (this.rangeCodec && this.tsCodec) {
       for (const rg of group.rowGroups) {
         if (s.memberIndex >= rg.memberCount) continue;
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const tsChunk = group.frozenTimestamps[rg.tsChunkIndex]!;
         if (tsChunk.maxT < start || tsChunk.minT > end) continue;
 
         const compressedValues = rg.valueBuffer.subarray(
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           rg.offsets[s.memberIndex]!,
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           rg.offsets[s.memberIndex]! + rg.sizes[s.memberIndex]!
         );
 
         const result = this.rangeCodec.rangeDecodeValues(
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           tsChunk.compressed!,
           compressedValues,
           start,
@@ -254,6 +266,7 @@ export class RowGroupStore implements StorageBackend {
         if (result.timestamps.length > 0) {
           parts.push(result);
           if (!tsChunk.timestamps) {
+            // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
             tsChunk.timestamps = this.tsCodec.decodeTimestamps(tsChunk.compressed!);
           }
         }
@@ -261,16 +274,20 @@ export class RowGroupStore implements StorageBackend {
     } else {
       for (const rg of group.rowGroups) {
         if (s.memberIndex >= rg.memberCount) continue;
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const tsChunk = group.frozenTimestamps[rg.tsChunkIndex]!;
         if (tsChunk.maxT < start || tsChunk.minT > end) continue;
 
         if (!tsChunk.timestamps && this.tsCodec && tsChunk.compressed) {
           tsChunk.timestamps = this.tsCodec.decodeTimestamps(tsChunk.compressed);
         }
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const timestamps = tsChunk.timestamps!;
 
         const compressedValues = rg.valueBuffer.subarray(
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           rg.offsets[s.memberIndex]!,
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           rg.offsets[s.memberIndex]! + rg.sizes[s.memberIndex]!
         );
         const values = this.valuesCodec.decodeValues(compressedValues);
@@ -347,6 +364,7 @@ export class RowGroupStore implements StorageBackend {
   private maybeFreeze(group: SeriesGroup): void {
     let minCount = Infinity;
     for (const memberId of group.members) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       const c = this.allSeries[memberId]!.hot.count;
       if (c < minCount) minCount = c;
     }
@@ -369,14 +387,18 @@ export class RowGroupStore implements StorageBackend {
         const compressed = this.tsCodec.encodeTimestamps(ts);
         group.frozenTimestamps.push({
           compressed,
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           minT: ts[0]!,
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           maxT: ts[this.chunkSize - 1]!,
           count: this.chunkSize,
         });
       } else {
         group.frozenTimestamps.push({
           timestamps: ts,
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           minT: ts[0]!,
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           maxT: ts[this.chunkSize - 1]!,
           count: this.chunkSize,
         });
@@ -392,11 +414,14 @@ export class RowGroupStore implements StorageBackend {
           const bEnd = Math.min(bStart + BATCH_CAP, numMembers);
           const arrays: Float64Array[] = [];
           for (let m = bStart; m < bEnd; m++) {
+            // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
             const s = this.allSeries[group.members[m]!]!;
             arrays.push(s.hot.values.subarray(chunkStart, chunkStart + this.chunkSize));
           }
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           const results = this.valuesCodec.encodeBatchValuesWithStats!(arrays);
           for (let m = 0; m < results.length; m++) {
+            // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
             const { compressed, stats } = results[m]!;
             blobs.push(compressed);
             allStats.push(stats);
@@ -404,12 +429,14 @@ export class RowGroupStore implements StorageBackend {
         }
       } else {
         for (const memberId of group.members) {
+          // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
           const s = this.allSeries[memberId]!;
           const vals = s.hot.values.subarray(chunkStart, chunkStart + this.chunkSize);
 
           let compressed: Uint8Array;
           let stats: ChunkStats;
           if (hasWasmStats) {
+            // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
             const result = this.valuesCodec.encodeValuesWithStats!(vals);
             compressed = result.compressed;
             stats = result.stats;
@@ -433,12 +460,14 @@ export class RowGroupStore implements StorageBackend {
 
       let pos = 0;
       for (let m = 0; m < numMembers; m++) {
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const blob = blobs[m]!;
         valueBuffer.set(blob, pos);
         offsets[m] = pos;
         sizes[m] = blob.byteLength;
         pos += blob.byteLength;
 
+        // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
         const st = allStats[m]!;
         const si = m * 8;
         packedStats[si] = st.minV;
@@ -464,6 +493,7 @@ export class RowGroupStore implements StorageBackend {
     // Shift remaining hot data back.
     const frozenSamples = chunksToFreeze * this.chunkSize;
     for (const memberId of group.members) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
       const s = this.allSeries[memberId]!;
       const remaining = s.hot.count - frozenSamples;
       if (remaining > 0) {

--- a/packages/o11ytsdb/src/row-group-store.ts
+++ b/packages/o11ytsdb/src/row-group-store.ts
@@ -122,6 +122,9 @@ export class RowGroupStore implements StorageBackend {
     if (!isNew) return id;
 
     const groupId = this.groupResolver(labels);
+    if (!Number.isInteger(groupId) || groupId < 0) {
+      throw new RangeError(`groupResolver must return a non-negative integer, got ${groupId}`);
+    }
 
     while (this.groups.length <= groupId) {
       this.groups.push({
@@ -170,6 +173,10 @@ export class RowGroupStore implements StorageBackend {
   }
 
   appendBatch(id: SeriesId, timestamps: BigInt64Array, values: Float64Array): void {
+    if (timestamps.length !== values.length) {
+      throw new RangeError(`appendBatch: timestamps.length (${timestamps.length}) !== values.length (${values.length})`);
+    }
+    if (timestamps.length === 0) return;
     // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const s = this.allSeries[id]!;
     // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction

--- a/packages/o11ytsdb/src/stats.ts
+++ b/packages/o11ytsdb/src/stats.ts
@@ -2,18 +2,24 @@ import type { ChunkStats } from "./types.js";
 
 export function computeStats(values: Float64Array): ChunkStats {
   const n = values.length;
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   let minV = values[0]!;
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   let maxV = values[0]!;
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   let sum = values[0]!;
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   let sumOfSquares = values[0]! * values[0]!;
   let resetCount = 0;
 
   for (let i = 1; i < n; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     const v = values[i]!;
     if (v < minV) minV = v;
     if (v > maxV) maxV = v;
     sum += v;
     sumOfSquares += v * v;
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     if (v < values[i - 1]!) resetCount++;
   }
 
@@ -22,7 +28,9 @@ export function computeStats(values: Float64Array): ChunkStats {
     maxV,
     sum,
     count: n,
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     firstV: values[0]!,
+    // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
     lastV: values[n - 1]!,
     sumOfSquares,
     resetCount,

--- a/packages/o11ytsdb/src/stats.ts
+++ b/packages/o11ytsdb/src/stats.ts
@@ -2,7 +2,10 @@ import type { ChunkStats } from "./types.js";
 
 export function computeStats(values: Float64Array): ChunkStats {
   const n = values.length;
-  // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
+  if (n === 0) {
+    throw new RangeError("computeStats requires at least one sample");
+  }
+  // biome-ignore lint/style/noNonNullAssertion: bounds-checked above
   let minV = values[0]!;
   // biome-ignore lint/style/noNonNullAssertion: bounds-checked by construction
   let maxV = values[0]!;

--- a/packages/o11ytsdb/src/types.ts
+++ b/packages/o11ytsdb/src/types.ts
@@ -46,7 +46,9 @@ export interface ValuesCodec {
   /** Optional: encode values and compute block stats in one pass (WASM fast-path). */
   encodeValuesWithStats?(values: Float64Array): { compressed: Uint8Array; stats: ChunkStats };
   /** Optional: batch-encode N arrays in a single WASM call, returning compressed blobs + stats. */
-  encodeBatchValuesWithStats?(arrays: Float64Array[]): Array<{ compressed: Uint8Array; stats: ChunkStats }>;
+  encodeBatchValuesWithStats?(
+    arrays: Float64Array[]
+  ): Array<{ compressed: Uint8Array; stats: ChunkStats }>;
   /** Optional: batch-decode N compressed blobs in a single WASM call. */
   decodeBatchValues?(blobs: Uint8Array[], chunkSize: number): Float64Array[];
 }
@@ -74,7 +76,7 @@ export interface RangeDecodeCodec {
     compressedTimestamps: Uint8Array,
     compressedValues: Uint8Array,
     startT: bigint,
-    endT: bigint,
+    endT: bigint
   ): RangeDecodeResult;
 }
 
@@ -131,7 +133,7 @@ export interface StorageBackend {
 
 // ── Query engine ─────────────────────────────────────────────────────
 
-export type AggFn = 'sum' | 'avg' | 'min' | 'max' | 'count' | 'last' | 'rate';
+export type AggFn = "sum" | "avg" | "min" | "max" | "count" | "last" | "rate";
 
 export interface Matcher {
   label: string;

--- a/packages/o11ytsdb/src/worker-client.ts
+++ b/packages/o11ytsdb/src/worker-client.ts
@@ -1,4 +1,4 @@
-import type { QueryOpts, QueryResult } from './types.js';
+import type { QueryOpts, QueryResult } from "./types.js";
 import {
   isResponseEnvelope,
   type RequestEnvelope,
@@ -7,7 +7,7 @@ import {
   type TransferStrategy,
   type WorkerRequest,
   type WorkerResponse,
-} from './worker-protocol.js';
+} from "./worker-protocol.js";
 
 interface MessageEventLike {
   data: unknown;
@@ -15,7 +15,7 @@ interface MessageEventLike {
 
 interface WorkerLike {
   postMessage(message: unknown, transfer?: ArrayBufferLike[]): void;
-  addEventListener(type: 'message', listener: (event: MessageEventLike) => void): void;
+  addEventListener(type: "message", listener: (event: MessageEventLike) => void): void;
   terminate?: () => void;
 }
 
@@ -37,76 +37,81 @@ export class WorkerClient {
 
   constructor(opts: WorkerClientOptions) {
     this.worker = opts.worker;
-    this.transferStrategy = opts.transferStrategy ?? 'transferable';
-    this.worker.addEventListener('message', (event) => this.onMessage(event.data));
+    this.transferStrategy = opts.transferStrategy ?? "transferable";
+    this.worker.addEventListener("message", (event) => this.onMessage(event.data));
   }
 
   async init(chunkSize?: number): Promise<{ backend: string }> {
-    const payload: WorkerRequest = chunkSize === undefined
-      ? { type: 'init' }
-      : { type: 'init', chunkSize };
+    const payload: WorkerRequest =
+      chunkSize === undefined ? { type: "init" } : { type: "init", chunkSize };
 
     const response = await this.send(payload);
     if (response.ok === false) throw new Error(response.error);
-    if (response.type !== 'init') throw new Error(`Unexpected response type: ${response.type}`);
+    if (response.type !== "init") throw new Error(`Unexpected response type: ${response.type}`);
     return { backend: response.backend };
   }
 
   async ingest(
     labels: ReadonlyMap<string, string>,
     timestamps: BigInt64Array,
-    values: Float64Array,
+    values: Float64Array
   ): Promise<{ seriesId: number; ingestedSamples: number }> {
-    const response = await this.send({
-      type: 'ingest',
-      labels: [...labels.entries()],
-      timestamps,
-      values,
-    }, this.getTransferables(timestamps, values));
+    const response = await this.send(
+      {
+        type: "ingest",
+        labels: [...labels.entries()],
+        timestamps,
+        values,
+      },
+      this.getTransferables(timestamps, values)
+    );
 
     if (response.ok === false) throw new Error(response.error);
-    if (response.type !== 'ingest') throw new Error(`Unexpected response type: ${response.type}`);
+    if (response.type !== "ingest") throw new Error(`Unexpected response type: ${response.type}`);
     return { seriesId: response.seriesId, ingestedSamples: response.ingestedSamples };
   }
 
   async query(opts: QueryOpts): Promise<QueryResult> {
-    const response = await this.send({ type: 'query', opts });
+    const response = await this.send({ type: "query", opts });
     if (response.ok === false) throw new Error(response.error);
-    if (response.type !== 'query') throw new Error(`Unexpected response type: ${response.type}`);
+    if (response.type !== "query") throw new Error(`Unexpected response type: ${response.type}`);
     return response.result;
   }
 
   async stats(): Promise<{ seriesCount: number; sampleCount: number; memoryBytes: number }> {
-    const response = await this.send({ type: 'stats' });
+    const response = await this.send({ type: "stats" });
     if (response.ok === false) throw new Error(response.error);
-    if (response.type !== 'stats') throw new Error(`Unexpected response type: ${response.type}`);
+    if (response.type !== "stats") throw new Error(`Unexpected response type: ${response.type}`);
     return response.stats;
   }
 
-  async echo(payload: Uint8Array, strategy: TransferStrategy = this.transferStrategy): Promise<number> {
-    const transferables = strategy === 'transferable' ? [payload.buffer] : [];
-    const response = await this.send({ type: 'echo', payload }, transferables, strategy);
+  async echo(
+    payload: Uint8Array,
+    strategy: TransferStrategy = this.transferStrategy
+  ): Promise<number> {
+    const transferables = strategy === "transferable" ? [payload.buffer] : [];
+    const response = await this.send({ type: "echo", payload }, transferables, strategy);
     if (response.ok === false) throw new Error(response.error);
-    if (response.type !== 'echo') throw new Error(`Unexpected response type: ${response.type}`);
+    if (response.type !== "echo") throw new Error(`Unexpected response type: ${response.type}`);
     return response.bytes;
   }
 
   async close(): Promise<void> {
-    const response = await this.send({ type: 'close' });
+    const response = await this.send({ type: "close" });
     if (response.ok === false) throw new Error(response.error);
-    if (response.type !== 'close') throw new Error(`Unexpected response type: ${response.type}`);
+    if (response.type !== "close") throw new Error(`Unexpected response type: ${response.type}`);
     this.worker.terminate?.();
   }
 
   private send<T extends WorkerRequest>(
     payload: T,
     transfer: ArrayBufferLike[] = [],
-    strategy: TransferStrategy = this.transferStrategy,
+    strategy: TransferStrategy = this.transferStrategy
   ): Promise<WorkerResponse> {
     const id = this.nextId++;
     const envelope: RequestEnvelope<T> = {
       id,
-      kind: 'request',
+      kind: "request",
       payload,
       meta: { strategy, sentAt: Date.now() },
     };
@@ -132,7 +137,7 @@ export class WorkerClient {
   }
 
   private getTransferables(timestamps: BigInt64Array, values: Float64Array): ArrayBufferLike[] {
-    if (this.transferStrategy !== 'transferable') return [];
+    if (this.transferStrategy !== "transferable") return [];
     return [timestamps.buffer, values.buffer];
   }
 }

--- a/packages/o11ytsdb/src/worker-protocol.ts
+++ b/packages/o11ytsdb/src/worker-protocol.ts
@@ -1,8 +1,8 @@
-import type { QueryOpts, QueryResult } from './types.js';
+import type { QueryOpts, QueryResult } from "./types.js";
 
 export type RequestId = number;
 
-export type TransferStrategy = 'structured-clone' | 'transferable' | 'shared-array-buffer';
+export type TransferStrategy = "structured-clone" | "transferable" | "shared-array-buffer";
 
 export type LabelEntries = Array<[string, string]>;
 
@@ -12,59 +12,65 @@ export interface ProtocolMeta {
 }
 
 export interface InitRequest {
-  type: 'init';
+  type: "init";
   chunkSize?: number;
 }
 
 export interface IngestRequest {
-  type: 'ingest';
+  type: "ingest";
   labels: LabelEntries;
   timestamps: BigInt64Array;
   values: Float64Array;
 }
 
 export interface QueryRequest {
-  type: 'query';
+  type: "query";
   opts: QueryOpts;
 }
 
 export interface StatsRequest {
-  type: 'stats';
+  type: "stats";
 }
 
 export interface CloseRequest {
-  type: 'close';
+  type: "close";
 }
 
 export interface EchoRequest {
-  type: 'echo';
+  type: "echo";
   payload: Uint8Array;
 }
 
-export type WorkerRequest = InitRequest | IngestRequest | QueryRequest | StatsRequest | CloseRequest | EchoRequest;
+export type WorkerRequest =
+  | InitRequest
+  | IngestRequest
+  | QueryRequest
+  | StatsRequest
+  | CloseRequest
+  | EchoRequest;
 
 export interface InitResponse {
   ok: true;
-  type: 'init';
+  type: "init";
   backend: string;
 }
 
 export interface IngestResponse {
   ok: true;
-  type: 'ingest';
+  type: "ingest";
   seriesId: number;
   ingestedSamples: number;
 }
 
 export interface QueryResponse {
   ok: true;
-  type: 'query';
+  type: "query";
   result: QueryResult;
 }
 
 export interface StatsResponse {
   ok: true;
-  type: 'stats';
+  type: "stats";
   stats: {
     seriesCount: number;
     sampleCount: number;
@@ -74,57 +80,70 @@ export interface StatsResponse {
 
 export interface EchoResponse {
   ok: true;
-  type: 'echo';
+  type: "echo";
   bytes: number;
 }
 
 export interface CloseResponse {
   ok: true;
-  type: 'close';
+  type: "close";
 }
 
 export interface ErrorResponse {
   ok: false;
-  type: 'error';
+  type: "error";
   error: string;
   stack?: string;
 }
 
-export type WorkerResponse = InitResponse | IngestResponse | QueryResponse | StatsResponse | EchoResponse | CloseResponse | ErrorResponse;
+export type WorkerResponse =
+  | InitResponse
+  | IngestResponse
+  | QueryResponse
+  | StatsResponse
+  | EchoResponse
+  | CloseResponse
+  | ErrorResponse;
 
 export interface RequestEnvelope<T extends WorkerRequest = WorkerRequest> {
   id: RequestId;
-  kind: 'request';
+  kind: "request";
   payload: T;
   meta?: ProtocolMeta;
 }
 
 export interface ResponseEnvelope<T extends WorkerResponse = WorkerResponse> {
   id: RequestId;
-  kind: 'response';
+  kind: "response";
   payload: T;
   meta?: ProtocolMeta;
 }
 
-export function ok<T extends WorkerResponse>(id: RequestId, payload: T, meta?: ProtocolMeta): ResponseEnvelope<T> {
-  return meta ? { id, kind: 'response', payload, meta } : { id, kind: 'response', payload };
+export function ok<T extends WorkerResponse>(
+  id: RequestId,
+  payload: T,
+  meta?: ProtocolMeta
+): ResponseEnvelope<T> {
+  return meta ? { id, kind: "response", payload, meta } : { id, kind: "response", payload };
 }
 
-export function err(id: RequestId, error: unknown, meta?: ProtocolMeta): ResponseEnvelope<ErrorResponse> {
+export function err(
+  id: RequestId,
+  error: unknown,
+  meta?: ProtocolMeta
+): ResponseEnvelope<ErrorResponse> {
   const message = error instanceof Error ? error.message : String(error);
   const stack = error instanceof Error ? error.stack : undefined;
   const payload: ErrorResponse = stack
-    ? { ok: false, type: 'error', error: message, stack }
-    : { ok: false, type: 'error', error: message };
-  return meta
-    ? { id, kind: 'response', payload, meta }
-    : { id, kind: 'response', payload };
+    ? { ok: false, type: "error", error: message, stack }
+    : { ok: false, type: "error", error: message };
+  return meta ? { id, kind: "response", payload, meta } : { id, kind: "response", payload };
 }
 
 export function isResponseEnvelope(value: unknown): value is ResponseEnvelope {
-  if (!value || typeof value !== 'object') return false;
+  if (!value || typeof value !== "object") return false;
   const candidate = value as Partial<ResponseEnvelope>;
-  return candidate.kind === 'response' && typeof candidate.id === 'number' && !!candidate.payload;
+  return candidate.kind === "response" && typeof candidate.id === "number" && !!candidate.payload;
 }
 
 export function labelsFromEntries(entries: LabelEntries): ReadonlyMap<string, string> {

--- a/packages/o11ytsdb/src/worker.ts
+++ b/packages/o11ytsdb/src/worker.ts
@@ -1,22 +1,17 @@
-import { ColumnStore } from './column-store.js';
-import { ScanEngine } from './query.js';
-import type { QueryEngine, StorageBackend, ValuesCodec } from './types.js';
-import {
-  err,
-  ok,
-  type RequestEnvelope,
-  type ResponseEnvelope,
-} from './worker-protocol.js';
+import { ColumnStore } from "./column-store.js";
+import { ScanEngine } from "./query.js";
+import type { QueryEngine, StorageBackend, ValuesCodec } from "./types.js";
+import { err, ok, type RequestEnvelope, type ResponseEnvelope } from "./worker-protocol.js";
 
 interface WorkerLikeEndpoint {
   postMessage(message: unknown, transfer?: ArrayBufferLike[]): void;
-  addEventListener?: (type: 'message', listener: (event: { data: unknown }) => void) => void;
-  on?: (type: 'message', listener: (data: unknown) => void) => void;
+  addEventListener?: (type: "message", listener: (event: { data: unknown }) => void) => void;
+  on?: (type: "message", listener: (data: unknown) => void) => void;
 }
 
 function createValuesCodec(): ValuesCodec {
   return {
-    name: 'f64-plain',
+    name: "f64-plain",
     encodeValues(values: Float64Array): Uint8Array {
       const out = new Uint8Array(4 + values.byteLength);
       new DataView(out.buffer).setUint32(0, values.length, true);
@@ -29,7 +24,11 @@ function createValuesCodec(): ValuesCodec {
       const raw = buf.subarray(4);
       const bytes = raw.byteLength - (raw.byteLength % 8);
       const copy = raw.slice(0, bytes);
-      const values = new Float64Array(copy.buffer, copy.byteOffset, Math.min(n, Math.floor(bytes / 8)));
+      const values = new Float64Array(
+        copy.buffer,
+        copy.byteOffset,
+        Math.min(n, Math.floor(bytes / 8))
+      );
       return values.slice();
     },
   };
@@ -41,21 +40,24 @@ function resolveEndpoint(): WorkerLikeEndpoint {
     postMessage?: (message: unknown, transfer?: ArrayBufferLike[]) => void;
   };
 
-  if (maybeSelf.self && typeof maybeSelf.self.postMessage === 'function') {
+  if (maybeSelf.self && typeof maybeSelf.self.postMessage === "function") {
     return maybeSelf.self;
   }
 
-  if (typeof maybeSelf.postMessage === 'function') {
+  if (typeof maybeSelf.postMessage === "function") {
     return {
       postMessage: maybeSelf.postMessage.bind(globalThis),
       addEventListener: (type, listener) => {
-        (globalThis as unknown as { addEventListener: (event: string, cb: (e: { data: unknown }) => void) => void })
-          .addEventListener(type, listener);
+        (
+          globalThis as unknown as {
+            addEventListener: (event: string, cb: (e: { data: unknown }) => void) => void;
+          }
+        ).addEventListener(type, listener);
       },
     };
   }
 
-  throw new Error('No worker endpoint available.');
+  throw new Error("No worker endpoint available.");
 }
 
 export interface WorkerRuntimeConfig {
@@ -82,66 +84,78 @@ export class O11yWorkerRuntime {
   start(): void {
     const listener = (raw: unknown): void => {
       const eventData = (raw as { data?: unknown }).data ?? raw;
-      if (!eventData || typeof eventData !== 'object') return;
+      if (!eventData || typeof eventData !== "object") return;
 
       const msg = eventData as RequestEnvelope;
-      if (msg.kind !== 'request') return;
+      if (msg.kind !== "request") return;
       void this.handle(msg);
     };
 
-    if (typeof this.endpoint.addEventListener === 'function') {
-      this.endpoint.addEventListener('message', listener);
+    if (typeof this.endpoint.addEventListener === "function") {
+      this.endpoint.addEventListener("message", listener);
       return;
     }
 
-    if (typeof this.endpoint.on === 'function') {
-      this.endpoint.on('message', listener);
+    if (typeof this.endpoint.on === "function") {
+      this.endpoint.on("message", listener);
       return;
     }
 
-    throw new Error('Worker endpoint does not support message listeners.');
+    throw new Error("Worker endpoint does not support message listeners.");
   }
 
   private async handle(msg: RequestEnvelope): Promise<void> {
     const { id, payload, meta } = msg;
     try {
       switch (payload.type) {
-        case 'init': {
+        case "init": {
           const chunkSize = payload.chunkSize ?? 1024;
           this.store = this.createStore(chunkSize);
-          this.send(ok(id, { ok: true, type: 'init', backend: this.store.name }, meta));
+          this.send(ok(id, { ok: true, type: "init", backend: this.store.name }, meta));
           return;
         }
-        case 'ingest': {
+        case "ingest": {
           const labels = new Map(payload.labels);
           const seriesId = this.store.getOrCreateSeries(labels);
           this.store.appendBatch(seriesId, payload.timestamps, payload.values);
-          this.send(ok(id, { ok: true, type: 'ingest', seriesId, ingestedSamples: payload.values.length }, meta));
+          this.send(
+            ok(
+              id,
+              { ok: true, type: "ingest", seriesId, ingestedSamples: payload.values.length },
+              meta
+            )
+          );
           return;
         }
-        case 'query': {
+        case "query": {
           const result = this.engine.query(this.store, payload.opts);
-          this.send(ok(id, { ok: true, type: 'query', result }, meta));
+          this.send(ok(id, { ok: true, type: "query", result }, meta));
           return;
         }
-        case 'stats': {
-          this.send(ok(id, {
-            ok: true,
-            type: 'stats',
-            stats: {
-              seriesCount: this.store.seriesCount,
-              sampleCount: this.store.sampleCount,
-              memoryBytes: this.store.memoryBytes(),
-            },
-          }, meta));
+        case "stats": {
+          this.send(
+            ok(
+              id,
+              {
+                ok: true,
+                type: "stats",
+                stats: {
+                  seriesCount: this.store.seriesCount,
+                  sampleCount: this.store.sampleCount,
+                  memoryBytes: this.store.memoryBytes(),
+                },
+              },
+              meta
+            )
+          );
           return;
         }
-        case 'echo': {
-          this.send(ok(id, { ok: true, type: 'echo', bytes: payload.payload.byteLength }, meta));
+        case "echo": {
+          this.send(ok(id, { ok: true, type: "echo", bytes: payload.payload.byteLength }, meta));
           return;
         }
-        case 'close': {
-          this.send(ok(id, { ok: true, type: 'close' }, meta));
+        case "close": {
+          this.send(ok(id, { ok: true, type: "close" }, meta));
           return;
         }
       }
@@ -156,18 +170,21 @@ export class O11yWorkerRuntime {
 }
 
 const endpointProbe = globalThis as { self?: unknown; onmessage?: unknown };
-if (endpointProbe.self || typeof endpointProbe.onmessage !== 'undefined') {
+if (endpointProbe.self || typeof endpointProbe.onmessage !== "undefined") {
   new O11yWorkerRuntime().start();
 } else {
-  const dynamicImport = new Function('s', 'return import(s)') as (specifier: string) => Promise<any>;
-  void dynamicImport('node:worker_threads')
+  const dynamicImport = new Function("s", "return import(s)") as (
+    specifier: string
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic import requires any
+  ) => Promise<any>;
+  void dynamicImport("node:worker_threads")
     .then((wt) => {
       if (!wt.parentPort) return;
       const endpoint: WorkerLikeEndpoint = {
         postMessage: (message, transfer) => wt.parentPort.postMessage(message, transfer),
         on: (type, listener) => {
-          if (type !== 'message') return;
-          wt.parentPort.on('message', (data: unknown) => listener({ data }));
+          if (type !== "message") return;
+          wt.parentPort.on("message", (data: unknown) => listener({ data }));
         },
       };
       new O11yWorkerRuntime(endpoint).start();

--- a/packages/o11ytsdb/test/codec.test.ts
+++ b/packages/o11ytsdb/test/codec.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-import { BitWriter, BitReader, encodeChunk, decodeChunk } from '../src/codec.js';
+import { BitReader, BitWriter, decodeChunk, encodeChunk } from "../src/codec.js";
 
-describe('BitWriter / BitReader', () => {
-  it('round-trips individual bits', () => {
+describe("BitWriter / BitReader", () => {
+  it("round-trips individual bits", () => {
     const w = new BitWriter();
     w.writeBit(1);
     w.writeBit(0);
@@ -25,24 +25,24 @@ describe('BitWriter / BitReader', () => {
     expect(r.readBit()).toBe(0);
   });
 
-  it('round-trips multi-bit values', () => {
+  it("round-trips multi-bit values", () => {
     const w = new BitWriter();
-    w.writeBits(0xDEADn, 16);
+    w.writeBits(0xdeadn, 16);
     w.writeBitsNum(42, 7);
     const buf = w.finish();
     const r = new BitReader(buf);
-    expect(r.readBits(16)).toBe(0xDEADn);
+    expect(r.readBits(16)).toBe(0xdeadn);
     expect(r.readBitsNum(7)).toBe(42);
   });
 });
 
-describe('encodeChunk / decodeChunk', () => {
-  it('encodes and decodes empty array', () => {
+describe("encodeChunk / decodeChunk", () => {
+  it("encodes and decodes empty array", () => {
     const result = encodeChunk(new BigInt64Array(0), new Float64Array(0));
     expect(result.byteLength).toBe(0);
   });
 
-  it('round-trips a single sample', () => {
+  it("round-trips a single sample", () => {
     const ts = BigInt64Array.from([1_700_000_000_000n]);
     const vals = Float64Array.from([42.5]);
     const compressed = encodeChunk(ts, vals);
@@ -51,7 +51,7 @@ describe('encodeChunk / decodeChunk', () => {
     expect(decoded.values[0]).toBe(vals[0]);
   });
 
-  it('round-trips constant values (all XOR == 0)', () => {
+  it("round-trips constant values (all XOR == 0)", () => {
     const n = 100;
     const ts = new BigInt64Array(n);
     const vals = new Float64Array(n);
@@ -67,7 +67,7 @@ describe('encodeChunk / decodeChunk', () => {
     }
   });
 
-  it('round-trips monotonic counter values', () => {
+  it("round-trips monotonic counter values", () => {
     const n = 500;
     const ts = new BigInt64Array(n);
     const vals = new Float64Array(n);
@@ -84,7 +84,7 @@ describe('encodeChunk / decodeChunk', () => {
     }
   });
 
-  it('round-trips high-entropy float values', () => {
+  it("round-trips high-entropy float values", () => {
     const n = 200;
     const ts = new BigInt64Array(n);
     const vals = new Float64Array(n);
@@ -99,13 +99,13 @@ describe('encodeChunk / decodeChunk', () => {
     }
   });
 
-  it('handles irregular timestamp intervals (large DoD)', () => {
+  it("handles irregular timestamp intervals (large DoD)", () => {
     const ts = BigInt64Array.from([
       1_000_000n,
-      1_015_000n,  // delta=15000
-      1_030_000n,  // delta=15000, dod=0
-      1_100_000n,  // delta=70000, dod=55000 (large)
-      5_000_000n,  // delta=3900000, dod=3830000 (huge)
+      1_015_000n, // delta=15000
+      1_030_000n, // delta=15000, dod=0
+      1_100_000n, // delta=70000, dod=55000 (large)
+      5_000_000n, // delta=3900000, dod=3830000 (huge)
     ]);
     const vals = Float64Array.from([1.0, 2.0, 3.0, 4.0, 5.0]);
     const decoded = decodeChunk(encodeChunk(ts, vals));
@@ -115,7 +115,7 @@ describe('encodeChunk / decodeChunk', () => {
     }
   });
 
-  it('achieves good compression on constant data', () => {
+  it("achieves good compression on constant data", () => {
     const n = 1000;
     const ts = new BigInt64Array(n);
     const vals = new Float64Array(n);
@@ -129,16 +129,15 @@ describe('encodeChunk / decodeChunk', () => {
     expect(compressed.byteLength).toBeLessThan(rawSize / 4);
   });
 
-  it('rejects mismatched array lengths', () => {
-    expect(() => encodeChunk(
-      BigInt64Array.from([1n, 2n]),
-      Float64Array.from([1.0]),
-    )).toThrow('same length');
+  it("rejects mismatched array lengths", () => {
+    expect(() => encodeChunk(BigInt64Array.from([1n, 2n]), Float64Array.from([1.0]))).toThrow(
+      "same length"
+    );
   });
 
-  it('rejects arrays exceeding 65535 samples', () => {
+  it("rejects arrays exceeding 65535 samples", () => {
     const big = new BigInt64Array(70000);
     const bigV = new Float64Array(70000);
-    expect(() => encodeChunk(big, bigV)).toThrow('65535');
+    expect(() => encodeChunk(big, bigV)).toThrow("65535");
   });
 });

--- a/packages/o11ytsdb/test/fixtures/otlp-sample.json
+++ b/packages/o11ytsdb/test/fixtures/otlp-sample.json
@@ -12,9 +12,7 @@
           "scope": {
             "name": "otel.demo",
             "version": "1.2.3",
-            "attributes": [
-              { "key": "scope.role", "value": { "stringValue": "ingester" } }
-            ]
+            "attributes": [{ "key": "scope.role", "value": { "stringValue": "ingester" } }]
           },
           "metrics": [
             {
@@ -24,16 +22,12 @@
                 "dataPoints": [
                   {
                     "timeUnixNano": "1710000000000",
-                    "attributes": [
-                      { "key": "host.name", "value": { "stringValue": "node-a" } }
-                    ],
+                    "attributes": [{ "key": "host.name", "value": { "stringValue": "node-a" } }],
                     "asDouble": 0.73
                   },
                   {
                     "timeUnixNano": "1710000001000000000",
-                    "attributes": [
-                      { "key": "host.name", "value": { "stringValue": "node-a" } }
-                    ],
+                    "attributes": [{ "key": "host.name", "value": { "stringValue": "node-a" } }],
                     "asDouble": 0.74
                   },
                   {
@@ -66,9 +60,7 @@
                 "dataPoints": [
                   {
                     "timeUnixNano": "1710000001000000000",
-                    "attributes": [
-                      { "key": "route", "value": { "stringValue": "/cart" } }
-                    ],
+                    "attributes": [{ "key": "route", "value": { "stringValue": "/cart" } }],
                     "count": "4",
                     "sum": 53,
                     "bucketCounts": ["1", "2", "1"],
@@ -83,9 +75,7 @@
                 "dataPoints": [
                   {
                     "timeUnixNano": "1710000001000000000",
-                    "attributes": [
-                      { "key": "rpc.system", "value": { "stringValue": "grpc" } }
-                    ],
+                    "attributes": [{ "key": "rpc.system", "value": { "stringValue": "grpc" } }],
                     "count": "3",
                     "sum": 21,
                     "quantileValues": [
@@ -102,9 +92,7 @@
                 "dataPoints": [
                   {
                     "timeUnixNano": "1710000001000000000",
-                    "attributes": [
-                      { "key": "queue.name", "value": { "stringValue": "emails" } }
-                    ],
+                    "attributes": [{ "key": "queue.name", "value": { "stringValue": "emails" } }],
                     "count": "5",
                     "sum": 27,
                     "scale": "2",

--- a/packages/o11ytsdb/test/ingest.test.ts
+++ b/packages/o11ytsdb/test/ingest.test.ts
@@ -1,21 +1,21 @@
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
 
-import { FlatStore } from '../src/flat-store.js';
-import { ingestOtlpJson } from '../src/ingest.js';
+import { FlatStore } from "../src/flat-store.js";
+import { ingestOtlpJson } from "../src/ingest.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 function loadFixture(name: string): unknown {
-  const file = join(__dirname, 'fixtures', name);
-  return JSON.parse(readFileSync(file, 'utf8')) as unknown;
+  const file = join(__dirname, "fixtures", name);
+  return JSON.parse(readFileSync(file, "utf8")) as unknown;
 }
 
-describe('o11ytsdb ingestOtlpJson', () => {
-  it('ingests all OTLP metric kinds and batch-inserts samples', () => {
-    const fixture = loadFixture('otlp-sample.json');
+describe("o11ytsdb ingestOtlpJson", () => {
+  it("ingests all OTLP metric kinds and batch-inserts samples", () => {
+    const fixture = loadFixture("otlp-sample.json");
     const storage = new FlatStore();
 
     const result = ingestOtlpJson(fixture, storage);
@@ -36,37 +36,38 @@ describe('o11ytsdb ingestOtlpJson', () => {
     expect(storage.sampleCount).toBe(18);
     expect(storage.seriesCount).toBeGreaterThanOrEqual(10);
 
-    const cpuIds = storage.matchLabel('__name__', 'system.cpu.utilization');
+    const cpuIds = storage.matchLabel("__name__", "system.cpu.utilization");
     expect(cpuIds).toHaveLength(1);
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const cpu = storage.read(cpuIds[0]!, 0n, 3_000_000_000_000_000_000n);
     expect(cpu.values).toHaveLength(2);
 
     // First timestamp was provided in milliseconds and should be normalized to nanos.
     expect(cpu.timestamps[0]).toBe(1_710_000_000_000_000_000n);
 
-    const histBucketIds = storage.matchLabel('__name__', 'http.server.duration_bucket');
+    const histBucketIds = storage.matchLabel("__name__", "http.server.duration_bucket");
     expect(histBucketIds.length).toBeGreaterThan(0);
     const hasLeBucket = histBucketIds
       .map((id) => storage.labels(id))
-      .some((labels) => labels?.has('le'));
+      .some((labels) => labels?.has("le"));
     expect(hasLeBucket).toBe(true);
 
-    const expIds = storage.matchLabel('__name__', 'queue.delay_bucket');
+    const expIds = storage.matchLabel("__name__", "queue.delay_bucket");
     expect(expIds.length).toBeGreaterThan(0);
     const hasZeroBucket = expIds
       .map((id) => storage.labels(id))
-      .some((labels) => labels?.get('exp_bucket') === 'zero');
+      .some((labels) => labels?.get("exp_bucket") === "zero");
     expect(hasZeroBucket).toBe(true);
   });
 
-  it('accepts JSON string payloads and rejects malformed/unsupported payloads gracefully', () => {
-    const fixture = loadFixture('otlp-sample.json');
+  it("accepts JSON string payloads and rejects malformed/unsupported payloads gracefully", () => {
+    const fixture = loadFixture("otlp-sample.json");
     const storage = new FlatStore();
 
     const good = ingestOtlpJson(JSON.stringify(fixture), storage);
     expect(good.samplesInserted).toBeGreaterThan(0);
 
-    const badJson = ingestOtlpJson('{not valid', storage);
+    const badJson = ingestOtlpJson("{not valid", storage);
     expect(badJson.errors).toBe(1);
     expect(badJson.samplesInserted).toBe(0);
 

--- a/packages/o11ytsdb/test/interner.test.ts
+++ b/packages/o11ytsdb/test/interner.test.ts
@@ -27,7 +27,9 @@ describe("Interner", () => {
     const interner = new Interner();
     const ids = interner.bulkIntern(["a", "b", "a", "🌊"]);
     expect(ids[0]).toBe(ids[2]);
+    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(interner.resolve(ids[1]!)).toBe("b");
+    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(interner.resolve(ids[3]!)).toBe("🌊");
   });
 

--- a/packages/o11ytsdb/test/query.test.ts
+++ b/packages/o11ytsdb/test/query.test.ts
@@ -1,15 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-import { ColumnStore } from '../src/column-store.js';
-import { FlatStore } from '../src/flat-store.js';
-import { ScanEngine } from '../src/query.js';
-import type { Labels, StorageBackend, ValuesCodec } from '../src/types.js';
+import { ColumnStore } from "../src/column-store.js";
+import { FlatStore } from "../src/flat-store.js";
+import { ScanEngine } from "../src/query.js";
+// biome-ignore lint/correctness/noUnusedImports: test code
+import type { Labels, StorageBackend, ValuesCodec } from "../src/types.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function makeLabels(name: string, extra?: Record<string, string>): Labels {
   const m = new Map<string, string>();
-  m.set('__name__', name);
+  m.set("__name__", name);
   if (extra) {
     for (const [k, v] of Object.entries(extra)) m.set(k, v);
   }
@@ -19,14 +20,18 @@ function makeLabels(name: string, extra?: Record<string, string>): Labels {
 function populateStore(): FlatStore {
   const store = new FlatStore();
   // 3 CPU series for hosts a, b, c — each with 100 points
-  for (const host of ['a', 'b', 'c']) {
-    const id = store.getOrCreateSeries(makeLabels('cpu', { host, region: 'us-east' }));
+  for (const host of ["a", "b", "c"]) {
+    const id = store.getOrCreateSeries(makeLabels("cpu", { host, region: "us-east" }));
     for (let i = 0; i < 100; i++) {
-      store.append(id, 1_000_000n + BigInt(i) * 15_000n, 10 + (host.charCodeAt(0) - 97) * 10 + i * 0.1);
+      store.append(
+        id,
+        1_000_000n + BigInt(i) * 15_000n,
+        10 + (host.charCodeAt(0) - 97) * 10 + i * 0.1
+      );
     }
   }
   // 1 memory series
-  const memId = store.getOrCreateSeries(makeLabels('mem', { host: 'a' }));
+  const memId = store.getOrCreateSeries(makeLabels("mem", { host: "a" }));
   for (let i = 0; i < 50; i++) {
     store.append(memId, 1_000_000n + BigInt(i) * 15_000n, 8192 + i);
   }
@@ -35,13 +40,13 @@ function populateStore(): FlatStore {
 
 // ── Tests ────────────────────────────────────────────────────────────
 
-describe('ScanEngine', () => {
+describe("ScanEngine", () => {
   const engine = new ScanEngine();
 
-  it('queries single metric without aggregation', () => {
+  it("queries single metric without aggregation", () => {
     const store = populateStore();
     const result = engine.query(store, {
-      metric: 'cpu',
+      metric: "cpu",
       start: 0n,
       end: BigInt(Number.MAX_SAFE_INTEGER),
     });
@@ -50,38 +55,40 @@ describe('ScanEngine', () => {
     expect(result.scannedSamples).toBe(300);
   });
 
-  it('filters by label matcher', () => {
+  it("filters by label matcher", () => {
     const store = populateStore();
     const result = engine.query(store, {
-      metric: 'cpu',
-      matchers: [{ label: 'host', value: 'b' }],
+      metric: "cpu",
+      matchers: [{ label: "host", value: "b" }],
       start: 0n,
       end: BigInt(Number.MAX_SAFE_INTEGER),
     });
     expect(result.series.length).toBe(1);
-    expect(result.series[0]!.labels.get('host')).toBe('b');
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    expect(result.series[0]!.labels.get("host")).toBe("b");
   });
 
-  it('filters by time range', () => {
+  it("filters by time range", () => {
     const store = populateStore();
     const start = 1_000_000n + 50n * 15_000n;
     const end = 1_000_000n + 70n * 15_000n;
     const result = engine.query(store, {
-      metric: 'cpu',
-      matchers: [{ label: 'host', value: 'a' }],
+      metric: "cpu",
+      matchers: [{ label: "host", value: "a" }],
       start,
       end,
     });
     expect(result.series.length).toBe(1);
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBeGreaterThanOrEqual(15);
     expect(s.timestamps.length).toBeLessThanOrEqual(25);
   });
 
-  it('returns empty for non-existent metric', () => {
+  it("returns empty for non-existent metric", () => {
     const store = populateStore();
     const result = engine.query(store, {
-      metric: 'nonexistent',
+      metric: "nonexistent",
       start: 0n,
       end: BigInt(Number.MAX_SAFE_INTEGER),
     });
@@ -89,83 +96,89 @@ describe('ScanEngine', () => {
     expect(result.scannedSeries).toBe(0);
   });
 
-  it('aggregates with sum', () => {
+  it("aggregates with sum", () => {
     const store = populateStore();
     const result = engine.query(store, {
-      metric: 'cpu',
+      metric: "cpu",
       start: 0n,
       end: BigInt(Number.MAX_SAFE_INTEGER),
-      agg: 'sum',
+      agg: "sum",
     });
     expect(result.series.length).toBe(1);
     // Sum of 3 series at each point
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(100);
     // First point: 10 + 20 + 30 = 60
     expect(s.values[0]).toBeCloseTo(60);
   });
 
-  it('aggregates with avg', () => {
+  it("aggregates with avg", () => {
     const store = populateStore();
     const result = engine.query(store, {
-      metric: 'cpu',
+      metric: "cpu",
       start: 0n,
       end: BigInt(Number.MAX_SAFE_INTEGER),
-      agg: 'avg',
+      agg: "avg",
     });
     expect(result.series.length).toBe(1);
     // Avg of 10, 20, 30 = 20
+    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(result.series[0]!.values[0]).toBeCloseTo(20);
   });
 
-  it('aggregates with min', () => {
+  it("aggregates with min", () => {
     const store = populateStore();
     const result = engine.query(store, {
-      metric: 'cpu',
+      metric: "cpu",
       start: 0n,
       end: BigInt(Number.MAX_SAFE_INTEGER),
-      agg: 'min',
+      agg: "min",
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(result.series[0]!.values[0]).toBeCloseTo(10);
   });
 
-  it('aggregates with max', () => {
+  it("aggregates with max", () => {
     const store = populateStore();
     const result = engine.query(store, {
-      metric: 'cpu',
+      metric: "cpu",
       start: 0n,
       end: BigInt(Number.MAX_SAFE_INTEGER),
-      agg: 'max',
+      agg: "max",
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(result.series[0]!.values[0]).toBeCloseTo(30);
   });
 
-  it('aggregates with count', () => {
+  it("aggregates with count", () => {
     const store = populateStore();
     const result = engine.query(store, {
-      metric: 'cpu',
+      metric: "cpu",
       start: 0n,
       end: BigInt(Number.MAX_SAFE_INTEGER),
-      agg: 'count',
+      agg: "count",
     });
     // 3 series contribute to each point
+    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(result.series[0]!.values[0]).toBe(3);
   });
 
-  it('aggregates with rate', () => {
+  it("aggregates with rate", () => {
     const store = new FlatStore();
-    const id = store.getOrCreateSeries(makeLabels('counter'));
+    const id = store.getOrCreateSeries(makeLabels("counter"));
     // Counter: 0, 100, 200, 300 at 1-second intervals (1e9 ns)
     for (let i = 0; i < 4; i++) {
       store.append(id, BigInt(i) * 1_000_000_000n, i * 100);
     }
     const result = engine.query(store, {
-      metric: 'counter',
+      metric: "counter",
       start: 0n,
       end: BigInt(Number.MAX_SAFE_INTEGER),
-      agg: 'rate',
+      agg: "rate",
     });
     // rate = delta_v / delta_t (in seconds, but delta is in ms)
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(4);
     // First rate is 0 (no previous)
@@ -188,8 +201,8 @@ describe('ScanEngine', () => {
    */
   function makeStepStore(): FlatStore {
     const store = new FlatStore();
-    const idA = store.getOrCreateSeries(makeLabels('m', { host: 'a', region: 'us' }));
-    const idB = store.getOrCreateSeries(makeLabels('m', { host: 'b', region: 'eu' }));
+    const idA = store.getOrCreateSeries(makeLabels("m", { host: "a", region: "us" }));
+    const idB = store.getOrCreateSeries(makeLabels("m", { host: "b", region: "eu" }));
     for (let i = 0; i < 6; i++) {
       store.append(idA, BigInt(i) * 1_000n, (i + 1) * 10);
       store.append(idB, BigInt(i) * 1_000n, i + 1);
@@ -197,11 +210,16 @@ describe('ScanEngine', () => {
     return store;
   }
 
-  it('step aggregation sum computes correct values', () => {
+  it("step aggregation sum computes correct values", () => {
     const store = makeStepStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 6_000n, agg: 'sum', step: 2_000n,
+      metric: "m",
+      start: 0n,
+      end: 6_000n,
+      agg: "sum",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(3);
     // bucket 0: 10+20+1+2 = 33
@@ -212,11 +230,16 @@ describe('ScanEngine', () => {
     expect(s.values[2]).toBeCloseTo(121);
   });
 
-  it('step aggregation min computes correct values', () => {
+  it("step aggregation min computes correct values", () => {
     const store = makeStepStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 6_000n, agg: 'min', step: 2_000n,
+      metric: "m",
+      start: 0n,
+      end: 6_000n,
+      agg: "min",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(3);
     // bucket 0: min(10,20,1,2) = 1
@@ -227,11 +250,16 @@ describe('ScanEngine', () => {
     expect(s.values[2]).toBe(5);
   });
 
-  it('step aggregation max computes correct values', () => {
+  it("step aggregation max computes correct values", () => {
     const store = makeStepStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 6_000n, agg: 'max', step: 2_000n,
+      metric: "m",
+      start: 0n,
+      end: 6_000n,
+      agg: "max",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(3);
     // bucket 0: max(10,20,1,2) = 20
@@ -242,11 +270,16 @@ describe('ScanEngine', () => {
     expect(s.values[2]).toBe(60);
   });
 
-  it('step aggregation avg computes correct values', () => {
+  it("step aggregation avg computes correct values", () => {
     const store = makeStepStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 6_000n, agg: 'avg', step: 2_000n,
+      metric: "m",
+      start: 0n,
+      end: 6_000n,
+      agg: "avg",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(3);
     // bucket 0: (10+20+1+2)/4 = 8.25
@@ -257,11 +290,16 @@ describe('ScanEngine', () => {
     expect(s.values[2]).toBeCloseTo(30.25);
   });
 
-  it('step aggregation count computes correct values', () => {
+  it("step aggregation count computes correct values", () => {
     const store = makeStepStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 6_000n, agg: 'count', step: 2_000n,
+      metric: "m",
+      start: 0n,
+      end: 6_000n,
+      agg: "count",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(3);
     // Each bucket: 2 samples from A + 2 from B = 4
@@ -270,11 +308,16 @@ describe('ScanEngine', () => {
     expect(s.values[2]).toBe(4);
   });
 
-  it('step aggregation last computes correct values', () => {
+  it("step aggregation last computes correct values", () => {
     const store = makeStepStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 6_000n, agg: 'last', step: 2_000n,
+      metric: "m",
+      start: 0n,
+      end: 6_000n,
+      agg: "last",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(3);
     // last overwrites in insertion order: A then B processed sequentially
@@ -286,11 +329,16 @@ describe('ScanEngine', () => {
     expect(s.values[2]).toBe(6);
   });
 
-  it('step aggregation bucket timestamps are aligned to step', () => {
+  it("step aggregation bucket timestamps are aligned to step", () => {
     const store = makeStepStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 6_000n, agg: 'sum', step: 2_000n,
+      metric: "m",
+      start: 0n,
+      end: 6_000n,
+      agg: "sum",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const ts = result.series[0]!.timestamps;
     expect(ts[0]).toBe(0n);
     expect(ts[1]).toBe(2_000n);
@@ -299,9 +347,9 @@ describe('ScanEngine', () => {
 
   // ── stepAggregate rate ─────────────────────────────────────────────
 
-  it('step aggregation rate computes per-bucket derivative', () => {
+  it("step aggregation rate computes per-bucket derivative", () => {
     const store = new FlatStore();
-    const id = store.getOrCreateSeries(makeLabels('counter'));
+    const id = store.getOrCreateSeries(makeLabels("counter"));
     // Counter: 0, 100, 200, 300, 400, 500 at 1s intervals
     for (let i = 0; i < 6; i++) {
       store.append(id, BigInt(i) * 1_000n, i * 100);
@@ -311,8 +359,13 @@ describe('ScanEngine', () => {
     //   bucket 1 (t=2000): values 200,300 → rate = (300-200)/(3000-2000)/1000 = 100/1 = 100/s
     //   bucket 2 (t=4000): values 400,500 → rate = (500-400)/(5000-4000)/1000 = 100/1 = 100/s
     const result = engine.query(store, {
-      metric: 'counter', start: 0n, end: 6_000n, agg: 'rate', step: 2_000n,
+      metric: "counter",
+      start: 0n,
+      end: 6_000n,
+      agg: "rate",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(3);
     // (100 - 0) / ((1000 - 0) / 1000) = 100 / 1 = 100
@@ -321,9 +374,9 @@ describe('ScanEngine', () => {
     expect(s.values[2]).toBeCloseTo(100);
   });
 
-  it('step aggregation rate with varying rate', () => {
+  it("step aggregation rate with varying rate", () => {
     const store = new FlatStore();
-    const id = store.getOrCreateSeries(makeLabels('counter'));
+    const id = store.getOrCreateSeries(makeLabels("counter"));
     // bucket 0: t=0 v=0, t=1000 v=50  → rate = 50/s
     // bucket 1: t=2000 v=50, t=3000 v=250 → rate = 200/s
     store.append(id, 0n, 0);
@@ -331,23 +384,33 @@ describe('ScanEngine', () => {
     store.append(id, 2_000n, 50);
     store.append(id, 3_000n, 250);
     const result = engine.query(store, {
-      metric: 'counter', start: 0n, end: 4_000n, agg: 'rate', step: 2_000n,
+      metric: "counter",
+      start: 0n,
+      end: 4_000n,
+      agg: "rate",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(2);
     expect(s.values[0]).toBeCloseTo(50);
     expect(s.values[1]).toBeCloseTo(200);
   });
 
-  it('step aggregation rate with single point per bucket produces 0', () => {
+  it("step aggregation rate with single point per bucket produces 0", () => {
     const store = new FlatStore();
-    const id = store.getOrCreateSeries(makeLabels('counter'));
+    const id = store.getOrCreateSeries(makeLabels("counter"));
     // One point per bucket → dt=0 → rate=0
     store.append(id, 0n, 100);
     store.append(id, 5_000n, 200);
     const result = engine.query(store, {
-      metric: 'counter', start: 0n, end: 6_000n, agg: 'rate', step: 3_000n,
+      metric: "counter",
+      start: 0n,
+      end: 6_000n,
+      agg: "rate",
+      step: 3_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(2);
     // Each bucket has only one point: dt=0 → rate=0
@@ -355,118 +418,166 @@ describe('ScanEngine', () => {
     expect(s.values[1]).toBe(0);
   });
 
-  it('step aggregation rate with empty bucket produces NaN', () => {
+  it("step aggregation rate with empty bucket produces NaN", () => {
     const store = new FlatStore();
-    const id = store.getOrCreateSeries(makeLabels('counter'));
+    const id = store.getOrCreateSeries(makeLabels("counter"));
     store.append(id, 0n, 100);
     store.append(id, 4_000n, 200);
     const result = engine.query(store, {
-      metric: 'counter', start: 0n, end: 5_000n, agg: 'rate', step: 2_000n,
+      metric: "counter",
+      start: 0n,
+      end: 5_000n,
+      agg: "rate",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(3);
-    expect(s.values[0]).toBe(0);     // single point → rate=0
-    expect(s.values[1]).toBeNaN();   // empty bucket → NaN
-    expect(s.values[2]).toBe(0);     // single point → rate=0
+    expect(s.values[0]).toBe(0); // single point → rate=0
+    expect(s.values[1]).toBeNaN(); // empty bucket → NaN
+    expect(s.values[2]).toBe(0); // single point → rate=0
   });
 
   // ── stepAggregate edge cases ───────────────────────────────────────
 
-  it('step aggregation with single point produces one bucket', () => {
+  it("step aggregation with single point produces one bucket", () => {
     const store = new FlatStore();
-    const id = store.getOrCreateSeries(makeLabels('single'));
+    const id = store.getOrCreateSeries(makeLabels("single"));
     store.append(id, 5_000n, 42);
     const result = engine.query(store, {
-      metric: 'single', start: 0n, end: 10_000n, agg: 'sum', step: 3_000n,
+      metric: "single",
+      start: 0n,
+      end: 10_000n,
+      agg: "sum",
+      step: 3_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(result.series[0]!.timestamps.length).toBe(1);
+    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(result.series[0]!.values[0]).toBe(42);
   });
 
-  it('step aggregation with step larger than data span produces one bucket', () => {
+  it("step aggregation with step larger than data span produces one bucket", () => {
     const store = makeStepStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 6_000n, agg: 'sum', step: 100_000n,
+      metric: "m",
+      start: 0n,
+      end: 6_000n,
+      agg: "sum",
+      step: 100_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(1);
     // All 12 values: (10+20+30+40+50+60) + (1+2+3+4+5+6) = 210 + 21 = 231
     expect(s.values[0]).toBeCloseTo(231);
   });
 
-  it('step aggregation with empty buckets produces NaN', () => {
+  it("step aggregation with empty buckets produces NaN", () => {
     const store = new FlatStore();
-    const id = store.getOrCreateSeries(makeLabels('sparse'));
+    const id = store.getOrCreateSeries(makeLabels("sparse"));
     // Points at t=0 and t=4000 → bucket at t=2000 has no data
     store.append(id, 0n, 10);
     store.append(id, 4_000n, 50);
     const result = engine.query(store, {
-      metric: 'sparse', start: 0n, end: 5_000n, agg: 'min', step: 2_000n,
+      metric: "sparse",
+      start: 0n,
+      end: 5_000n,
+      agg: "min",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(3);
-    expect(s.values[0]).toBe(10);         // bucket 0: has data
-    expect(s.values[1]).toBeNaN();        // bucket 1: empty → NaN
-    expect(s.values[2]).toBe(50);         // bucket 2: has data
+    expect(s.values[0]).toBe(10); // bucket 0: has data
+    expect(s.values[1]).toBeNaN(); // bucket 1: empty → NaN
+    expect(s.values[2]).toBe(50); // bucket 2: has data
   });
 
-  it('step aggregation empty buckets NaN for max', () => {
+  it("step aggregation empty buckets NaN for max", () => {
     const store = new FlatStore();
-    const id = store.getOrCreateSeries(makeLabels('sparse'));
+    const id = store.getOrCreateSeries(makeLabels("sparse"));
     store.append(id, 0n, 10);
     store.append(id, 4_000n, 50);
     const result = engine.query(store, {
-      metric: 'sparse', start: 0n, end: 5_000n, agg: 'max', step: 2_000n,
+      metric: "sparse",
+      start: 0n,
+      end: 5_000n,
+      agg: "max",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.values[0]).toBe(10);
     expect(s.values[1]).toBeNaN();
     expect(s.values[2]).toBe(50);
   });
 
-  it('step aggregation empty buckets NaN for avg', () => {
+  it("step aggregation empty buckets NaN for avg", () => {
     const store = new FlatStore();
-    const id = store.getOrCreateSeries(makeLabels('sparse'));
+    const id = store.getOrCreateSeries(makeLabels("sparse"));
     store.append(id, 0n, 10);
     store.append(id, 4_000n, 50);
     const result = engine.query(store, {
-      metric: 'sparse', start: 0n, end: 5_000n, agg: 'avg', step: 2_000n,
+      metric: "sparse",
+      start: 0n,
+      end: 5_000n,
+      agg: "avg",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.values[0]).toBe(10);
     expect(s.values[1]).toBeNaN();
     expect(s.values[2]).toBe(50);
   });
 
-  it('step aggregation empty buckets are 0 for sum and count', () => {
+  it("step aggregation empty buckets are 0 for sum and count", () => {
     const store = new FlatStore();
-    const id = store.getOrCreateSeries(makeLabels('sparse'));
+    const id = store.getOrCreateSeries(makeLabels("sparse"));
     store.append(id, 0n, 10);
     store.append(id, 4_000n, 50);
     // sum: empty bucket stays 0
     const sumResult = engine.query(store, {
-      metric: 'sparse', start: 0n, end: 5_000n, agg: 'sum', step: 2_000n,
+      metric: "sparse",
+      start: 0n,
+      end: 5_000n,
+      agg: "sum",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(sumResult.series[0]!.values[1]).toBe(0);
     // count: empty bucket stays 0
     const countResult = engine.query(store, {
-      metric: 'sparse', start: 0n, end: 5_000n, agg: 'count', step: 2_000n,
+      metric: "sparse",
+      start: 0n,
+      end: 5_000n,
+      agg: "count",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(countResult.series[0]!.values[1]).toBe(0);
   });
 
   // ── groupBy + step combined ────────────────────────────────────────
 
-  it('groupBy + step produces correct per-group values', () => {
+  it("groupBy + step produces correct per-group values", () => {
     const store = makeStepStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 6_000n, agg: 'sum', step: 2_000n, groupBy: ['region'],
+      metric: "m",
+      start: 0n,
+      end: 6_000n,
+      agg: "sum",
+      step: 2_000n,
+      groupBy: ["region"],
     });
     // 2 regions: 'us' (host a) and 'eu' (host b)
     expect(result.series.length).toBe(2);
 
-    const us = result.series.find(s => s.labels.get('region') === 'us')!;
-    const eu = result.series.find(s => s.labels.get('region') === 'eu')!;
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    const us = result.series.find((s) => s.labels.get("region") === "us")!;
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    const eu = result.series.find((s) => s.labels.get("region") === "eu")!;
     expect(us).toBeDefined();
     expect(eu).toBeDefined();
 
@@ -481,13 +592,20 @@ describe('ScanEngine', () => {
     expect(eu.values[2]).toBeCloseTo(11);
   });
 
-  it('groupBy + step min produces correct per-group values', () => {
+  it("groupBy + step min produces correct per-group values", () => {
     const store = makeStepStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 6_000n, agg: 'min', step: 2_000n, groupBy: ['host'],
+      metric: "m",
+      start: 0n,
+      end: 6_000n,
+      agg: "min",
+      step: 2_000n,
+      groupBy: ["host"],
     });
-    const a = result.series.find(s => s.labels.get('host') === 'a')!;
-    const b = result.series.find(s => s.labels.get('host') === 'b')!;
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    const a = result.series.find((s) => s.labels.get("host") === "a")!;
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    const b = result.series.find((s) => s.labels.get("host") === "b")!;
     // Host a: bucket 0: min(10,20)=10, bucket 1: min(30,40)=30, bucket 2: min(50,60)=50
     expect(a.values[0]).toBe(10);
     expect(a.values[1]).toBe(30);
@@ -498,41 +616,52 @@ describe('ScanEngine', () => {
     expect(b.values[2]).toBe(5);
   });
 
-  it('groupBy with no groupBy key returns single group', () => {
+  it("groupBy with no groupBy key returns single group", () => {
     const store = populateStore();
     const result = engine.query(store, {
-      metric: 'cpu', start: 0n, end: BigInt(Number.MAX_SAFE_INTEGER),
-      agg: 'sum',
+      metric: "cpu",
+      start: 0n,
+      end: BigInt(Number.MAX_SAFE_INTEGER),
+      agg: "sum",
     });
     // No groupBy → all series aggregated into one
     expect(result.series.length).toBe(1);
     // First point: 10 + 20 + 30 = 60
+    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(result.series[0]!.values[0]).toBeCloseTo(60);
   });
 
   // ── pointAggregate coverage ────────────────────────────────────────
 
-  it('aggregates with last (pointAggregate)', () => {
+  it("aggregates with last (pointAggregate)", () => {
     const store = populateStore();
     const result = engine.query(store, {
-      metric: 'cpu', start: 0n, end: BigInt(Number.MAX_SAFE_INTEGER), agg: 'last',
+      metric: "cpu",
+      start: 0n,
+      end: BigInt(Number.MAX_SAFE_INTEGER),
+      agg: "last",
     });
     expect(result.series.length).toBe(1);
     // last overwrites sequentially: a=10, b=20, c=30 → last = 30
+    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(result.series[0]!.values[0]).toBe(30);
   });
 
-  it('pointAggregate handles unequal-length series', () => {
+  it("pointAggregate handles unequal-length series", () => {
     const store = new FlatStore();
-    const idA = store.getOrCreateSeries(makeLabels('m', { host: 'x' }));
-    const idB = store.getOrCreateSeries(makeLabels('m', { host: 'y' }));
+    const idA = store.getOrCreateSeries(makeLabels("m", { host: "x" }));
+    const idB = store.getOrCreateSeries(makeLabels("m", { host: "y" }));
     // A has 5 points, B has 3
     for (let i = 0; i < 5; i++) store.append(idA, BigInt(i) * 1_000n, 10);
     for (let i = 0; i < 3; i++) store.append(idB, BigInt(i) * 1_000n, 20);
 
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 10_000n, agg: 'sum',
+      metric: "m",
+      start: 0n,
+      end: 10_000n,
+      agg: "sum",
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     // Longest series (A) has 5 points, so output has 5 timestamps
     expect(s.timestamps.length).toBe(5);
@@ -546,33 +675,37 @@ describe('ScanEngine', () => {
 
   // ── scannedSamples tracking ────────────────────────────────────────
 
-  it('scannedSamples is correct with step aggregation', () => {
+  it("scannedSamples is correct with step aggregation", () => {
     const store = makeStepStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 6_000n, agg: 'sum', step: 2_000n,
+      metric: "m",
+      start: 0n,
+      end: 6_000n,
+      agg: "sum",
+      step: 2_000n,
     });
     // 2 series × 6 points = 12
     expect(result.scannedSamples).toBe(12);
     expect(result.scannedSeries).toBe(2);
   });
 
-  it('handles empty store gracefully', () => {
+  it("handles empty store gracefully", () => {
     const store = new FlatStore();
     const result = engine.query(store, {
-      metric: 'anything',
+      metric: "anything",
       start: 0n,
       end: BigInt(Number.MAX_SAFE_INTEGER),
     });
     expect(result.series.length).toBe(0);
   });
 
-  it('handles aggregation on empty result', () => {
+  it("handles aggregation on empty result", () => {
     const store = new FlatStore();
     const result = engine.query(store, {
-      metric: 'nothing',
+      metric: "nothing",
       start: 0n,
       end: BigInt(Number.MAX_SAFE_INTEGER),
-      agg: 'sum',
+      agg: "sum",
     });
     expect(result.series.length).toBe(0);
     expect(result.scannedSamples).toBe(0);
@@ -586,7 +719,7 @@ describe('ScanEngine', () => {
    * doesn't provide encodeValuesWithStats.
    */
   const identityValuesCodec: ValuesCodec = {
-    name: 'identity',
+    name: "identity",
     encodeValues(values: Float64Array): Uint8Array {
       return new Uint8Array(values.buffer.slice(0));
     },
@@ -604,19 +737,24 @@ describe('ScanEngine', () => {
    */
   function makeStatsStore(): ColumnStore {
     const store = new ColumnStore(identityValuesCodec, 4);
-    const id = store.getOrCreateSeries(makeLabels('m'));
+    const id = store.getOrCreateSeries(makeLabels("m"));
     for (let i = 0; i < 8; i++) {
       store.append(id, BigInt(i) * 1_000n, (i + 1) * 10);
     }
     return store;
   }
 
-  it('stats-skip: sum with large step uses chunk stats', () => {
+  it("stats-skip: sum with large step uses chunk stats", () => {
     const store = makeStatsStore();
     // step=4000 → 2 buckets, each chunk fits exactly in one bucket
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 8_000n, agg: 'sum', step: 4_000n,
+      metric: "m",
+      start: 0n,
+      end: 8_000n,
+      agg: "sum",
+      step: 4_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(2);
     // Chunk 0: sum(10,20,30,40) = 100
@@ -625,31 +763,46 @@ describe('ScanEngine', () => {
     expect(s.values[1]).toBeCloseTo(260);
   });
 
-  it('stats-skip: min with large step uses chunk stats', () => {
+  it("stats-skip: min with large step uses chunk stats", () => {
     const store = makeStatsStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 8_000n, agg: 'min', step: 4_000n,
+      metric: "m",
+      start: 0n,
+      end: 8_000n,
+      agg: "min",
+      step: 4_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.values[0]).toBe(10);
     expect(s.values[1]).toBe(50);
   });
 
-  it('stats-skip: max with large step uses chunk stats', () => {
+  it("stats-skip: max with large step uses chunk stats", () => {
     const store = makeStatsStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 8_000n, agg: 'max', step: 4_000n,
+      metric: "m",
+      start: 0n,
+      end: 8_000n,
+      agg: "max",
+      step: 4_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.values[0]).toBe(40);
     expect(s.values[1]).toBe(80);
   });
 
-  it('stats-skip: avg with large step uses chunk stats', () => {
+  it("stats-skip: avg with large step uses chunk stats", () => {
     const store = makeStatsStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 8_000n, agg: 'avg', step: 4_000n,
+      metric: "m",
+      start: 0n,
+      end: 8_000n,
+      agg: "avg",
+      step: 4_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     // Chunk 0: avg(10,20,30,40) = 25
     expect(s.values[0]).toBeCloseTo(25);
@@ -657,52 +810,76 @@ describe('ScanEngine', () => {
     expect(s.values[1]).toBeCloseTo(65);
   });
 
-  it('stats-skip: count with large step uses chunk stats', () => {
+  it("stats-skip: count with large step uses chunk stats", () => {
     const store = makeStatsStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 8_000n, agg: 'count', step: 4_000n,
+      metric: "m",
+      start: 0n,
+      end: 8_000n,
+      agg: "count",
+      step: 4_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.values[0]).toBe(4);
     expect(s.values[1]).toBe(4);
   });
 
-  it('stats-skip: last with large step uses chunk stats', () => {
+  it("stats-skip: last with large step uses chunk stats", () => {
     const store = makeStatsStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 8_000n, agg: 'last', step: 4_000n,
+      metric: "m",
+      start: 0n,
+      end: 8_000n,
+      agg: "last",
+      step: 4_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
-    expect(s.values[0]).toBe(40);  // last of chunk 0
-    expect(s.values[1]).toBe(80);  // last of chunk 1
+    expect(s.values[0]).toBe(40); // last of chunk 0
+    expect(s.values[1]).toBe(80); // last of chunk 1
   });
 
-  it('stats-skip: single big bucket (step > data span) uses stats', () => {
+  it("stats-skip: single big bucket (step > data span) uses stats", () => {
     const store = makeStatsStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 10_000n, agg: 'sum', step: 100_000n,
+      metric: "m",
+      start: 0n,
+      end: 10_000n,
+      agg: "sum",
+      step: 100_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(1);
     // sum(10..80) = 360
     expect(s.values[0]).toBeCloseTo(360);
   });
 
-  it('stats-skip: scannedSamples counts stats-only parts', () => {
+  it("stats-skip: scannedSamples counts stats-only parts", () => {
     const store = makeStatsStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 8_000n, agg: 'sum', step: 4_000n,
+      metric: "m",
+      start: 0n,
+      end: 8_000n,
+      agg: "sum",
+      step: 4_000n,
     });
     // 8 samples total (2 chunks × 4)
     expect(result.scannedSamples).toBe(8);
   });
 
-  it('stats-skip: small step lazy-decodes chunks spanning multiple buckets', () => {
+  it("stats-skip: small step lazy-decodes chunks spanning multiple buckets", () => {
     const store = makeStatsStore();
     // step=2000 → 4 buckets; each 4-sample chunk spans 2 buckets → lazy decode
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 8_000n, agg: 'sum', step: 2_000n,
+      metric: "m",
+      start: 0n,
+      end: 8_000n,
+      agg: "sum",
+      step: 2_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(4);
     // Bucket 0 [0,2000): t=0→10, t=1000→20 → sum=30
@@ -715,11 +892,16 @@ describe('ScanEngine', () => {
     expect(s.values[3]).toBeCloseTo(150);
   });
 
-  it('stats-skip: rate with ColumnStore lazy-decodes correctly', () => {
+  it("stats-skip: rate with ColumnStore lazy-decodes correctly", () => {
     const store = makeStatsStore();
     const result = engine.query(store, {
-      metric: 'm', start: 0n, end: 8_000n, agg: 'rate', step: 4_000n,
+      metric: "m",
+      start: 0n,
+      end: 8_000n,
+      agg: "rate",
+      step: 4_000n,
     });
+    // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(2);
     // Each bucket has 4 points at 1s intervals, values increase by 10 each

--- a/packages/o11ytsdb/test/storage.test.ts
+++ b/packages/o11ytsdb/test/storage.test.ts
@@ -1,21 +1,20 @@
-import { describe, expect, it } from 'vitest';
-
-import { FlatStore } from '../src/flat-store.js';
-import { ChunkedStore } from '../src/chunked-store.js';
-import { ColumnStore } from '../src/column-store.js';
-import { encodeChunk, decodeChunk } from '../src/codec.js';
-import type { Codec, StorageBackend, Labels, ValuesCodec } from '../src/types.js';
+import { describe, expect, it } from "vitest";
+import { ChunkedStore } from "../src/chunked-store.js";
+import { decodeChunk, encodeChunk } from "../src/codec.js";
+import { ColumnStore } from "../src/column-store.js";
+import { FlatStore } from "../src/flat-store.js";
+import type { Codec, Labels, StorageBackend, ValuesCodec } from "../src/types.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
 const tsCodec: Codec = {
-  name: 'ts-xor-delta',
+  name: "ts-xor-delta",
   encode: encodeChunk,
   decode: decodeChunk,
 };
 
 const tsValuesCodec: ValuesCodec = {
-  name: 'identity',
+  name: "identity",
   encodeValues(values: Float64Array): Uint8Array {
     return new Uint8Array(values.buffer.slice(0));
   },
@@ -26,14 +25,20 @@ const tsValuesCodec: ValuesCodec = {
 
 function makeLabels(name: string, extra?: Record<string, string>): Labels {
   const m = new Map<string, string>();
-  m.set('__name__', name);
+  m.set("__name__", name);
   if (extra) {
     for (const [k, v] of Object.entries(extra)) m.set(k, v);
   }
   return m;
 }
 
-function insertSamples(store: StorageBackend, labels: Labels, count: number, t0 = 1_000_000n, interval = 15_000n) {
+function insertSamples(
+  store: StorageBackend,
+  labels: Labels,
+  count: number,
+  t0 = 1_000_000n,
+  interval = 15_000n
+) {
   const id = store.getOrCreateSeries(labels);
   for (let i = 0; i < count; i++) {
     store.append(id, t0 + BigInt(i) * interval, i * 1.5);
@@ -41,7 +46,13 @@ function insertSamples(store: StorageBackend, labels: Labels, count: number, t0 
   return id;
 }
 
-function insertBatch(store: StorageBackend, labels: Labels, count: number, t0 = 1_000_000n, interval = 15_000n) {
+function insertBatch(
+  store: StorageBackend,
+  labels: Labels,
+  count: number,
+  t0 = 1_000_000n,
+  interval = 15_000n
+) {
   const id = store.getOrCreateSeries(labels);
   const ts = new BigInt64Array(count);
   const vals = new Float64Array(count);
@@ -57,20 +68,20 @@ function insertBatch(store: StorageBackend, labels: Labels, count: number, t0 = 
 
 function describeStorageBackend(name: string, create: () => StorageBackend) {
   describe(name, () => {
-    it('creates and retrieves series by labels', () => {
+    it("creates and retrieves series by labels", () => {
       const store = create();
-      const labels = makeLabels('cpu', { host: 'a' });
+      const labels = makeLabels("cpu", { host: "a" });
       const id1 = store.getOrCreateSeries(labels);
       const id2 = store.getOrCreateSeries(labels);
       expect(id1).toBe(id2); // same labels → same id
 
-      const id3 = store.getOrCreateSeries(makeLabels('cpu', { host: 'b' }));
+      const id3 = store.getOrCreateSeries(makeLabels("cpu", { host: "b" }));
       expect(id3).not.toBe(id1); // different labels → different id
     });
 
-    it('appends and reads samples', () => {
+    it("appends and reads samples", () => {
       const store = create();
-      const id = insertSamples(store, makeLabels('metric_a'), 10);
+      const id = insertSamples(store, makeLabels("metric_a"), 10);
       expect(store.sampleCount).toBe(10);
 
       const data = store.read(id, 0n, BigInt(Number.MAX_SAFE_INTEGER));
@@ -79,11 +90,11 @@ function describeStorageBackend(name: string, create: () => StorageBackend) {
       expect(data.values[9]).toBe(9 * 1.5);
     });
 
-    it('reads with time range filter', () => {
+    it("reads with time range filter", () => {
       const store = create();
       const t0 = 1_000_000n;
       const interval = 15_000n;
-      const id = insertSamples(store, makeLabels('metric_b'), 100, t0, interval);
+      const id = insertSamples(store, makeLabels("metric_b"), 100, t0, interval);
 
       // Read middle third
       const start = t0 + 33n * interval;
@@ -97,69 +108,72 @@ function describeStorageBackend(name: string, create: () => StorageBackend) {
       }
     });
 
-    it('appendBatch inserts all samples', () => {
+    it("appendBatch inserts all samples", () => {
       const store = create();
-      const id = insertBatch(store, makeLabels('batch_metric'), 200);
+      const id = insertBatch(store, makeLabels("batch_metric"), 200);
       expect(store.sampleCount).toBe(200);
       const data = store.read(id, 0n, BigInt(Number.MAX_SAFE_INTEGER));
       expect(data.timestamps.length).toBe(200);
     });
 
-    it('matchLabel finds correct series', () => {
+    it("matchLabel finds correct series", () => {
       const store = create();
-      insertSamples(store, makeLabels('cpu', { host: 'a' }), 5);
-      insertSamples(store, makeLabels('cpu', { host: 'b' }), 5);
-      insertSamples(store, makeLabels('mem', { host: 'a' }), 5);
+      insertSamples(store, makeLabels("cpu", { host: "a" }), 5);
+      insertSamples(store, makeLabels("cpu", { host: "b" }), 5);
+      insertSamples(store, makeLabels("mem", { host: "a" }), 5);
 
-      const cpuIds = store.matchLabel('__name__', 'cpu');
+      const cpuIds = store.matchLabel("__name__", "cpu");
       expect(cpuIds.length).toBe(2);
 
-      const hostAIds = store.matchLabel('host', 'a');
+      const hostAIds = store.matchLabel("host", "a");
       expect(hostAIds.length).toBe(2);
 
-      const memIds = store.matchLabel('__name__', 'mem');
+      const memIds = store.matchLabel("__name__", "mem");
       expect(memIds.length).toBe(1);
     });
 
-    it('labels() returns correct label map', () => {
+    it("labels() returns correct label map", () => {
       const store = create();
-      const labels = makeLabels('test_metric', { env: 'prod', region: 'us-east' });
+      const labels = makeLabels("test_metric", { env: "prod", region: "us-east" });
       const id = store.getOrCreateSeries(labels);
       const retrieved = store.labels(id);
       expect(retrieved).toBeDefined();
-      expect(retrieved!.get('__name__')).toBe('test_metric');
-      expect(retrieved!.get('env')).toBe('prod');
-      expect(retrieved!.get('region')).toBe('us-east');
+      // biome-ignore lint/style/noNonNullAssertion: test code
+      expect(retrieved!.get("__name__")).toBe("test_metric");
+      // biome-ignore lint/style/noNonNullAssertion: test code
+      expect(retrieved!.get("env")).toBe("prod");
+      // biome-ignore lint/style/noNonNullAssertion: test code
+      expect(retrieved!.get("region")).toBe("us-east");
     });
 
-    it('labels() returns undefined for invalid id', () => {
+    it("labels() returns undefined for invalid id", () => {
       const store = create();
       expect(store.labels(999)).toBeUndefined();
     });
 
-    it('seriesCount and sampleCount track correctly', () => {
+    it("seriesCount and sampleCount track correctly", () => {
       const store = create();
       expect(store.seriesCount).toBe(0);
       expect(store.sampleCount).toBe(0);
 
-      insertSamples(store, makeLabels('m1'), 10);
+      insertSamples(store, makeLabels("m1"), 10);
       expect(store.seriesCount).toBe(1);
       expect(store.sampleCount).toBe(10);
 
-      insertSamples(store, makeLabels('m2'), 20);
+      insertSamples(store, makeLabels("m2"), 20);
       expect(store.seriesCount).toBe(2);
       expect(store.sampleCount).toBe(30);
     });
 
-    it('memoryBytes returns positive value', () => {
+    it("memoryBytes returns positive value", () => {
       const store = create();
-      insertSamples(store, makeLabels('m1'), 100);
+      insertSamples(store, makeLabels("m1"), 100);
       expect(store.memoryBytes()).toBeGreaterThan(0);
     });
 
-    it('handles large batch spanning multiple chunks', () => {
+    it("handles large batch spanning multiple chunks", () => {
       const store = create();
-      const id = insertBatch(store, makeLabels('big_metric'), 5000);
+      const id = insertBatch(store, makeLabels("big_metric"), 5000);
       expect(store.sampleCount).toBe(5000);
       const data = store.read(id, 0n, BigInt(Number.MAX_SAFE_INTEGER));
       expect(data.timestamps.length).toBe(5000);
@@ -172,17 +186,17 @@ function describeStorageBackend(name: string, create: () => StorageBackend) {
 
 // ── Run contract tests against each backend ──────────────────────────
 
-describeStorageBackend('FlatStore', () => new FlatStore());
-describeStorageBackend('ChunkedStore (chunk=64)', () => new ChunkedStore(tsCodec, 64));
-describeStorageBackend('ChunkedStore (chunk=640)', () => new ChunkedStore(tsCodec, 640));
-describeStorageBackend('ColumnStore (chunk=64)', () => new ColumnStore(tsValuesCodec, 64));
+describeStorageBackend("FlatStore", () => new FlatStore());
+describeStorageBackend("ChunkedStore (chunk=64)", () => new ChunkedStore(tsCodec, 64));
+describeStorageBackend("ChunkedStore (chunk=640)", () => new ChunkedStore(tsCodec, 640));
+describeStorageBackend("ColumnStore (chunk=64)", () => new ColumnStore(tsValuesCodec, 64));
 
 // ── ChunkedStore-specific tests ──────────────────────────────────────
 
-describe('ChunkedStore freeze behavior', () => {
-  it('freezes chunks when reaching chunk size', () => {
+describe("ChunkedStore freeze behavior", () => {
+  it("freezes chunks when reaching chunk size", () => {
     const store = new ChunkedStore(tsCodec, 16);
-    const id = insertSamples(store, makeLabels('freeze_test'), 48);
+    const id = insertSamples(store, makeLabels("freeze_test"), 48);
 
     // 48 samples with chunk size 16 → 3 frozen chunks, hot chunk empty
     const data = store.read(id, 0n, BigInt(Number.MAX_SAFE_INTEGER));
@@ -190,13 +204,14 @@ describe('ChunkedStore freeze behavior', () => {
 
     // Compressed should use less memory than flat
     const flat = new FlatStore();
-    const flatId = insertSamples(flat, makeLabels('freeze_test'), 48);
+    // biome-ignore lint/correctness/noUnusedVariables: test code
+    const flatId = insertSamples(flat, makeLabels("freeze_test"), 48);
     expect(store.memoryBytes()).toBeLessThan(flat.memoryBytes());
   });
 
-  it('correctly reads across frozen and hot chunks', () => {
+  it("correctly reads across frozen and hot chunks", () => {
     const store = new ChunkedStore(tsCodec, 10);
-    const id = insertSamples(store, makeLabels('mixed'), 25);
+    const id = insertSamples(store, makeLabels("mixed"), 25);
 
     // 25 samples with chunk size 10 → 2 frozen chunks + 5 in hot
     const data = store.read(id, 0n, BigInt(Number.MAX_SAFE_INTEGER));

--- a/packages/o11ytsdb/test/worker-client.test.ts
+++ b/packages/o11ytsdb/test/worker-client.test.ts
@@ -1,12 +1,14 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { WorkerClient, type WorkerClientOptions } from '../src/worker-client.js';
+// biome-ignore lint/correctness/noUnusedImports: test code
+import { WorkerClient, type WorkerClientOptions } from "../src/worker-client.js";
 import type {
   RequestEnvelope,
   ResponseEnvelope,
+  // biome-ignore lint/correctness/noUnusedImports: test code
   TransferStrategy,
   WorkerResponse,
-} from '../src/worker-protocol.js';
+} from "../src/worker-protocol.js";
 
 // ── Mock worker ─────────────────────────────────────────────────────
 
@@ -34,27 +36,29 @@ function createMockWorker() {
     },
     /** Auto-respond to the next postMessage with a success envelope. */
     autoRespond(payload: WorkerResponse): void {
+      // biome-ignore lint/correctness/noUnusedVariables: test code
       const orig = posted.length;
       // We'll patch postMessage to respond immediately.
+      // biome-ignore lint/correctness/noUnusedVariables: test code
       const realPost = posted;
-      const self = this;
-      const origPostMessage = self.worker.postMessage;
-      self.worker.postMessage = function (message: unknown, transfer?: ArrayBufferLike[]) {
-        origPostMessage.call(self.worker, message, transfer);
+
+      const origPostMessage = this.worker.postMessage;
+      this.worker.postMessage = (message: unknown, transfer?: ArrayBufferLike[]) => {
+        origPostMessage.call(this.worker, message, transfer);
         const req = message as RequestEnvelope;
         const response: ResponseEnvelope = {
           id: req.id,
-          kind: 'response',
+          kind: "response",
           payload,
         };
-        self.respond(response);
+        this.respond(response);
       };
     },
     posted,
   };
 }
 
-describe('WorkerClient', () => {
+describe("WorkerClient", () => {
   let mock: ReturnType<typeof createMockWorker>;
   let client: WorkerClient;
 
@@ -65,40 +69,43 @@ describe('WorkerClient', () => {
 
   // ── init() ────────────────────────────────────────────────────
 
-  describe('init()', () => {
-    it('sends an init request and resolves with backend name', async () => {
-      mock.autoRespond({ ok: true, type: 'init', backend: 'column' });
+  describe("init()", () => {
+    it("sends an init request and resolves with backend name", async () => {
+      mock.autoRespond({ ok: true, type: "init", backend: "column" });
 
       const result = await client.init(640);
-      expect(result).toEqual({ backend: 'column' });
+      expect(result).toEqual({ backend: "column" });
 
       const envelope = mock.posted[0].message as RequestEnvelope;
-      expect(envelope.kind).toBe('request');
-      expect(envelope.payload).toEqual({ type: 'init', chunkSize: 640 });
+      expect(envelope.kind).toBe("request");
+      expect(envelope.payload).toEqual({ type: "init", chunkSize: 640 });
     });
 
-    it('sends init without chunkSize when omitted', async () => {
-      mock.autoRespond({ ok: true, type: 'init', backend: 'column' });
+    it("sends init without chunkSize when omitted", async () => {
+      mock.autoRespond({ ok: true, type: "init", backend: "column" });
 
       await client.init();
       const envelope = mock.posted[0].message as RequestEnvelope;
-      expect(envelope.payload).toEqual({ type: 'init' });
+      expect(envelope.payload).toEqual({ type: "init" });
     });
 
-    it('throws on error response', async () => {
-      mock.autoRespond({ ok: false, type: 'error', error: 'init failed' });
+    it("throws on error response", async () => {
+      mock.autoRespond({ ok: false, type: "error", error: "init failed" });
 
-      await expect(client.init()).rejects.toThrow('init failed');
+      await expect(client.init()).rejects.toThrow("init failed");
     });
   });
 
   // ── ingest() ──────────────────────────────────────────────────
 
-  describe('ingest()', () => {
-    it('sends ingest request with labels, timestamps, values', async () => {
-      mock.autoRespond({ ok: true, type: 'ingest', seriesId: 0, ingestedSamples: 3 });
+  describe("ingest()", () => {
+    it("sends ingest request with labels, timestamps, values", async () => {
+      mock.autoRespond({ ok: true, type: "ingest", seriesId: 0, ingestedSamples: 3 });
 
-      const labels = new Map([['__name__', 'cpu'], ['host', 'a']]);
+      const labels = new Map([
+        ["__name__", "cpu"],
+        ["host", "a"],
+      ]);
       const timestamps = BigInt64Array.from([1n, 2n, 3n]);
       const values = new Float64Array([10, 20, 30]);
 
@@ -106,76 +113,77 @@ describe('WorkerClient', () => {
       expect(result).toEqual({ seriesId: 0, ingestedSamples: 3 });
 
       const envelope = mock.posted[0].message as RequestEnvelope;
-      expect(envelope.payload.type).toBe('ingest');
+      expect(envelope.payload.type).toBe("ingest");
     });
 
-    it('includes transferables for transferable strategy', async () => {
-      mock.autoRespond({ ok: true, type: 'ingest', seriesId: 0, ingestedSamples: 1 });
+    it("includes transferables for transferable strategy", async () => {
+      mock.autoRespond({ ok: true, type: "ingest", seriesId: 0, ingestedSamples: 1 });
 
       const timestamps = BigInt64Array.from([1n]);
       const values = new Float64Array([1]);
 
-      await client.ingest(new Map([['k', 'v']]), timestamps, values);
+      await client.ingest(new Map([["k", "v"]]), timestamps, values);
 
       const transfer = mock.posted[0].transfer;
       expect(transfer).toBeDefined();
+      // biome-ignore lint/style/noNonNullAssertion: test code
       expect(transfer!.length).toBe(2);
     });
 
-    it('omits transferables for structured-clone strategy', async () => {
+    it("omits transferables for structured-clone strategy", async () => {
       mock = createMockWorker();
-      client = new WorkerClient({ worker: mock.worker, transferStrategy: 'structured-clone' });
-      mock.autoRespond({ ok: true, type: 'ingest', seriesId: 0, ingestedSamples: 1 });
+      client = new WorkerClient({ worker: mock.worker, transferStrategy: "structured-clone" });
+      mock.autoRespond({ ok: true, type: "ingest", seriesId: 0, ingestedSamples: 1 });
 
       const timestamps = BigInt64Array.from([1n]);
       const values = new Float64Array([1]);
 
-      await client.ingest(new Map([['k', 'v']]), timestamps, values);
+      await client.ingest(new Map([["k", "v"]]), timestamps, values);
 
       const transfer = mock.posted[0].transfer;
       expect(transfer).toEqual([]);
     });
 
-    it('throws on error response', async () => {
-      mock.autoRespond({ ok: false, type: 'error', error: 'ingest fail' });
+    it("throws on error response", async () => {
+      mock.autoRespond({ ok: false, type: "error", error: "ingest fail" });
 
       await expect(
-        client.ingest(new Map(), BigInt64Array.from([1n]), new Float64Array([1])),
-      ).rejects.toThrow('ingest fail');
+        client.ingest(new Map(), BigInt64Array.from([1n]), new Float64Array([1]))
+      ).rejects.toThrow("ingest fail");
     });
   });
 
   // ── query() ───────────────────────────────────────────────────
 
-  describe('query()', () => {
-    it('sends query and returns result', async () => {
+  describe("query()", () => {
+    it("sends query and returns result", async () => {
       const queryResult = { series: [], scannedSeries: 0, scannedSamples: 0 };
-      mock.autoRespond({ ok: true, type: 'query', result: queryResult });
+      mock.autoRespond({ ok: true, type: "query", result: queryResult });
 
       const result = await client.query({
-        metric: 'cpu',
+        metric: "cpu",
         start: 0n,
         end: 100n,
       });
       expect(result).toEqual(queryResult);
     });
 
-    it('throws on error response', async () => {
-      mock.autoRespond({ ok: false, type: 'error', error: 'query fail' });
+    it("throws on error response", async () => {
+      mock.autoRespond({ ok: false, type: "error", error: "query fail" });
 
-      await expect(
-        client.query({ metric: 'cpu', start: 0n, end: 100n }),
-      ).rejects.toThrow('query fail');
+      await expect(client.query({ metric: "cpu", start: 0n, end: 100n })).rejects.toThrow(
+        "query fail"
+      );
     });
   });
 
   // ── stats() ───────────────────────────────────────────────────
 
-  describe('stats()', () => {
-    it('returns stats from worker', async () => {
+  describe("stats()", () => {
+    it("returns stats from worker", async () => {
       mock.autoRespond({
         ok: true,
-        type: 'stats',
+        type: "stats",
         stats: { seriesCount: 10, sampleCount: 1000, memoryBytes: 4096 },
       });
 
@@ -186,30 +194,31 @@ describe('WorkerClient', () => {
 
   // ── echo() ────────────────────────────────────────────────────
 
-  describe('echo()', () => {
-    it('sends echo and returns byte count', async () => {
-      mock.autoRespond({ ok: true, type: 'echo', bytes: 256 });
+  describe("echo()", () => {
+    it("sends echo and returns byte count", async () => {
+      mock.autoRespond({ ok: true, type: "echo", bytes: 256 });
 
       const result = await client.echo(new Uint8Array(256));
       expect(result).toBe(256);
     });
 
-    it('uses transferable strategy by default', async () => {
-      mock.autoRespond({ ok: true, type: 'echo', bytes: 8 });
+    it("uses transferable strategy by default", async () => {
+      mock.autoRespond({ ok: true, type: "echo", bytes: 8 });
 
       const payload = new Uint8Array(8);
       await client.echo(payload);
 
       const transfer = mock.posted[0].transfer;
       expect(transfer).toBeDefined();
+      // biome-ignore lint/style/noNonNullAssertion: test code
       expect(transfer!.length).toBe(1);
     });
 
-    it('skips transferables when strategy is structured-clone', async () => {
-      mock.autoRespond({ ok: true, type: 'echo', bytes: 8 });
+    it("skips transferables when strategy is structured-clone", async () => {
+      mock.autoRespond({ ok: true, type: "echo", bytes: 8 });
 
       const payload = new Uint8Array(8);
-      await client.echo(payload, 'structured-clone');
+      await client.echo(payload, "structured-clone");
 
       const transfer = mock.posted[0].transfer;
       expect(transfer).toEqual([]);
@@ -218,26 +227,30 @@ describe('WorkerClient', () => {
 
   // ── close() ───────────────────────────────────────────────────
 
-  describe('close()', () => {
-    it('sends close and calls terminate', async () => {
-      mock.autoRespond({ ok: true, type: 'close' });
+  describe("close()", () => {
+    it("sends close and calls terminate", async () => {
+      mock.autoRespond({ ok: true, type: "close" });
 
       await client.close();
       expect(mock.worker.terminate).toHaveBeenCalled();
     });
 
-    it('throws on error response', async () => {
-      mock.autoRespond({ ok: false, type: 'error', error: 'close fail' });
+    it("throws on error response", async () => {
+      mock.autoRespond({ ok: false, type: "error", error: "close fail" });
 
-      await expect(client.close()).rejects.toThrow('close fail');
+      await expect(client.close()).rejects.toThrow("close fail");
     });
   });
 
   // ── Request IDs ───────────────────────────────────────────────
 
-  describe('request IDs', () => {
-    it('increments request IDs across calls', async () => {
-      mock.autoRespond({ ok: true, type: 'stats', stats: { seriesCount: 0, sampleCount: 0, memoryBytes: 0 } });
+  describe("request IDs", () => {
+    it("increments request IDs across calls", async () => {
+      mock.autoRespond({
+        ok: true,
+        type: "stats",
+        stats: { seriesCount: 0, sampleCount: 0, memoryBytes: 0 },
+      });
 
       await client.stats();
       await client.stats();
@@ -250,34 +263,36 @@ describe('WorkerClient', () => {
 
   // ── Meta ──────────────────────────────────────────────────────
 
-  describe('protocol meta', () => {
-    it('includes strategy and sentAt in meta', async () => {
-      mock.autoRespond({ ok: true, type: 'close' });
+  describe("protocol meta", () => {
+    it("includes strategy and sentAt in meta", async () => {
+      mock.autoRespond({ ok: true, type: "close" });
       await client.close();
 
       const envelope = mock.posted[0].message as RequestEnvelope;
       expect(envelope.meta).toBeDefined();
-      expect(envelope.meta!.strategy).toBe('transferable');
-      expect(typeof envelope.meta!.sentAt).toBe('number');
+      // biome-ignore lint/style/noNonNullAssertion: test code
+      expect(envelope.meta!.strategy).toBe("transferable");
+      // biome-ignore lint/style/noNonNullAssertion: test code
+      expect(typeof envelope.meta!.sentAt).toBe("number");
     });
   });
 
   // ── Unmatched responses ───────────────────────────────────────
 
-  describe('message handling', () => {
-    it('ignores non-response messages', () => {
+  describe("message handling", () => {
+    it("ignores non-response messages", () => {
       // Should not throw
-      mock.respond({ kind: 'request', id: 1, payload: { type: 'stats' } });
+      mock.respond({ kind: "request", id: 1, payload: { type: "stats" } });
       mock.respond(null);
       mock.respond(42);
-      mock.respond('garbage');
+      mock.respond("garbage");
     });
 
-    it('ignores responses with unknown IDs', () => {
+    it("ignores responses with unknown IDs", () => {
       mock.respond({
         id: 9999,
-        kind: 'response',
-        payload: { ok: true, type: 'close' },
+        kind: "response",
+        payload: { ok: true, type: "close" },
       });
       // No pending request with id 9999 — should silently ignore
     });
@@ -285,10 +300,11 @@ describe('WorkerClient', () => {
 
   // ── Worker without terminate ──────────────────────────────────
 
-  describe('worker without terminate()', () => {
-    it('does not throw when terminate is undefined', async () => {
+  describe("worker without terminate()", () => {
+    it("does not throw when terminate is undefined", async () => {
       const workerNoTerminate = {
         postMessage: vi.fn(),
+        // biome-ignore lint/correctness/noUnusedFunctionParameters: test code
         addEventListener: vi.fn((_type: string, listener: MessageListener) => {
           // store for later
         }),
@@ -296,17 +312,20 @@ describe('WorkerClient', () => {
 
       // We need to wire up manually
       let capturedListener: MessageListener | undefined;
-      workerNoTerminate.addEventListener.mockImplementation((_type: string, listener: MessageListener) => {
-        capturedListener = listener;
-      });
+      workerNoTerminate.addEventListener.mockImplementation(
+        (_type: string, listener: MessageListener) => {
+          capturedListener = listener;
+        }
+      );
 
       const c = new WorkerClient({ worker: workerNoTerminate });
 
       // Auto-respond via the captured listener
       workerNoTerminate.postMessage.mockImplementation((message: unknown) => {
         const req = message as RequestEnvelope;
+        // biome-ignore lint/style/noNonNullAssertion: test code
         capturedListener!({
-          data: { id: req.id, kind: 'response', payload: { ok: true, type: 'close' } },
+          data: { id: req.id, kind: "response", payload: { ok: true, type: "close" } },
         });
       });
 

--- a/packages/o11ytsdb/test/worker-protocol.test.ts
+++ b/packages/o11ytsdb/test/worker-protocol.test.ts
@@ -1,174 +1,174 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
 import {
-  ok,
+  type ErrorResponse,
   err,
+  type InitResponse,
   isResponseEnvelope,
   labelsFromEntries,
+  ok,
+  type ProtocolMeta,
   type RequestEnvelope,
   type ResponseEnvelope,
-  type ErrorResponse,
-  type InitResponse,
-  type ProtocolMeta,
-} from '../src/worker-protocol.js';
+} from "../src/worker-protocol.js";
 
-describe('worker-protocol helpers', () => {
+describe("worker-protocol helpers", () => {
   // ── ok() ──────────────────────────────────────────────────────
 
-  describe('ok()', () => {
-    it('wraps a response payload without meta', () => {
-      const payload: InitResponse = { ok: true, type: 'init', backend: 'column' };
+  describe("ok()", () => {
+    it("wraps a response payload without meta", () => {
+      const payload: InitResponse = { ok: true, type: "init", backend: "column" };
       const env = ok(42, payload);
 
       expect(env).toEqual({
         id: 42,
-        kind: 'response',
-        payload: { ok: true, type: 'init', backend: 'column' },
+        kind: "response",
+        payload: { ok: true, type: "init", backend: "column" },
       });
-      expect(env).not.toHaveProperty('meta');
+      expect(env).not.toHaveProperty("meta");
     });
 
-    it('includes meta when provided', () => {
-      const payload: InitResponse = { ok: true, type: 'init', backend: 'column' };
-      const meta: ProtocolMeta = { strategy: 'transferable', sentAt: 1000 };
+    it("includes meta when provided", () => {
+      const payload: InitResponse = { ok: true, type: "init", backend: "column" };
+      const meta: ProtocolMeta = { strategy: "transferable", sentAt: 1000 };
       const env = ok(1, payload, meta);
 
       expect(env.meta).toEqual(meta);
       expect(env.id).toBe(1);
-      expect(env.kind).toBe('response');
+      expect(env.kind).toBe("response");
     });
 
-    it('preserves payload type for all response types', () => {
-      const echo = ok(1, { ok: true as const, type: 'echo' as const, bytes: 128 });
-      expect(echo.payload.type).toBe('echo');
+    it("preserves payload type for all response types", () => {
+      const echo = ok(1, { ok: true as const, type: "echo" as const, bytes: 128 });
+      expect(echo.payload.type).toBe("echo");
 
-      const close = ok(2, { ok: true as const, type: 'close' as const });
-      expect(close.payload.type).toBe('close');
+      const close = ok(2, { ok: true as const, type: "close" as const });
+      expect(close.payload.type).toBe("close");
 
       const stats = ok(3, {
         ok: true as const,
-        type: 'stats' as const,
+        type: "stats" as const,
         stats: { seriesCount: 5, sampleCount: 100, memoryBytes: 2048 },
       });
-      expect(stats.payload.type).toBe('stats');
+      expect(stats.payload.type).toBe("stats");
     });
   });
 
   // ── err() ─────────────────────────────────────────────────────
 
-  describe('err()', () => {
-    it('wraps an Error instance with message and stack', () => {
-      const error = new Error('something broke');
+  describe("err()", () => {
+    it("wraps an Error instance with message and stack", () => {
+      const error = new Error("something broke");
       const env = err(7, error);
 
       expect(env.id).toBe(7);
-      expect(env.kind).toBe('response');
+      expect(env.kind).toBe("response");
       expect(env.payload.ok).toBe(false);
-      expect(env.payload.type).toBe('error');
-      expect(env.payload.error).toBe('something broke');
+      expect(env.payload.type).toBe("error");
+      expect(env.payload.error).toBe("something broke");
       expect(env.payload.stack).toBeDefined();
-      expect(env).not.toHaveProperty('meta');
+      expect(env).not.toHaveProperty("meta");
     });
 
-    it('wraps a string error without stack', () => {
-      const env = err(8, 'plain string error');
+    it("wraps a string error without stack", () => {
+      const env = err(8, "plain string error");
 
-      expect(env.payload.error).toBe('plain string error');
-      expect(env.payload).not.toHaveProperty('stack');
+      expect(env.payload.error).toBe("plain string error");
+      expect(env.payload).not.toHaveProperty("stack");
     });
 
-    it('wraps a non-Error object via String()', () => {
+    it("wraps a non-Error object via String()", () => {
       const env = err(9, 42);
-      expect(env.payload.error).toBe('42');
+      expect(env.payload.error).toBe("42");
     });
 
-    it('includes meta when provided', () => {
-      const meta: ProtocolMeta = { strategy: 'structured-clone' };
-      const env = err(10, new Error('oops'), meta);
+    it("includes meta when provided", () => {
+      const meta: ProtocolMeta = { strategy: "structured-clone" };
+      const env = err(10, new Error("oops"), meta);
 
       expect(env.meta).toEqual(meta);
-      expect(env.payload.error).toBe('oops');
+      expect(env.payload.error).toBe("oops");
     });
 
-    it('omits meta field when meta is undefined', () => {
-      const env = err(11, 'no meta');
-      expect(env).not.toHaveProperty('meta');
+    it("omits meta field when meta is undefined", () => {
+      const env = err(11, "no meta");
+      expect(env).not.toHaveProperty("meta");
     });
   });
 
   // ── isResponseEnvelope() ──────────────────────────────────────
 
-  describe('isResponseEnvelope()', () => {
-    it('returns true for a valid response envelope', () => {
+  describe("isResponseEnvelope()", () => {
+    it("returns true for a valid response envelope", () => {
       const env: ResponseEnvelope = {
         id: 1,
-        kind: 'response',
-        payload: { ok: true, type: 'close' },
+        kind: "response",
+        payload: { ok: true, type: "close" },
       };
       expect(isResponseEnvelope(env)).toBe(true);
     });
 
-    it('returns true for an error response envelope', () => {
+    it("returns true for an error response envelope", () => {
       const env: ResponseEnvelope<ErrorResponse> = {
         id: 2,
-        kind: 'response',
-        payload: { ok: false, type: 'error', error: 'fail' },
+        kind: "response",
+        payload: { ok: false, type: "error", error: "fail" },
       };
       expect(isResponseEnvelope(env)).toBe(true);
     });
 
-    it('returns false for null', () => {
+    it("returns false for null", () => {
       expect(isResponseEnvelope(null)).toBe(false);
     });
 
-    it('returns false for undefined', () => {
+    it("returns false for undefined", () => {
       expect(isResponseEnvelope(undefined)).toBe(false);
     });
 
-    it('returns false for a primitive', () => {
+    it("returns false for a primitive", () => {
       expect(isResponseEnvelope(42)).toBe(false);
-      expect(isResponseEnvelope('hello')).toBe(false);
+      expect(isResponseEnvelope("hello")).toBe(false);
     });
 
-    it('returns false for a request envelope', () => {
+    it("returns false for a request envelope", () => {
       const req: RequestEnvelope = {
         id: 1,
-        kind: 'request',
-        payload: { type: 'stats' },
+        kind: "request",
+        payload: { type: "stats" },
       };
       expect(isResponseEnvelope(req)).toBe(false);
     });
 
-    it('returns false when id is missing', () => {
-      expect(isResponseEnvelope({ kind: 'response', payload: { ok: true } })).toBe(false);
+    it("returns false when id is missing", () => {
+      expect(isResponseEnvelope({ kind: "response", payload: { ok: true } })).toBe(false);
     });
 
-    it('returns false when payload is missing', () => {
-      expect(isResponseEnvelope({ id: 1, kind: 'response' })).toBe(false);
+    it("returns false when payload is missing", () => {
+      expect(isResponseEnvelope({ id: 1, kind: "response" })).toBe(false);
     });
 
-    it('returns false for an empty object', () => {
+    it("returns false for an empty object", () => {
       expect(isResponseEnvelope({})).toBe(false);
     });
   });
 
   // ── labelsFromEntries() ───────────────────────────────────────
 
-  describe('labelsFromEntries()', () => {
-    it('converts label entries to a Map', () => {
+  describe("labelsFromEntries()", () => {
+    it("converts label entries to a Map", () => {
       const entries: [string, string][] = [
-        ['__name__', 'cpu_usage'],
-        ['host', 'web-01'],
+        ["__name__", "cpu_usage"],
+        ["host", "web-01"],
       ];
       const result = labelsFromEntries(entries);
 
       expect(result).toBeInstanceOf(Map);
-      expect(result.get('__name__')).toBe('cpu_usage');
-      expect(result.get('host')).toBe('web-01');
+      expect(result.get("__name__")).toBe("cpu_usage");
+      expect(result.get("host")).toBe("web-01");
       expect(result.size).toBe(2);
     });
 
-    it('returns an empty Map for empty entries', () => {
+    it("returns an empty Map for empty entries", () => {
       expect(labelsFromEntries([]).size).toBe(0);
     });
   });

--- a/packages/o11ytsdb/test/worker-runtime.test.ts
+++ b/packages/o11ytsdb/test/worker-runtime.test.ts
@@ -1,14 +1,14 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { O11yWorkerRuntime } from '../src/worker.js';
-import type { RequestEnvelope, ResponseEnvelope } from '../src/worker-protocol.js';
+import { O11yWorkerRuntime } from "../src/worker.js";
+import type { RequestEnvelope, ResponseEnvelope } from "../src/worker-protocol.js";
 
 // ── Mock endpoint ───────────────────────────────────────────────────
 
 type EventListener = (event: { data: unknown }) => void;
 type OnListener = (data: unknown) => void;
 
-function createMockEndpoint(mode: 'addEventListener' | 'on' = 'addEventListener') {
+function createMockEndpoint(mode: "addEventListener" | "on" = "addEventListener") {
   const posted: Array<{ message: unknown; transfer?: ArrayBufferLike[] }> = [];
   let eventListener: EventListener | undefined;
   let onListener: OnListener | undefined;
@@ -17,7 +17,7 @@ function createMockEndpoint(mode: 'addEventListener' | 'on' = 'addEventListener'
     postMessage(message: unknown, transfer?: ArrayBufferLike[]): void {
       posted.push({ message, transfer });
     },
-    ...(mode === 'addEventListener'
+    ...(mode === "addEventListener"
       ? {
           addEventListener(_type: string, listener: EventListener): void {
             eventListener = listener;
@@ -49,7 +49,10 @@ function createMockEndpoint(mode: 'addEventListener' | 'on' = 'addEventListener'
 }
 
 /** Wait for the runtime to post a response (polls for up to 100ms). */
-async function waitForResponse(mock: ReturnType<typeof createMockEndpoint>, afterIndex = -1): Promise<ResponseEnvelope> {
+async function waitForResponse(
+  mock: ReturnType<typeof createMockEndpoint>,
+  afterIndex = -1
+): Promise<ResponseEnvelope> {
   const target = afterIndex >= 0 ? afterIndex + 1 : mock.posted.length;
   for (let i = 0; i < 20; i++) {
     await new Promise((r) => setTimeout(r, 5));
@@ -58,72 +61,78 @@ async function waitForResponse(mock: ReturnType<typeof createMockEndpoint>, afte
     }
   }
   const last = mock.posted[mock.posted.length - 1];
-  if (!last) throw new Error('No response received within timeout');
+  if (!last) throw new Error("No response received within timeout");
   return last.message as ResponseEnvelope;
 }
 
-function makeRequest(id: number, payload: RequestEnvelope['payload']): RequestEnvelope {
-  return { id, kind: 'request', payload };
+function makeRequest(id: number, payload: RequestEnvelope["payload"]): RequestEnvelope {
+  return { id, kind: "request", payload };
 }
 
-describe('O11yWorkerRuntime', () => {
+describe("O11yWorkerRuntime", () => {
   let mock: ReturnType<typeof createMockEndpoint>;
   let runtime: O11yWorkerRuntime;
 
   beforeEach(() => {
     mock = createMockEndpoint();
+    // biome-ignore lint/suspicious/noExplicitAny: test code
     runtime = new O11yWorkerRuntime(mock.endpoint as any);
     runtime.start();
   });
 
   // ── init ──────────────────────────────────────────────────────
 
-  describe('init', () => {
-    it('responds with backend name', async () => {
-      mock.sendRequest(makeRequest(1, { type: 'init', chunkSize: 128 }));
+  describe("init", () => {
+    it("responds with backend name", async () => {
+      mock.sendRequest(makeRequest(1, { type: "init", chunkSize: 128 }));
       const resp = await waitForResponse(mock);
 
-      expect(resp.kind).toBe('response');
+      expect(resp.kind).toBe("response");
       expect(resp.id).toBe(1);
       expect(resp.payload.ok).toBe(true);
-      expect(resp.payload.type).toBe('init');
-      if (resp.payload.type === 'init') {
-        expect(typeof resp.payload.backend).toBe('string');
+      expect(resp.payload.type).toBe("init");
+      if (resp.payload.type === "init") {
+        expect(typeof resp.payload.backend).toBe("string");
       }
     });
 
-    it('uses default chunk size when omitted', async () => {
-      mock.sendRequest(makeRequest(1, { type: 'init' }));
+    it("uses default chunk size when omitted", async () => {
+      mock.sendRequest(makeRequest(1, { type: "init" }));
       const resp = await waitForResponse(mock);
 
       expect(resp.payload.ok).toBe(true);
-      expect(resp.payload.type).toBe('init');
+      expect(resp.payload.type).toBe("init");
     });
   });
 
   // ── ingest ────────────────────────────────────────────────────
 
-  describe('ingest', () => {
-    it('ingests samples and returns series info', async () => {
+  describe("ingest", () => {
+    it("ingests samples and returns series info", async () => {
       // Init first
-      mock.sendRequest(makeRequest(1, { type: 'init', chunkSize: 1024 }));
+      mock.sendRequest(makeRequest(1, { type: "init", chunkSize: 1024 }));
       await waitForResponse(mock);
 
       const timestamps = BigInt64Array.from([1000n, 2000n, 3000n]);
       const values = new Float64Array([1.0, 2.0, 3.0]);
 
-      mock.sendRequest(makeRequest(2, {
-        type: 'ingest',
-        labels: [['__name__', 'cpu'], ['host', 'a']],
-        timestamps,
-        values,
-      }));
+      mock.sendRequest(
+        makeRequest(2, {
+          type: "ingest",
+          labels: [
+            ["__name__", "cpu"],
+            ["host", "a"],
+          ],
+          timestamps,
+          values,
+        })
+      );
       const resp = await waitForResponse(mock);
 
       expect(resp.payload.ok).toBe(true);
-      expect(resp.payload.type).toBe('ingest');
-      if (resp.payload.type === 'ingest') {
-        expect(resp.payload.seriesId).toBeTypeOf('number');
+      expect(resp.payload.type).toBe("ingest");
+      if (resp.payload.type === "ingest") {
+        expect(resp.payload.seriesId).toBeTypeOf("number");
         expect(resp.payload.ingestedSamples).toBe(3);
       }
     });
@@ -131,48 +140,57 @@ describe('O11yWorkerRuntime', () => {
 
   // ── query ─────────────────────────────────────────────────────
 
-  describe('query', () => {
-    it('returns query results after ingesting data', async () => {
+  describe("query", () => {
+    it("returns query results after ingesting data", async () => {
       // Init
-      mock.sendRequest(makeRequest(1, { type: 'init', chunkSize: 1024 }));
+      mock.sendRequest(makeRequest(1, { type: "init", chunkSize: 1024 }));
       await waitForResponse(mock);
 
       // Ingest
-      mock.sendRequest(makeRequest(2, {
-        type: 'ingest',
-        labels: [['__name__', 'cpu'], ['host', 'web-01']],
-        timestamps: BigInt64Array.from([100n, 200n, 300n]),
-        values: new Float64Array([10, 20, 30]),
-      }));
+      mock.sendRequest(
+        makeRequest(2, {
+          type: "ingest",
+          labels: [
+            ["__name__", "cpu"],
+            ["host", "web-01"],
+          ],
+          timestamps: BigInt64Array.from([100n, 200n, 300n]),
+          values: new Float64Array([10, 20, 30]),
+        })
+      );
       await waitForResponse(mock);
 
       // Query
-      mock.sendRequest(makeRequest(3, {
-        type: 'query',
-        opts: { metric: 'cpu', start: 0n, end: 1000n },
-      }));
+      mock.sendRequest(
+        makeRequest(3, {
+          type: "query",
+          opts: { metric: "cpu", start: 0n, end: 1000n },
+        })
+      );
       const resp = await waitForResponse(mock);
 
       expect(resp.payload.ok).toBe(true);
-      expect(resp.payload.type).toBe('query');
-      if (resp.payload.type === 'query') {
+      expect(resp.payload.type).toBe("query");
+      if (resp.payload.type === "query") {
         expect(resp.payload.result.series.length).toBeGreaterThanOrEqual(1);
         expect(resp.payload.result.scannedSamples).toBeGreaterThan(0);
       }
     });
 
-    it('returns empty result for non-matching metric', async () => {
-      mock.sendRequest(makeRequest(1, { type: 'init' }));
+    it("returns empty result for non-matching metric", async () => {
+      mock.sendRequest(makeRequest(1, { type: "init" }));
       await waitForResponse(mock);
 
-      mock.sendRequest(makeRequest(2, {
-        type: 'query',
-        opts: { metric: 'nonexistent', start: 0n, end: 1000n },
-      }));
+      mock.sendRequest(
+        makeRequest(2, {
+          type: "query",
+          opts: { metric: "nonexistent", start: 0n, end: 1000n },
+        })
+      );
       const resp = await waitForResponse(mock);
 
       expect(resp.payload.ok).toBe(true);
-      if (resp.payload.type === 'query') {
+      if (resp.payload.type === "query") {
         expect(resp.payload.result.series).toEqual([]);
       }
     });
@@ -180,39 +198,41 @@ describe('O11yWorkerRuntime', () => {
 
   // ── stats ─────────────────────────────────────────────────────
 
-  describe('stats', () => {
-    it('returns zero stats on fresh store', async () => {
-      mock.sendRequest(makeRequest(1, { type: 'init' }));
+  describe("stats", () => {
+    it("returns zero stats on fresh store", async () => {
+      mock.sendRequest(makeRequest(1, { type: "init" }));
       await waitForResponse(mock);
 
-      mock.sendRequest(makeRequest(2, { type: 'stats' }));
+      mock.sendRequest(makeRequest(2, { type: "stats" }));
       const resp = await waitForResponse(mock);
 
       expect(resp.payload.ok).toBe(true);
-      expect(resp.payload.type).toBe('stats');
-      if (resp.payload.type === 'stats') {
+      expect(resp.payload.type).toBe("stats");
+      if (resp.payload.type === "stats") {
         expect(resp.payload.stats.seriesCount).toBe(0);
         expect(resp.payload.stats.sampleCount).toBe(0);
-        expect(resp.payload.stats.memoryBytes).toBeTypeOf('number');
+        expect(resp.payload.stats.memoryBytes).toBeTypeOf("number");
       }
     });
 
-    it('reflects ingested data', async () => {
-      mock.sendRequest(makeRequest(1, { type: 'init' }));
+    it("reflects ingested data", async () => {
+      mock.sendRequest(makeRequest(1, { type: "init" }));
       await waitForResponse(mock);
 
-      mock.sendRequest(makeRequest(2, {
-        type: 'ingest',
-        labels: [['__name__', 'mem']],
-        timestamps: BigInt64Array.from([1n, 2n]),
-        values: new Float64Array([100, 200]),
-      }));
+      mock.sendRequest(
+        makeRequest(2, {
+          type: "ingest",
+          labels: [["__name__", "mem"]],
+          timestamps: BigInt64Array.from([1n, 2n]),
+          values: new Float64Array([100, 200]),
+        })
+      );
       await waitForResponse(mock);
 
-      mock.sendRequest(makeRequest(3, { type: 'stats' }));
+      mock.sendRequest(makeRequest(3, { type: "stats" }));
       const resp = await waitForResponse(mock);
 
-      if (resp.payload.type === 'stats') {
+      if (resp.payload.type === "stats") {
         expect(resp.payload.stats.seriesCount).toBe(1);
         expect(resp.payload.stats.sampleCount).toBe(2);
       }
@@ -221,23 +241,23 @@ describe('O11yWorkerRuntime', () => {
 
   // ── echo ──────────────────────────────────────────────────────
 
-  describe('echo', () => {
-    it('echoes back the byte length', async () => {
-      mock.sendRequest(makeRequest(1, { type: 'echo', payload: new Uint8Array(512) }));
+  describe("echo", () => {
+    it("echoes back the byte length", async () => {
+      mock.sendRequest(makeRequest(1, { type: "echo", payload: new Uint8Array(512) }));
       const resp = await waitForResponse(mock);
 
       expect(resp.payload.ok).toBe(true);
-      expect(resp.payload.type).toBe('echo');
-      if (resp.payload.type === 'echo') {
+      expect(resp.payload.type).toBe("echo");
+      if (resp.payload.type === "echo") {
         expect(resp.payload.bytes).toBe(512);
       }
     });
 
-    it('echoes zero bytes for empty payload', async () => {
-      mock.sendRequest(makeRequest(1, { type: 'echo', payload: new Uint8Array(0) }));
+    it("echoes zero bytes for empty payload", async () => {
+      mock.sendRequest(makeRequest(1, { type: "echo", payload: new Uint8Array(0) }));
       const resp = await waitForResponse(mock);
 
-      if (resp.payload.type === 'echo') {
+      if (resp.payload.type === "echo") {
         expect(resp.payload.bytes).toBe(0);
       }
     });
@@ -245,34 +265,34 @@ describe('O11yWorkerRuntime', () => {
 
   // ── close ─────────────────────────────────────────────────────
 
-  describe('close', () => {
-    it('responds with close acknowledgement', async () => {
-      mock.sendRequest(makeRequest(1, { type: 'close' }));
+  describe("close", () => {
+    it("responds with close acknowledgement", async () => {
+      mock.sendRequest(makeRequest(1, { type: "close" }));
       const resp = await waitForResponse(mock);
 
       expect(resp.payload.ok).toBe(true);
-      expect(resp.payload.type).toBe('close');
+      expect(resp.payload.type).toBe("close");
     });
   });
 
   // ── Meta passthrough ──────────────────────────────────────────
 
-  describe('meta passthrough', () => {
-    it('includes meta in response when request has meta', async () => {
+  describe("meta passthrough", () => {
+    it("includes meta in response when request has meta", async () => {
       const req: RequestEnvelope = {
         id: 1,
-        kind: 'request',
-        payload: { type: 'echo', payload: new Uint8Array(1) },
-        meta: { strategy: 'transferable', sentAt: 12345 },
+        kind: "request",
+        payload: { type: "echo", payload: new Uint8Array(1) },
+        meta: { strategy: "transferable", sentAt: 12345 },
       };
       mock.sendRequest(req);
       const resp = await waitForResponse(mock);
 
-      expect(resp.meta).toEqual({ strategy: 'transferable', sentAt: 12345 });
+      expect(resp.meta).toEqual({ strategy: "transferable", sentAt: 12345 });
     });
 
-    it('omits meta in response when request has no meta', async () => {
-      mock.sendRequest(makeRequest(1, { type: 'close' }));
+    it("omits meta in response when request has no meta", async () => {
+      mock.sendRequest(makeRequest(1, { type: "close" }));
       const resp = await waitForResponse(mock);
 
       // ok() omits meta when undefined
@@ -282,47 +302,52 @@ describe('O11yWorkerRuntime', () => {
 
   // ── Error handling ────────────────────────────────────────────
 
-  describe('error handling', () => {
-    it('ignores non-request messages', async () => {
+  describe("error handling", () => {
+    it("ignores non-request messages", async () => {
       mock.send(null);
       mock.send(42);
-      mock.send('garbage');
-      mock.send({ kind: 'response', id: 1, payload: {} });
+      mock.send("garbage");
+      mock.send({ kind: "response", id: 1, payload: {} });
 
       // No responses should have been posted
       expect(mock.posted.length).toBe(0);
     });
 
-    it('ignores messages without kind=request', async () => {
-      mock.send({ id: 1, kind: 'not-request', payload: { type: 'echo', payload: new Uint8Array(1) } });
+    it("ignores messages without kind=request", async () => {
+      mock.send({
+        id: 1,
+        kind: "not-request",
+        payload: { type: "echo", payload: new Uint8Array(1) },
+      });
       expect(mock.posted.length).toBe(0);
     });
 
-    it('unwraps event.data from addEventListener messages', async () => {
+    it("unwraps event.data from addEventListener messages", async () => {
       // All sendRequest calls already exercise the event.data unwrap path
       // (mock.send wraps in {data: ...} for addEventListener endpoints).
       // Verify explicitly with a high request id.
-      mock.sendRequest(makeRequest(99, { type: 'echo', payload: new Uint8Array(16) }));
+      mock.sendRequest(makeRequest(99, { type: "echo", payload: new Uint8Array(16) }));
       const resp = await waitForResponse(mock, mock.posted.length - 1);
       expect(resp.payload.ok).toBe(true);
-      expect(resp.payload.type).toBe('echo');
+      expect(resp.payload.type).toBe("echo");
       expect(resp.id).toBe(99);
     });
   });
 
   // ── on() endpoint (Node.js worker_threads style) ──────────────
 
-  describe('Node.js-style endpoint (on)', () => {
+  describe("Node.js-style endpoint (on)", () => {
     it('works with on("message") instead of addEventListener', async () => {
-      const onMock = createMockEndpoint('on');
+      const onMock = createMockEndpoint("on");
+      // biome-ignore lint/suspicious/noExplicitAny: test code
       const rt = new O11yWorkerRuntime(onMock.endpoint as any);
       rt.start();
 
-      onMock.sendRequest(makeRequest(1, { type: 'echo', payload: new Uint8Array(64) }));
+      onMock.sendRequest(makeRequest(1, { type: "echo", payload: new Uint8Array(64) }));
       const resp = await waitForResponse(onMock);
 
       expect(resp.payload.ok).toBe(true);
-      if (resp.payload.type === 'echo') {
+      if (resp.payload.type === "echo") {
         expect(resp.payload.bytes).toBe(64);
       }
     });
@@ -330,66 +355,79 @@ describe('O11yWorkerRuntime', () => {
 
   // ── Endpoint without any listener method ──────────────────────
 
-  describe('bad endpoint', () => {
-    it('throws when endpoint has neither addEventListener nor on', () => {
+  describe("bad endpoint", () => {
+    it("throws when endpoint has neither addEventListener nor on", () => {
       const badEndpoint = {
         postMessage: vi.fn(),
       };
 
+      // biome-ignore lint/suspicious/noExplicitAny: test code
       const rt = new O11yWorkerRuntime(badEndpoint as any);
-      expect(() => rt.start()).toThrow('Worker endpoint does not support message listeners.');
+      expect(() => rt.start()).toThrow("Worker endpoint does not support message listeners.");
     });
   });
 
   // ── Full round-trip: init → ingest → query → stats → close ───
 
-  describe('full lifecycle', () => {
-    it('supports a complete init → ingest → query → stats → close cycle', async () => {
+  describe("full lifecycle", () => {
+    it("supports a complete init → ingest → query → stats → close cycle", async () => {
       // Init
-      mock.sendRequest(makeRequest(1, { type: 'init', chunkSize: 640 }));
+      mock.sendRequest(makeRequest(1, { type: "init", chunkSize: 640 }));
       const initResp = await waitForResponse(mock);
-      expect(initResp.payload.type).toBe('init');
+      expect(initResp.payload.type).toBe("init");
 
       // Ingest two series
-      mock.sendRequest(makeRequest(2, {
-        type: 'ingest',
-        labels: [['__name__', 'http_requests'], ['method', 'GET']],
-        timestamps: BigInt64Array.from([100n, 200n, 300n]),
-        values: new Float64Array([1, 2, 3]),
-      }));
+      mock.sendRequest(
+        makeRequest(2, {
+          type: "ingest",
+          labels: [
+            ["__name__", "http_requests"],
+            ["method", "GET"],
+          ],
+          timestamps: BigInt64Array.from([100n, 200n, 300n]),
+          values: new Float64Array([1, 2, 3]),
+        })
+      );
       await waitForResponse(mock);
 
-      mock.sendRequest(makeRequest(3, {
-        type: 'ingest',
-        labels: [['__name__', 'http_requests'], ['method', 'POST']],
-        timestamps: BigInt64Array.from([100n, 200n]),
-        values: new Float64Array([10, 20]),
-      }));
+      mock.sendRequest(
+        makeRequest(3, {
+          type: "ingest",
+          labels: [
+            ["__name__", "http_requests"],
+            ["method", "POST"],
+          ],
+          timestamps: BigInt64Array.from([100n, 200n]),
+          values: new Float64Array([10, 20]),
+        })
+      );
       await waitForResponse(mock);
 
       // Query
-      mock.sendRequest(makeRequest(4, {
-        type: 'query',
-        opts: { metric: 'http_requests', start: 0n, end: 1000n },
-      }));
+      mock.sendRequest(
+        makeRequest(4, {
+          type: "query",
+          opts: { metric: "http_requests", start: 0n, end: 1000n },
+        })
+      );
       const queryResp = await waitForResponse(mock);
-      if (queryResp.payload.type === 'query') {
+      if (queryResp.payload.type === "query") {
         expect(queryResp.payload.result.series.length).toBe(2);
         expect(queryResp.payload.result.scannedSamples).toBe(5);
       }
 
       // Stats
-      mock.sendRequest(makeRequest(5, { type: 'stats' }));
+      mock.sendRequest(makeRequest(5, { type: "stats" }));
       const statsResp = await waitForResponse(mock);
-      if (statsResp.payload.type === 'stats') {
+      if (statsResp.payload.type === "stats") {
         expect(statsResp.payload.stats.seriesCount).toBe(2);
         expect(statsResp.payload.stats.sampleCount).toBe(5);
       }
 
       // Close
-      mock.sendRequest(makeRequest(6, { type: 'close' }));
+      mock.sendRequest(makeRequest(6, { type: "close" }));
       const closeResp = await waitForResponse(mock);
-      expect(closeResp.payload.type).toBe('close');
+      expect(closeResp.payload.type).toBe("close");
     });
   });
 });

--- a/research/gorilla-bench.mjs
+++ b/research/gorilla-bench.mjs
@@ -1,10 +1,10 @@
 /**
  * R1: Gorilla Compression in TypeScript — Quantified
- * 
+ *
  * Implements delta-of-delta timestamp encoding and XOR float compression
  * from Facebook's Gorilla paper, then benchmarks throughput and compression
  * ratio on realistic OTLP-like data.
- * 
+ *
  * Run: node research/gorilla-bench.mjs
  */
 
@@ -22,27 +22,45 @@ class BitWriter {
       next.set(this.buf);
       this.buf = next;
     }
-    if (bit) this.buf[this.bytePos] |= (0x80 >>> this.bitPos);
+    if (bit) this.buf[this.bytePos] |= 0x80 >>> this.bitPos;
     this.bitPos++;
-    if (this.bitPos === 8) { this.bitPos = 0; this.bytePos++; }
+    if (this.bitPos === 8) {
+      this.bitPos = 0;
+      this.bytePos++;
+    }
   }
   writeBits(value, count) {
     for (let i = count - 1; i >= 0; i--) this.writeBit((value >>> i) & 1);
   }
   writeBits64(hi, lo, count) {
-    if (count <= 32) { this.writeBits(lo, count); }
-    else { this.writeBits(hi, count - 32); this.writeBits(lo, 32); }
+    if (count <= 32) {
+      this.writeBits(lo, count);
+    } else {
+      this.writeBits(hi, count - 32);
+      this.writeBits(lo, 32);
+    }
   }
-  totalBits() { return this.bytePos * 8 + this.bitPos; }
-  bytes() { return this.buf.slice(0, this.bytePos + (this.bitPos > 0 ? 1 : 0)); }
+  totalBits() {
+    return this.bytePos * 8 + this.bitPos;
+  }
+  bytes() {
+    return this.buf.slice(0, this.bytePos + (this.bitPos > 0 ? 1 : 0));
+  }
 }
 
 class BitReader {
-  constructor(buf) { this.buf = buf; this.bytePos = 0; this.bitPos = 0; }
+  constructor(buf) {
+    this.buf = buf;
+    this.bytePos = 0;
+    this.bitPos = 0;
+  }
   readBit() {
     const bit = (this.buf[this.bytePos] >>> (7 - this.bitPos)) & 1;
     this.bitPos++;
-    if (this.bitPos === 8) { this.bitPos = 0; this.bytePos++; }
+    if (this.bitPos === 8) {
+      this.bitPos = 0;
+      this.bytePos++;
+    }
     return bit;
   }
   readBits(count) {
@@ -56,21 +74,34 @@ class BitReader {
 const f64Buf = new Float64Array(1);
 const u32Buf = new Uint32Array(f64Buf.buffer);
 
-function floatToU64(v) { f64Buf[0] = v; return [u32Buf[1], u32Buf[0]]; }
-function u64ToFloat(hi, lo) { u32Buf[1] = hi; u32Buf[0] = lo; return f64Buf[0]; }
-function xor64(aH, aL, bH, bL) { return [(aH ^ bH) >>> 0, (aL ^ bL) >>> 0]; }
-function clz64(hi, lo) { return hi ? Math.clz32(hi) : lo ? 32 + Math.clz32(lo) : 64; }
-function sigBits64(hi, lo) { return hi ? 64 - Math.clz32(hi) : lo ? 32 - Math.clz32(lo) : 0; }
+function floatToU64(v) {
+  f64Buf[0] = v;
+  return [u32Buf[1], u32Buf[0]];
+}
+function u64ToFloat(hi, lo) {
+  u32Buf[1] = hi;
+  u32Buf[0] = lo;
+  return f64Buf[0];
+}
+function xor64(aH, aL, bH, bL) {
+  return [(aH ^ bH) >>> 0, (aL ^ bL) >>> 0];
+}
+function clz64(hi, lo) {
+  return hi ? Math.clz32(hi) : lo ? 32 + Math.clz32(lo) : 64;
+}
+function sigBits64(hi, lo) {
+  return hi ? 64 - Math.clz32(hi) : lo ? 32 - Math.clz32(lo) : 0;
+}
 
 function shr64(hi, lo, s) {
   if (s === 0) return [hi, lo];
   if (s >= 32) return [0, (hi >>> (s - 32)) >>> 0];
-  return [(hi >>> s) >>> 0, (((lo >>> s) | (hi << (32 - s))) >>> 0)];
+  return [(hi >>> s) >>> 0, ((lo >>> s) | (hi << (32 - s))) >>> 0];
 }
 function shl64(hi, lo, s) {
   if (s === 0) return [hi, lo];
-  if (s >= 32) return [((lo << (s - 32)) >>> 0), 0];
-  return [(((hi << s) | (lo >>> (32 - s))) >>> 0), ((lo << s) >>> 0)];
+  if (s >= 32) return [(lo << (s - 32)) >>> 0, 0];
+  return [((hi << s) | (lo >>> (32 - s))) >>> 0, (lo << s) >>> 0];
 }
 
 // === Gorilla Encoder ===
@@ -88,9 +119,12 @@ function gorillaEncode(timestamps, values) {
   w.writeBits(v0Hi, 32);
   w.writeBits(v0Lo, 32);
 
-  let prevT = t0, prevDelta = 0;
-  let prevVHi = v0Hi, prevVLo = v0Lo;
-  let prevLeading = 64, prevTrailing = 0;
+  let prevT = t0,
+    prevDelta = 0;
+  let prevVHi = v0Hi,
+    prevVLo = v0Lo;
+  let prevLeading = 64,
+    prevTrailing = 0;
 
   for (let i = 1; i < n; i++) {
     const t = timestamps[i];
@@ -101,15 +135,20 @@ function gorillaEncode(timestamps, values) {
     if (dod === 0) {
       w.writeBit(0);
     } else if (dod >= -63 && dod <= 64) {
-      w.writeBits(0b10, 2); w.writeBits((dod + 63) & 0x7F, 7);
+      w.writeBits(0b10, 2);
+      w.writeBits((dod + 63) & 0x7f, 7);
     } else if (dod >= -255 && dod <= 256) {
-      w.writeBits(0b110, 3); w.writeBits((dod + 255) & 0x1FF, 9);
+      w.writeBits(0b110, 3);
+      w.writeBits((dod + 255) & 0x1ff, 9);
     } else if (dod >= -2047 && dod <= 2048) {
-      w.writeBits(0b1110, 4); w.writeBits((dod + 2047) & 0xFFF, 12);
+      w.writeBits(0b1110, 4);
+      w.writeBits((dod + 2047) & 0xfff, 12);
     } else {
-      w.writeBits(0b1111, 4); w.writeBits(dod >>> 0, 32);
+      w.writeBits(0b1111, 4);
+      w.writeBits(dod >>> 0, 32);
     }
-    prevDelta = delta; prevT = t;
+    prevDelta = delta;
+    prevT = t;
 
     // Value: XOR encoding
     const [vHi, vLo] = floatToU64(values[i]);
@@ -135,12 +174,20 @@ function gorillaEncode(timestamps, values) {
         const shifted = shr64(xHi, xLo, trailing);
         w.writeBits64(shifted[0], shifted[1], sig);
       }
-      prevLeading = leading; prevTrailing = trailing;
+      prevLeading = leading;
+      prevTrailing = trailing;
     }
-    prevVHi = vHi; prevVLo = vLo;
+    prevVHi = vHi;
+    prevVLo = vLo;
   }
 
-  return { data: w.bytes(), count: n, tFirst: t0, tLast: timestamps[n - 1], totalBits: w.totalBits() };
+  return {
+    data: w.bytes(),
+    count: n,
+    tFirst: t0,
+    tLast: timestamps[n - 1],
+    totalBits: w.totalBits(),
+  };
 }
 
 // === Gorilla Decoder ===
@@ -150,22 +197,38 @@ function gorillaDecode(chunk, outT, outV) {
   const n = chunk.count;
 
   outT[0] = r.readBits(32) * 0x100000000 + r.readBits(32);
-  const v0Hi = r.readBits(32), v0Lo = r.readBits(32);
+  const v0Hi = r.readBits(32),
+    v0Lo = r.readBits(32);
   outV[0] = u64ToFloat(v0Hi, v0Lo);
 
-  let prevT = outT[0], prevDelta = 0;
-  let prevVHi = v0Hi, prevVLo = v0Lo;
-  let prevLeading = 0, prevMeaningful = 64;
+  let prevT = outT[0],
+    prevDelta = 0;
+  let prevVHi = v0Hi,
+    prevVLo = v0Lo;
+  let prevLeading = 0,
+    prevMeaningful = 64;
 
   for (let i = 1; i < n; i++) {
     let dod;
-    if (r.readBit() === 0) { dod = 0; }
-    else if (r.readBit() === 0) { dod = r.readBits(7) - 63; }
-    else if (r.readBit() === 0) { dod = r.readBits(9) - 255; }
-    else if (r.readBit() === 0) { dod = r.readBits(12) - 2047; }
-    else { dod = r.readBits(32); if (dod >= 0x80000000) dod -= 0x100000000; }
+    if (r.readBit() === 0) {
+      dod = 0;
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch (Gorilla encoding)
+    } else if (r.readBit() === 0) {
+      dod = r.readBits(7) - 63;
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch (Gorilla encoding)
+    } else if (r.readBit() === 0) {
+      dod = r.readBits(9) - 255;
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch (Gorilla encoding)
+    } else if (r.readBit() === 0) {
+      dod = r.readBits(12) - 2047;
+    } else {
+      dod = r.readBits(32);
+      if (dod >= 0x80000000) dod -= 0x100000000;
+    }
 
-    prevDelta += dod; prevT += prevDelta; outT[i] = prevT;
+    prevDelta += dod;
+    prevT += prevDelta;
+    outT[i] = prevT;
 
     if (r.readBit() === 0) {
       outV[i] = outV[i - 1];
@@ -173,16 +236,29 @@ function gorillaDecode(chunk, outT, outV) {
       let xHi, xLo;
       if (r.readBit() === 0) {
         const bits = prevMeaningful;
-        let hi = 0, lo = 0;
-        if (bits <= 32) { lo = r.readBits(bits); } else { hi = r.readBits(bits - 32); lo = r.readBits(32); }
+        let hi = 0,
+          lo = 0;
+        if (bits <= 32) {
+          lo = r.readBits(bits);
+        } else {
+          hi = r.readBits(bits - 32);
+          lo = r.readBits(32);
+        }
         [xHi, xLo] = shl64(hi, lo, 64 - prevLeading - prevMeaningful);
       } else {
         const leading = r.readBits(6);
         const meaningful = r.readBits(6) + 1;
-        let hi = 0, lo = 0;
-        if (meaningful <= 32) { lo = r.readBits(meaningful); } else { hi = r.readBits(meaningful - 32); lo = r.readBits(32); }
+        let hi = 0,
+          lo = 0;
+        if (meaningful <= 32) {
+          lo = r.readBits(meaningful);
+        } else {
+          hi = r.readBits(meaningful - 32);
+          lo = r.readBits(32);
+        }
         [xHi, xLo] = shl64(hi, lo, 64 - leading - meaningful);
-        prevLeading = leading; prevMeaningful = meaningful;
+        prevLeading = leading;
+        prevMeaningful = meaningful;
       }
       prevVHi = (prevVHi ^ xHi) >>> 0;
       prevVLo = (prevVLo ^ xLo) >>> 0;
@@ -194,34 +270,54 @@ function gorillaDecode(chunk, outT, outV) {
 // === Data Generators ===
 
 function genConstant(n, t0, dt) {
-  const t = new Float64Array(n), v = new Float64Array(n);
-  for (let i = 0; i < n; i++) { t[i] = t0 + i * dt; v[i] = 42.0; }
+  const t = new Float64Array(n),
+    v = new Float64Array(n);
+  for (let i = 0; i < n; i++) {
+    t[i] = t0 + i * dt;
+    v[i] = 42.0;
+  }
   return [t, v];
 }
 
 function genSlowGauge(n, t0, dt) {
-  const t = new Float64Array(n), v = new Float64Array(n);
+  const t = new Float64Array(n),
+    v = new Float64Array(n);
   let val = 50.0;
-  for (let i = 0; i < n; i++) { t[i] = t0 + i * dt; val += (Math.random() - 0.5) * 0.1; v[i] = val; }
+  for (let i = 0; i < n; i++) {
+    t[i] = t0 + i * dt;
+    val += (Math.random() - 0.5) * 0.1;
+    v[i] = val;
+  }
   return [t, v];
 }
 
 function genCounter(n, t0, dt) {
-  const t = new Float64Array(n), v = new Float64Array(n);
+  const t = new Float64Array(n),
+    v = new Float64Array(n);
   let val = 0;
-  for (let i = 0; i < n; i++) { t[i] = t0 + i * dt; val += Math.floor(Math.random() * 100) + 1; v[i] = val; }
+  for (let i = 0; i < n; i++) {
+    t[i] = t0 + i * dt;
+    val += Math.floor(Math.random() * 100) + 1;
+    v[i] = val;
+  }
   return [t, v];
 }
 
 function genIntCounter(n, t0, dt) {
-  const t = new Float64Array(n), v = new Float64Array(n);
+  const t = new Float64Array(n),
+    v = new Float64Array(n);
   let val = 0;
-  for (let i = 0; i < n; i++) { t[i] = t0 + i * dt; val += Math.floor(Math.random() * 10) + 1; v[i] = val; }
+  for (let i = 0; i < n; i++) {
+    t[i] = t0 + i * dt;
+    val += Math.floor(Math.random() * 10) + 1;
+    v[i] = val;
+  }
   return [t, v];
 }
 
 function genSpiky(n, t0, dt) {
-  const t = new Float64Array(n), v = new Float64Array(n);
+  const t = new Float64Array(n),
+    v = new Float64Array(n);
   for (let i = 0; i < n; i++) {
     t[i] = t0 + i * dt;
     v[i] = Math.random() < 0.95 ? 5 + Math.random() * 10 : 500 + Math.random() * 1500;
@@ -230,27 +326,37 @@ function genSpiky(n, t0, dt) {
 }
 
 function genHighEntropy(n, t0, dt) {
-  const t = new Float64Array(n), v = new Float64Array(n);
-  for (let i = 0; i < n; i++) { t[i] = t0 + i * dt; v[i] = Math.random() * 1e15; }
+  const t = new Float64Array(n),
+    v = new Float64Array(n);
+  for (let i = 0; i < n; i++) {
+    t[i] = t0 + i * dt;
+    v[i] = Math.random() * 1e15;
+  }
   return [t, v];
 }
 
 // === VictoriaMetrics Float→Int Detection ===
 
 function analyzeIntConversion(values) {
-  let intCount = 0, convertCount = 0;
+  let intCount = 0,
+    convertCount = 0;
   const scaleDist = new Array(7).fill(0);
   for (let i = 0; i < values.length; i++) {
     for (let s = 0; s <= 6; s++) {
-      const scaled = values[i] * Math.pow(10, s);
+      const scaled = values[i] * 10 ** s;
       if (Number.isInteger(scaled) && Math.abs(scaled) < Number.MAX_SAFE_INTEGER) {
-        convertCount++; scaleDist[s]++;
+        convertCount++;
+        scaleDist[s]++;
         if (s === 0) intCount++;
         break;
       }
     }
   }
-  return { pctInt: (intCount / values.length * 100), pctConv: (convertCount / values.length * 100), scaleDist };
+  return {
+    pctInt: (intCount / values.length) * 100,
+    pctConv: (convertCount / values.length) * 100,
+    scaleDist,
+  };
 }
 
 // === String Interning Benchmark ===
@@ -258,9 +364,16 @@ function analyzeIntConversion(values) {
 function benchStringIntern(seriesCount, labelsPerSeries) {
   // Simulate realistic OTLP label sets
   const labelNames = [
-    "service.name", "service.namespace", "host.name", "http.method",
-    "http.route", "http.status_code", "rpc.method", "rpc.service",
-    "db.system", "container.id"
+    "service.name",
+    "service.namespace",
+    "host.name",
+    "http.method",
+    "http.route",
+    "http.status_code",
+    "rpc.method",
+    "rpc.service",
+    "db.system",
+    "container.id",
   ].slice(0, labelsPerSeries);
 
   const labelValues = labelNames.map((_, idx) => {
@@ -293,7 +406,10 @@ function benchStringIntern(seriesCount, labelsPerSeries) {
   let nextId = 0;
   const intern = (s) => {
     let id = interner.get(s);
-    if (id === undefined) { id = nextId++; interner.set(s, id); }
+    if (id === undefined) {
+      id = nextId++;
+      interner.set(s, id);
+    }
     return id;
   };
 
@@ -308,7 +424,16 @@ function benchStringIntern(seriesCount, labelsPerSeries) {
   const internMs = performance.now() - internStart;
   const internedSize = estimateInternedSize(internedStore, interner);
 
-  return { seriesCount, labelsPerSeries, rawMs, internMs, rawSize, internedSize, ratio: rawSize / internedSize, internerEntries: interner.size };
+  return {
+    seriesCount,
+    labelsPerSeries,
+    rawMs,
+    internMs,
+    rawSize,
+    internedSize,
+    ratio: rawSize / internedSize,
+    internerEntries: interner.size,
+  };
 }
 
 function estimateRawSize(store) {
@@ -343,7 +468,10 @@ function benchInvertedIndex(seriesCount, queryLabels) {
     for (let j = 0; j < labels.length; j++) {
       const key = `${labels[j]}=${i % cardinalities[j]}`;
       let list = postings.get(key);
-      if (!list) { list = []; postings.set(key, list); }
+      if (!list) {
+        list = [];
+        postings.set(key, list);
+      }
       list.push(i);
     }
   }
@@ -355,24 +483,33 @@ function benchInvertedIndex(seriesCount, queryLabels) {
 
   // Galloping intersection
   function gallop(arr, target, start) {
-    let lo = start, hi = 1;
+    let lo = start,
+      hi = 1;
     while (lo + hi < arr.length && arr[lo + hi] < target) hi *= 2;
     hi = Math.min(lo + hi, arr.length);
     lo = lo + (hi >>> 1);
     while (lo < hi) {
       const mid = (lo + hi) >>> 1;
-      if (arr[mid] < target) lo = mid + 1; else hi = mid;
+      if (arr[mid] < target) lo = mid + 1;
+      else hi = mid;
     }
     return lo;
   }
 
   function intersect(a, b) {
     const result = [];
-    let i = 0, j = 0;
+    let i = 0,
+      j = 0;
     while (i < a.length && j < b.length) {
-      if (a[i] === b[j]) { result.push(a[i]); i++; j++; }
-      else if (a[i] < b[j]) { i = gallop(a, b[j], i); }
-      else { j = gallop(b, a[i], j); }
+      if (a[i] === b[j]) {
+        result.push(a[i]);
+        i++;
+        j++;
+      } else if (a[i] < b[j]) {
+        i = gallop(a, b[j], i);
+      } else {
+        j = gallop(b, a[i], j);
+      }
     }
     return new Uint32Array(result);
   }
@@ -396,20 +533,23 @@ function benchInvertedIndex(seriesCount, queryLabels) {
   const elapsed = performance.now() - start;
 
   // Also benchmark: Set intersection
-  const sets = queryKeys.map(k => new Set(postings.get(k) || []));
+  const sets = queryKeys.map((k) => new Set(postings.get(k) || []));
   const setStart = performance.now();
   for (let it = 0; it < iters; it++) {
     let result = sets[0];
     for (let q = 1; q < sets.length; q++) {
       const next = new Set();
-      for (const id of result) { if (sets[q].has(id)) next.add(id); }
+      for (const id of result) {
+        if (sets[q].has(id)) next.add(id);
+      }
       result = next;
     }
   }
   const setElapsed = performance.now() - setStart;
 
   return {
-    seriesCount, queryLabels,
+    seriesCount,
+    queryLabels,
     gallopUsPerQuery: (elapsed / iters) * 1000,
     setUsPerQuery: (setElapsed / iters) * 1000,
     speedup: setElapsed / elapsed,
@@ -439,7 +579,8 @@ function benchStreamingQuery(seriesCount, pointsPerSeries) {
 
   // Method 1: Materializing — decompress all, then aggregate
   const matStart = performance.now();
-  let matSum = 0, matCount = 0;
+  let matSum = 0,
+    _matCount = 0;
   const allValues = new Float64Array(seriesCount * pointsPerSeries);
   const allTimes = new Float64Array(seriesCount * pointsPerSeries);
   for (let s = 0; s < seriesCount; s++) {
@@ -447,23 +588,32 @@ function benchStreamingQuery(seriesCount, pointsPerSeries) {
     gorillaDecode(chunks[s], allTimes.subarray(offset), allValues.subarray(offset));
   }
   // Sum across all series
-  for (let i = 0; i < allValues.length; i++) { matSum += allValues[i]; matCount++; }
+  for (let i = 0; i < allValues.length; i++) {
+    matSum += allValues[i];
+    _matCount++;
+  }
   const matMs = performance.now() - matStart;
 
   // Method 2: Streaming — decompress + aggregate chunk by chunk
   const streamStart = performance.now();
-  let streamSum = 0, streamCount = 0;
+  let streamSum = 0,
+    _streamCount = 0;
   const scratchT = new Float64Array(pointsPerSeries);
   const scratchV = new Float64Array(pointsPerSeries);
   for (let s = 0; s < seriesCount; s++) {
     gorillaDecode(chunks[s], scratchT, scratchV);
-    for (let i = 0; i < pointsPerSeries; i++) { streamSum += scratchV[i]; streamCount++; }
+    for (let i = 0; i < pointsPerSeries; i++) {
+      streamSum += scratchV[i];
+      _streamCount++;
+    }
   }
   const streamMs = performance.now() - streamStart;
 
   return {
-    seriesCount, pointsPerSeries,
-    matMs, streamMs,
+    seriesCount,
+    pointsPerSeries,
+    matMs,
+    streamMs,
     matPeakBytes: seriesCount * pointsPerSeries * 16,
     streamPeakBytes: pointsPerSeries * 16,
     memoryRatio: seriesCount, // streaming uses 1/seriesCount the memory
@@ -476,7 +626,7 @@ function benchStreamingQuery(seriesCount, pointsPerSeries) {
 
 console.log("╔══════════════════════════════════════════════════════════════╗");
 console.log("║  OTLP Metrics Engine — Research Benchmarks                  ║");
-console.log("║  Node " + process.version.padEnd(53) + "║");
+console.log(`║  Node ${process.version.padEnd(53)}║`);
 console.log("╚══════════════════════════════════════════════════════════════╝\n");
 
 // R1: Gorilla Compression
@@ -491,8 +641,10 @@ const generators = [
   ["High entropy random", genHighEntropy],
 ];
 
-console.log("  Data Type                           bits/pt  bytes/pt  ratio   enc µs/pt  dec µs/pt  ok?");
-console.log("  " + "─".repeat(95));
+console.log(
+  "  Data Type                           bits/pt  bytes/pt  ratio   enc µs/pt  dec µs/pt  ok?"
+);
+console.log(`  ${"─".repeat(95)}`);
 
 const results = [];
 for (const [name, gen] of generators) {
@@ -510,7 +662,8 @@ for (const [name, gen] of generators) {
   const eMs = (performance.now() - eS) / encIters;
 
   // Decode
-  const outT = new Float64Array(n), outV = new Float64Array(n);
+  const outT = new Float64Array(n),
+    outV = new Float64Array(n);
   const dS = performance.now();
   for (let i = 0; i < encIters; i++) gorillaDecode(chunk, outT, outV);
   const dMs = (performance.now() - dS) / encIters;
@@ -518,26 +671,32 @@ for (const [name, gen] of generators) {
   // Verify
   gorillaDecode(chunk, outT, outV);
   let ok = true;
-  for (let i = 0; i < n; i++) { if (outT[i] !== t[i] || outV[i] !== v[i]) { ok = false; break; } }
+  for (let i = 0; i < n; i++) {
+    if (outT[i] !== t[i] || outV[i] !== v[i]) {
+      ok = false;
+      break;
+    }
+  }
 
   const bpp = chunk.totalBits / n;
   const ia = analyzeIntConversion(v);
-  results.push({ name, bpp, encUs: eMs * 1000 / n, decUs: dMs * 1000 / n, ok, ia });
+  results.push({ name, bpp, encUs: (eMs * 1000) / n, decUs: (dMs * 1000) / n, ok, ia });
 
   console.log(
-    "  " + name.padEnd(36) +
-    bpp.toFixed(1).padStart(7) +
-    (bpp / 8).toFixed(2).padStart(9) +
-    ((128 / bpp).toFixed(1) + "x").padStart(7) +
-    (eMs * 1000 / n).toFixed(2).padStart(11) +
-    (dMs * 1000 / n).toFixed(2).padStart(11) +
-    (ok ? "  ✓" : "  ✗").padStart(5)
+    "  " +
+      name.padEnd(36) +
+      bpp.toFixed(1).padStart(7) +
+      (bpp / 8).toFixed(2).padStart(9) +
+      `${(128 / bpp).toFixed(1)}x`.padStart(7) +
+      ((eMs * 1000) / n).toFixed(2).padStart(11) +
+      ((dMs * 1000) / n).toFixed(2).padStart(11) +
+      (ok ? "  ✓" : "  ✗").padStart(5)
   );
 }
 
 // Chunk size impact
 console.log("\n  Chunk Size Impact (slow gauge):");
-console.log("  " + "─".repeat(70));
+console.log(`  ${"─".repeat(70)}`);
 for (const size of [120, 256, 512, 1024, 2048, 4096]) {
   const [t, v] = genSlowGauge(size, 1700000000000, 15000);
   for (let w = 0; w < 5; w++) gorillaEncode(t, v);
@@ -546,112 +705,145 @@ for (const size of [120, 256, 512, 1024, 2048, 4096]) {
   let chunk;
   for (let i = 0; i < iters; i++) chunk = gorillaEncode(t, v);
   const eMs = (performance.now() - eS) / iters;
-  const outT = new Float64Array(size), outV = new Float64Array(size);
+  const outT = new Float64Array(size),
+    outV = new Float64Array(size);
   const dS = performance.now();
   for (let i = 0; i < iters; i++) gorillaDecode(chunk, outT, outV);
   const dMs = (performance.now() - dS) / iters;
   const bpp = chunk.totalBits / size;
   console.log(
-    "  chunk=" + String(size).padStart(5) +
-    "  bits/pt=" + bpp.toFixed(1).padStart(6) +
-    "  bytes/pt=" + (bpp / 8).toFixed(2).padStart(5) +
-    "  ratio=" + (128 / bpp).toFixed(1).padStart(5) + "x" +
-    "  enc=" + (eMs * 1000 / size).toFixed(2).padStart(6) + " µs/pt" +
-    "  dec=" + (dMs * 1000 / size).toFixed(2).padStart(6) + " µs/pt"
+    "  chunk=" +
+      String(size).padStart(5) +
+      "  bits/pt=" +
+      bpp.toFixed(1).padStart(6) +
+      "  bytes/pt=" +
+      (bpp / 8).toFixed(2).padStart(5) +
+      "  ratio=" +
+      (128 / bpp).toFixed(1).padStart(5) +
+      "x" +
+      "  enc=" +
+      ((eMs * 1000) / size).toFixed(2).padStart(6) +
+      " µs/pt" +
+      "  dec=" +
+      ((dMs * 1000) / size).toFixed(2).padStart(6) +
+      " µs/pt"
   );
 }
 
 // Throughput
 const slowR = results[1];
 console.log("\n  Throughput (slow gauge, 1024-point chunks):");
-console.log("    Encode: " + (1 / (slowR.encUs / 1e6)).toFixed(2) + " M samples/sec");
-console.log("    Decode: " + (1 / (slowR.decUs / 1e6)).toFixed(2) + " M samples/sec");
+console.log(`    Encode: ${(1 / (slowR.encUs / 1e6)).toFixed(2)} M samples/sec`);
+console.log(`    Decode: ${(1 / (slowR.decUs / 1e6)).toFixed(2)} M samples/sec`);
 
 // R2: Float→Int
 console.log("\n\n═══ R2: VictoriaMetrics Float→Int Conversion ═══\n");
-console.log("  Data Type                           % pure int  % convertible  scale distribution (0-6)");
-console.log("  " + "─".repeat(95));
+console.log(
+  "  Data Type                           % pure int  % convertible  scale distribution (0-6)"
+);
+console.log(`  ${"─".repeat(95)}`);
 
 for (const r of results) {
   const ia = r.ia;
   console.log(
-    "  " + r.name.padEnd(36) +
-    (ia.pctInt.toFixed(0) + "%").padStart(10) +
-    (ia.pctConv.toFixed(0) + "%").padStart(14) +
-    "  [" + ia.scaleDist.join(", ") + "]"
+    "  " +
+      r.name.padEnd(36) +
+      `${ia.pctInt.toFixed(0)}%`.padStart(10) +
+      `${ia.pctConv.toFixed(0)}%`.padStart(14) +
+      "  [" +
+      ia.scaleDist.join(", ") +
+      "]"
   );
 }
 
 // R4: Inverted Index
 console.log("\n\n═══ R4: Inverted Index Performance ═══\n");
 console.log("  Series     Labels  Gallop µs/q   Set µs/q   Speedup");
-console.log("  " + "─".repeat(60));
+console.log(`  ${"─".repeat(60)}`);
 
 for (const series of [1000, 10000, 100000]) {
   for (const labels of [1, 2, 3]) {
     const r = benchInvertedIndex(series, labels);
     console.log(
-      "  " + String(series).padStart(7) +
-      String(labels).padStart(8) +
-      r.gallopUsPerQuery.toFixed(1).padStart(13) +
-      r.setUsPerQuery.toFixed(1).padStart(11) +
-      (r.speedup.toFixed(1) + "x").padStart(10)
+      "  " +
+        String(series).padStart(7) +
+        String(labels).padStart(8) +
+        r.gallopUsPerQuery.toFixed(1).padStart(13) +
+        r.setUsPerQuery.toFixed(1).padStart(11) +
+        `${r.speedup.toFixed(1)}x`.padStart(10)
     );
   }
 }
 
 // R5: Streaming vs Materializing
 console.log("\n\n═══ R5: Streaming vs Materializing Query ═══\n");
-console.log("  Series × Points     Mat ms    Stream ms  Speedup  Mat peak     Stream peak   Mem ratio");
-console.log("  " + "─".repeat(90));
+console.log(
+  "  Series × Points     Mat ms    Stream ms  Speedup  Mat peak     Stream peak   Mem ratio"
+);
+console.log(`  ${"─".repeat(90)}`);
 
-for (const [sc, pp] of [[100, 1024], [1000, 1024], [1000, 120], [5000, 1024]]) {
+for (const [sc, pp] of [
+  [100, 1024],
+  [1000, 1024],
+  [1000, 120],
+  [5000, 1024],
+]) {
   const r = benchStreamingQuery(sc, pp);
-  const fmt = (b) => b < 1024 * 1024 ? (b / 1024).toFixed(0) + " KB" : (b / 1024 / 1024).toFixed(1) + " MB";
+  const fmt = (b) =>
+    b < 1024 * 1024 ? `${(b / 1024).toFixed(0)} KB` : `${(b / 1024 / 1024).toFixed(1)} MB`;
   console.log(
-    "  " + (sc + "×" + pp).padStart(12) +
-    r.matMs.toFixed(1).padStart(11) +
-    r.streamMs.toFixed(1).padStart(11) +
-    (r.speedup.toFixed(2) + "x").padStart(9) +
-    fmt(r.matPeakBytes).padStart(12) +
-    fmt(r.streamPeakBytes).padStart(14) +
-    (r.memoryRatio + "x").padStart(11) +
-    (r.verify ? "" : " ✗ MISMATCH")
+    "  " +
+      `${sc}×${pp}`.padStart(12) +
+      r.matMs.toFixed(1).padStart(11) +
+      r.streamMs.toFixed(1).padStart(11) +
+      `${r.speedup.toFixed(2)}x`.padStart(9) +
+      fmt(r.matPeakBytes).padStart(12) +
+      fmt(r.streamPeakBytes).padStart(14) +
+      `${r.memoryRatio}x`.padStart(11) +
+      (r.verify ? "" : " ✗ MISMATCH")
   );
 }
 
 // String Interning
 console.log("\n\n═══ String Interning ═══\n");
 console.log("  Series   Labels  Raw KB  Interned KB  Ratio   Raw ms  Intern ms  Entries");
-console.log("  " + "─".repeat(80));
+console.log(`  ${"─".repeat(80)}`);
 
-for (const [sc, lps] of [[1000, 5], [10000, 5], [10000, 10], [100000, 5]]) {
+for (const [sc, lps] of [
+  [1000, 5],
+  [10000, 5],
+  [10000, 10],
+  [100000, 5],
+]) {
   const r = benchStringIntern(sc, lps);
   console.log(
-    "  " + String(sc).padStart(7) +
-    String(lps).padStart(8) +
-    (r.rawSize / 1024).toFixed(0).padStart(8) +
-    (r.internedSize / 1024).toFixed(0).padStart(12) +
-    (r.ratio.toFixed(1) + "x").padStart(7) +
-    r.rawMs.toFixed(1).padStart(8) +
-    r.internMs.toFixed(1).padStart(10) +
-    String(r.internerEntries).padStart(9)
+    "  " +
+      String(sc).padStart(7) +
+      String(lps).padStart(8) +
+      (r.rawSize / 1024).toFixed(0).padStart(8) +
+      (r.internedSize / 1024).toFixed(0).padStart(12) +
+      `${r.ratio.toFixed(1)}x`.padStart(7) +
+      r.rawMs.toFixed(1).padStart(8) +
+      r.internMs.toFixed(1).padStart(10) +
+      String(r.internerEntries).padStart(9)
   );
 }
 
 // Memory Projections
 console.log("\n\n═══ Memory Projections ═══\n");
 const avgBpp = results.reduce((s, r) => s + r.bpp, 0) / results.length;
-console.log("  Average bits/point across types: " + avgBpp.toFixed(1) + " (" + (avgBpp / 8).toFixed(2) + " bytes)");
+console.log(
+  `  Average bits/point across types: ${avgBpp.toFixed(1)} (${(avgBpp / 8).toFixed(2)} bytes)`
+);
 console.log("");
 console.log("  Scenario                         Raw         Compressed    Ratio");
-console.log("  " + "─".repeat(65));
+console.log(`  ${"─".repeat(65)}`);
 
 const fmt = (b) => {
-  if (b < 1024) return b + " B";
-  if (b < 1024 * 1024) return (b / 1024).toFixed(1) + " KB";
-  if (b < 1024 * 1024 * 1024) return (b / 1024 / 1024).toFixed(1) + " MB";
-  return (b / 1024 / 1024 / 1024).toFixed(2) + " GB";
+  if (b < 1024) return `${b} B`;
+  if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} KB`;
+  if (b < 1024 * 1024 * 1024) return `${(b / 1024 / 1024).toFixed(1)} MB`;
+  return `${(b / 1024 / 1024 / 1024).toFixed(2)} GB`;
 };
 
 for (const [sc, pp, label] of [
@@ -664,10 +856,11 @@ for (const [sc, pp, label] of [
   const raw = sc * pp * 16;
   const comp = sc * pp * (avgBpp / 8) + sc * 200;
   console.log(
-    "  " + label.padEnd(35) +
-    fmt(raw).padStart(10) +
-    fmt(comp).padStart(14) +
-    ((raw / comp).toFixed(1) + "x").padStart(9)
+    "  " +
+      label.padEnd(35) +
+      fmt(raw).padStart(10) +
+      fmt(comp).padStart(14) +
+      `${(raw / comp).toFixed(1)}x`.padStart(9)
   );
 }
 

--- a/site/tsdb-engine/css/architecture.css
+++ b/site/tsdb-engine/css/architecture.css
@@ -28,7 +28,9 @@
   padding: 16px;
   text-align: center;
   box-shadow: var(--shadow-sm);
-  transition: transform 200ms ease, box-shadow 200ms ease;
+  transition:
+    transform 200ms ease,
+    box-shadow 200ms ease;
 }
 
 .arch-box:hover {
@@ -62,12 +64,24 @@
   flex-shrink: 0;
 }
 
-.arch-ingest { border-top: 3px solid var(--otlp); }
-.arch-storage { border-top: 3px solid var(--octo); }
-.arch-query { border-top: 3px solid var(--bench); }
-.arch-codec { border-top: 3px solid var(--region-header); }
-.arch-labels { border-top: 3px solid #ec4899; }
-.arch-worker { border-top: 3px solid var(--region-exceptions); }
+.arch-ingest {
+  border-top: 3px solid var(--otlp);
+}
+.arch-storage {
+  border-top: 3px solid var(--octo);
+}
+.arch-query {
+  border-top: 3px solid var(--bench);
+}
+.arch-codec {
+  border-top: 3px solid var(--region-header);
+}
+.arch-labels {
+  border-top: 3px solid #ec4899;
+}
+.arch-worker {
+  border-top: 3px solid var(--region-exceptions);
+}
 
 /* ─── Backend Cards ───────────────────────────────────────────────── */
 
@@ -87,9 +101,18 @@
   margin-bottom: 8px;
 }
 
-.backend-badge.flat { background: var(--badge-flat-bg); color: var(--badge-flat-text); }
-.backend-badge.chunked { background: var(--badge-chunked-bg); color: var(--badge-chunked-text); }
-.backend-badge.column { background: var(--badge-column-bg); color: var(--badge-column-text); }
+.backend-badge.flat {
+  background: var(--badge-flat-bg);
+  color: var(--badge-flat-text);
+}
+.backend-badge.chunked {
+  background: var(--badge-chunked-bg);
+  color: var(--badge-chunked-text);
+}
+.backend-badge.column {
+  background: var(--badge-column-bg);
+  color: var(--badge-column-text);
+}
 
 .backend-stat {
   display: grid;

--- a/site/tsdb-engine/css/byte-explorer.css
+++ b/site/tsdb-engine/css/byte-explorer.css
@@ -90,8 +90,8 @@
   flex: 1;
   display: flex;
   gap: 8px;
-  background: rgba(255,255,255,0.03);
-  border: 1px solid rgba(255,255,255,0.06);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 6px;
   padding: 8px 10px;
 }
@@ -124,7 +124,7 @@
 .ci-detail {
   color: var(--dark-text-muted);
   font-size: 10px;
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: "IBM Plex Mono", monospace;
 }
 
 .ci-example {
@@ -137,7 +137,7 @@
 .ci-exceptions {
   margin-top: 8px;
   padding: 6px 10px;
-  background: rgba(255,255,255,0.03);
+  background: rgba(255, 255, 255, 0.03);
   border-radius: 4px;
   font-size: 11px;
   color: var(--dark-text-muted);
@@ -168,7 +168,9 @@
   border: 2px solid rgba(15, 58, 94, 0.4);
   border-radius: 2px;
   pointer-events: none;
-  transition: left 150ms ease, width 150ms ease;
+  transition:
+    left 150ms ease,
+    width 150ms ease;
   background: rgba(15, 58, 94, 0.06);
 }
 
@@ -257,8 +259,12 @@
 
 /* ── Hex-level sample mapping ── */
 /* Use opacity instead of filter:brightness — avoids per-cell compositing */
-.hex-cell.hex-mapped.hex-sample-even { opacity: 1; }
-.hex-cell.hex-mapped.hex-sample-odd  { opacity: 0.65; }
+.hex-cell.hex-mapped.hex-sample-even {
+  opacity: 1;
+}
+.hex-cell.hex-mapped.hex-sample-odd {
+  opacity: 0.65;
+}
 
 .hex-cell.hex-boundary {
   border-left: 2px solid var(--region-exceptions);
@@ -290,13 +296,38 @@
   animation: rise-in 200ms ease both;
 }
 
-.hex-decode-panel .bdp-header { display: flex; gap: 12px; align-items: baseline; flex-wrap: wrap; }
-.hex-decode-panel .bdp-type { font-weight: 700; font-size: 13px; }
-.hex-decode-panel .bdp-type.timestamp { color: var(--region-timestamps); }
-.hex-decode-panel .bdp-type.value { color: var(--region-values); }
-.hex-decode-panel .bdp-value { font-size: 16px; font-weight: 700; color: #f1f5f9; margin: 6px 0 4px; }
-.hex-decode-panel .bdp-encoding { font-size: 11px; color: #a5b4c8; line-height: 1.6; }
-.hex-decode-panel .bdp-detail { font-size: 10px; color: var(--dark-text-dim); margin-top: 2px; }
+.hex-decode-panel .bdp-header {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+.hex-decode-panel .bdp-type {
+  font-weight: 700;
+  font-size: 13px;
+}
+.hex-decode-panel .bdp-type.timestamp {
+  color: var(--region-timestamps);
+}
+.hex-decode-panel .bdp-type.value {
+  color: var(--region-values);
+}
+.hex-decode-panel .bdp-value {
+  font-size: 16px;
+  font-weight: 700;
+  color: #f1f5f9;
+  margin: 6px 0 4px;
+}
+.hex-decode-panel .bdp-encoding {
+  font-size: 11px;
+  color: #a5b4c8;
+  line-height: 1.6;
+}
+.hex-decode-panel .bdp-detail {
+  font-size: 10px;
+  color: var(--dark-text-dim);
+  margin-top: 2px;
+}
 
 /* Byte detail tooltip */
 .byte-tooltip {
@@ -341,9 +372,15 @@
   margin-left: 4px;
 }
 
-.byte-tooltip .bt-region.header { background: var(--region-header); }
-.byte-tooltip .bt-region.timestamps { background: var(--region-timestamps); }
-.byte-tooltip .bt-region.values { background: var(--region-values); }
+.byte-tooltip .bt-region.header {
+  background: var(--region-header);
+}
+.byte-tooltip .bt-region.timestamps {
+  background: var(--region-timestamps);
+}
+.byte-tooltip .bt-region.values {
+  background: var(--region-values);
+}
 
 .byte-tooltip .bt-sample {
   display: inline-block;
@@ -353,8 +390,12 @@
   border-radius: 3px;
   margin-left: 4px;
 }
-.byte-tooltip .bt-sample.timestamp { background: var(--region-timestamps); }
-.byte-tooltip .bt-sample.value { background: var(--region-values); }
+.byte-tooltip .bt-sample.timestamp {
+  background: var(--region-timestamps);
+}
+.byte-tooltip .bt-sample.value {
+  background: var(--region-values);
+}
 
 .byte-tooltip .bt-decoded {
   margin-top: 4px;
@@ -394,10 +435,18 @@
   color: white;
 }
 
-.region-badge.header { background: var(--region-header); }
-.region-badge.timestamps { background: var(--region-timestamps); }
-.region-badge.values { background: var(--region-values); }
-.region-badge.exceptions { background: var(--region-exceptions); }
+.region-badge.header {
+  background: var(--region-header);
+}
+.region-badge.timestamps {
+  background: var(--region-timestamps);
+}
+.region-badge.values {
+  background: var(--region-values);
+}
+.region-badge.exceptions {
+  background: var(--region-exceptions);
+}
 
 .region-detail-grid {
   display: grid;
@@ -477,7 +526,9 @@
   font-size: 8px;
   font-weight: 600;
   cursor: default;
-  transition: background 100ms ease, transform 100ms ease;
+  transition:
+    background 100ms ease,
+    transform 100ms ease;
 }
 
 .bit-row .bit.b1 {
@@ -543,12 +594,16 @@
 }
 
 .bit-row .bit.bit-highlight-ts {
+  /* biome-ignore lint/complexity/noImportantStyles: override requires !important for specificity */
   background: rgba(6, 182, 212, 0.5) !important;
+  /* biome-ignore lint/complexity/noImportantStyles: override requires !important for specificity */
   color: #e0f2fe !important;
 }
 
 .bit-row .bit.bit-highlight-val {
+  /* biome-ignore lint/complexity/noImportantStyles: override requires !important for specificity */
   background: rgba(16, 185, 129, 0.5) !important;
+  /* biome-ignore lint/complexity/noImportantStyles: override requires !important for specificity */
   color: #d1fae5 !important;
 }
 
@@ -566,6 +621,7 @@
   animation: rise-in 200ms ease both;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional modifier class */
 .bdp-header {
   display: flex;
   align-items: center;
@@ -574,6 +630,7 @@
   flex-wrap: wrap;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional modifier class */
 .bdp-type {
   font-weight: 700;
   font-size: 12px;
@@ -581,11 +638,13 @@
   border-radius: 4px;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional modifier class */
 .bdp-type.timestamp {
   background: rgba(6, 182, 212, 0.2);
   color: #67e8f9;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional modifier class */
 .bdp-type.value {
   background: rgba(16, 185, 129, 0.2);
   color: #6ee7b7;
@@ -602,6 +661,7 @@
   margin-left: auto;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional modifier class */
 .bdp-value {
   font-size: 16px;
   font-weight: 700;
@@ -610,6 +670,7 @@
   word-break: break-all;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional modifier class */
 .bdp-encoding {
   color: var(--dark-text-muted);
   font-size: 11px;
@@ -624,6 +685,7 @@
   font-weight: 600;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional modifier class */
 .bdp-detail {
   margin-top: 4px;
   color: var(--dark-text-dim);

--- a/site/tsdb-engine/css/chart.css
+++ b/site/tsdb-engine/css/chart.css
@@ -124,6 +124,7 @@
   font-size: 11px;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional modifier class */
 .tooltip-row strong {
   font-family: "IBM Plex Mono", monospace;
   font-size: 12px;

--- a/site/tsdb-engine/css/demo.css
+++ b/site/tsdb-engine/css/demo.css
@@ -145,9 +145,15 @@
   color: white;
 }
 
-.comp-bar-fill.raw { background: linear-gradient(90deg, #e74c3c, #c0392b); }
-.comp-bar-fill.compressed { background: linear-gradient(90deg, #10b981, #059669); }
-.comp-bar-fill.gzip { background: linear-gradient(90deg, #3b82f6, #1d4ed8); }
+.comp-bar-fill.raw {
+  background: linear-gradient(90deg, #e74c3c, #c0392b);
+}
+.comp-bar-fill.compressed {
+  background: linear-gradient(90deg, #10b981, #059669);
+}
+.comp-bar-fill.gzip {
+  background: linear-gradient(90deg, #3b82f6, #1d4ed8);
+}
 
 .comp-bar-value {
   font-size: 13px;

--- a/site/tsdb-engine/css/storage-explorer.css
+++ b/site/tsdb-engine/css/storage-explorer.css
@@ -127,8 +127,13 @@
   font-family: "IBM Plex Mono", monospace;
 }
 
-.label-key { color: #6b8a9e; }
-.label-val { color: #0f3a5e; font-weight: 500; }
+.label-key {
+  color: #6b8a9e;
+}
+.label-val {
+  color: #0f3a5e;
+  font-weight: 500;
+}
 
 .series-summary {
   margin-left: auto;
@@ -166,6 +171,7 @@
   display: none;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional modifier class */
 .chunk-block {
   border-radius: 6px;
   display: flex;
@@ -190,6 +196,7 @@
   background: linear-gradient(135deg, var(--region-exceptions), #d97706);
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: intentional modifier class */
 .chunk-label {
   font-size: 10px;
   font-weight: 600;
@@ -475,10 +482,18 @@
   border-radius: 3px;
 }
 
-.byte-swatch.header { background: var(--region-header); }
-.byte-swatch.timestamps { background: var(--region-timestamps); }
-.byte-swatch.values { background: var(--region-values); }
-.byte-swatch.exceptions { background: var(--region-exceptions); }
+.byte-swatch.header {
+  background: var(--region-header);
+}
+.byte-swatch.timestamps {
+  background: var(--region-timestamps);
+}
+.byte-swatch.values {
+  background: var(--region-values);
+}
+.byte-swatch.exceptions {
+  background: var(--region-exceptions);
+}
 
 .chunk-sparkline-container {
   margin-bottom: 16px;

--- a/site/tsdb-engine/index.html
+++ b/site/tsdb-engine/index.html
@@ -124,7 +124,7 @@
             </select>
             <div id="wasmStatus" class="wasm-status" style="display:none"></div>
           </div>
-          <button id="btnGenerate" class="cta cta-primary demo-btn">Generate Data</button>
+          <button type="button" id="btnGenerate" class="cta cta-primary demo-btn">Generate Data</button>
         </div>
 
         <!-- Stats dashboard -->
@@ -200,7 +200,7 @@
                 <option value="86400000">1 day</option>
               </select>
             </div>
-            <button id="btnQuery" class="cta cta-primary demo-btn">Run Query</button>
+            <button type="button" id="btnQuery" class="cta cta-primary demo-btn">Run Query</button>
           </div>
 
           <!-- Query results -->

--- a/site/tsdb-engine/js/app.js
+++ b/site/tsdb-engine/js/app.js
@@ -1,12 +1,12 @@
 // ── App Entry Point ──────────────────────────────────────────────────
 
-import { $, formatBytes, formatNum, formatDuration, autoSelectQueryStep } from './utils.js';
-import { FlatStore, ChunkedStore, ColumnStore } from './stores.js';
-import { loadWasm, wasmReady } from './wasm.js';
-import { ScanEngine } from './query.js';
-import { renderChart, setupChartTooltip, CHART_COLORS } from './chart.js';
-import { buildStorageExplorer } from './storage-explorer.js';
-import { generateValue, REGIONS, INSTANCES, METRICS } from './data-gen.js';
+import { CHART_COLORS, renderChart, setupChartTooltip } from "./chart.js";
+import { generateValue, INSTANCES, METRICS, REGIONS } from "./data-gen.js";
+import { ScanEngine } from "./query.js";
+import { buildStorageExplorer } from "./storage-explorer.js";
+import { ChunkedStore, ColumnStore, FlatStore } from "./stores.js";
+import { $, autoSelectQueryStep, formatBytes, formatDuration, formatNum } from "./utils.js";
+import { loadWasm, wasmReady } from "./wasm.js";
 
 const CHUNK_SIZE = 640;
 const NS_PER_MS = 1_000_000n;
@@ -14,21 +14,21 @@ const NS_PER_MS = 1_000_000n;
 // ── UI State ─────────────────────────────────────────────────────────
 
 let currentStore = null;
-let currentEngine = new ScanEngine();
+const currentEngine = new ScanEngine();
 let generatedMetrics = [];
 
 // ── Generate Data ────────────────────────────────────────────────────
 
-$('#btnGenerate').addEventListener('click', () => {
-  const numSeries = parseInt($('#numSeries').value);
-  const numPoints = parseInt($('#numPoints').value);
-  const pattern = $('#dataPattern').value;
-  const backendType = $('#backend').value;
-  const intervalMs = parseInt($('#sampleInterval').value);
+$("#btnGenerate").addEventListener("click", () => {
+  const numSeries = parseInt($("#numSeries").value, 10);
+  const numPoints = parseInt($("#numPoints").value, 10);
+  const pattern = $("#dataPattern").value;
+  const backendType = $("#backend").value;
+  const intervalMs = parseInt($("#sampleInterval").value, 10);
 
-  const btn = $('#btnGenerate');
+  const btn = $("#btnGenerate");
   btn.disabled = true;
-  btn.textContent = 'Generating…';
+  btn.textContent = "Generating…";
 
   requestAnimationFrame(() => {
     setTimeout(() => {
@@ -36,20 +36,20 @@ $('#btnGenerate').addEventListener('click', () => {
         generateData(numSeries, numPoints, pattern, backendType, intervalMs);
       } finally {
         btn.disabled = false;
-        btn.textContent = 'Generate Data';
+        btn.textContent = "Generate Data";
       }
     }, 50);
   });
 });
 
 function _createStore(backendType, chunkSize) {
-  if (backendType === 'column') {
+  if (backendType === "column") {
     if (!wasmReady) {
-      alert('WASM codec not loaded — ColumnStore requires WebAssembly. Try ChunkedStore instead.');
+      alert("WASM codec not loaded — ColumnStore requires WebAssembly. Try ChunkedStore instead.");
       return null;
     }
     return new ColumnStore(chunkSize);
-  } else if (backendType === 'chunked') {
+  } else if (backendType === "chunked") {
     return new ChunkedStore(chunkSize);
   }
   return new FlatStore();
@@ -68,10 +68,10 @@ function _ingestMetrics(store, numSeries, numPoints, pattern, stepMs, backendTyp
     metricsUsed.add(metricName);
 
     const labels = new Map([
-      ['__name__', metricName],
-      ['region', region],
-      ['instance', instance],
-      ['job', 'demo'],
+      ["__name__", metricName],
+      ["region", region],
+      ["instance", instance],
+      ["job", "demo"],
     ]);
 
     const id = store.getOrCreateSeries(labels);
@@ -85,12 +85,16 @@ function _ingestMetrics(store, numSeries, numPoints, pattern, stepMs, backendTyp
     allSeriesData.push({ id, timestamps, values });
   }
 
-  if (backendType === 'column') {
+  if (backendType === "column") {
     const chunkSize = CHUNK_SIZE;
     for (let offset = 0; offset < numPoints; offset += chunkSize) {
       const end = Math.min(offset + chunkSize, numPoints);
       for (const sd of allSeriesData) {
-        store.appendBatch(sd.id, sd.timestamps.subarray(offset, end), sd.values.subarray(offset, end));
+        store.appendBatch(
+          sd.id,
+          sd.timestamps.subarray(offset, end),
+          sd.values.subarray(offset, end)
+        );
       }
     }
   } else {
@@ -102,29 +106,29 @@ function _ingestMetrics(store, numSeries, numPoints, pattern, stepMs, backendTyp
   return { metricsUsed, totalIngested: store.sampleCount };
 }
 
-function _displayStats(store, metricsUsed, totalIngested, ingestTime, intervalMs, numPoints) {
+function _displayStats(store, _metricsUsed, totalIngested, ingestTime, intervalMs, numPoints) {
   const memBytes = store.memoryBytes();
   const rawBytes = totalIngested * 16;
   const compressionRatio = rawBytes / memBytes;
 
-  $('#statsGrid').style.display = '';
-  $('#statTotalPoints').textContent = totalIngested.toLocaleString();
-  $('#statSeries').textContent = store.seriesCount.toLocaleString();
-  $('#statMemory').textContent = formatBytes(memBytes);
-  $('#statCompression').textContent = compressionRatio.toFixed(1) + '×';
-  $('#statIngestTime').textContent = ingestTime.toFixed(0) + ' ms';
-  $('#statIngestRate').textContent = formatNum(totalIngested / (ingestTime / 1000)) + ' pts/s';
+  $("#statsGrid").style.display = "";
+  $("#statTotalPoints").textContent = totalIngested.toLocaleString();
+  $("#statSeries").textContent = store.seriesCount.toLocaleString();
+  $("#statMemory").textContent = formatBytes(memBytes);
+  $("#statCompression").textContent = `${compressionRatio.toFixed(1)}×`;
+  $("#statIngestTime").textContent = `${ingestTime.toFixed(0)} ms`;
+  $("#statIngestRate").textContent = `${formatNum(totalIngested / (ingestTime / 1000))} pts/s`;
 
-  const metricSelect = $('#queryMetric');
-  metricSelect.innerHTML = '';
+  const metricSelect = $("#queryMetric");
+  metricSelect.innerHTML = "";
   for (const m of generatedMetrics) {
-    const opt = document.createElement('option');
+    const opt = document.createElement("option");
     opt.value = m;
     opt.textContent = m;
     metricSelect.appendChild(opt);
   }
 
-  $('#queryControls').style.display = '';
+  $("#queryControls").style.display = "";
 
   showCompressionBreakdown(rawBytes, memBytes);
   autoSelectQueryStep(intervalMs, numPoints);
@@ -137,7 +141,14 @@ function generateData(numSeries, numPoints, pattern, backendType, intervalMs = 1
   if (!store) return;
 
   const t0 = performance.now();
-  const { metricsUsed, totalIngested } = _ingestMetrics(store, numSeries, numPoints, pattern, intervalMs, backendType);
+  const { metricsUsed, totalIngested } = _ingestMetrics(
+    store,
+    numSeries,
+    numPoints,
+    pattern,
+    intervalMs,
+    backendType
+  );
   const ingestTime = performance.now() - t0;
 
   currentStore = store;
@@ -148,58 +159,69 @@ function generateData(numSeries, numPoints, pattern, backendType, intervalMs = 1
 
 // ── Query ────────────────────────────────────────────────────────────
 
-$('#btnQuery').addEventListener('click', runQuery);
+$("#btnQuery").addEventListener("click", runQuery);
 
 function runQuery() {
   if (!currentStore) return;
 
-  const metric = $('#queryMetric').value;
-  const agg = $('#queryAgg').value || undefined;
-  const groupBy = $('#queryGroupBy').value ? [$('#queryGroupBy').value] : undefined;
-  const stepMs = parseInt($('#queryStep').value);
+  const metric = $("#queryMetric").value;
+  const agg = $("#queryAgg").value || undefined;
+  const groupBy = $("#queryGroupBy").value ? [$("#queryGroupBy").value] : undefined;
+  const stepMs = parseInt($("#queryStep").value, 10);
   const step = stepMs > 0 ? BigInt(stepMs) * NS_PER_MS : undefined;
 
-  const ids = currentStore.matchLabel('__name__', metric);
+  const ids = currentStore.matchLabel("__name__", metric);
   if (ids.length === 0) return;
 
-  let minT = BigInt('9223372036854775807');
+  let minT = BigInt("9223372036854775807");
   let maxT = -minT;
   for (const id of ids) {
     const data = currentStore.read(id, -minT, minT);
     if (data.timestamps.length > 0) {
       if (data.timestamps[0] < minT) minT = data.timestamps[0];
-      if (data.timestamps[data.timestamps.length - 1] > maxT) maxT = data.timestamps[data.timestamps.length - 1];
+      if (data.timestamps[data.timestamps.length - 1] > maxT)
+        maxT = data.timestamps[data.timestamps.length - 1];
     }
   }
 
   const t0 = performance.now();
   const result = currentEngine.query(currentStore, {
-    metric, start: minT, end: maxT, agg, groupBy, step,
+    metric,
+    start: minT,
+    end: maxT,
+    agg,
+    groupBy,
+    step,
   });
   const queryTime = performance.now() - t0;
 
-  $('#queryResults').style.display = '';
-  $('#qStatScannedSeries').innerHTML = `Scanned: <strong>${result.scannedSeries}</strong> series`;
-  $('#qStatScannedSamples').innerHTML = `Samples: <strong>${result.scannedSamples.toLocaleString()}</strong>`;
-  $('#qStatResultSeries').innerHTML = `Result: <strong>${result.series.length}</strong> series`;
-  $('#qStatQueryTime').innerHTML = `Time: <strong>${queryTime.toFixed(1)} ms</strong>`;
+  $("#queryResults").style.display = "";
+  $("#qStatScannedSeries").innerHTML = `Scanned: <strong>${result.scannedSeries}</strong> series`;
+  $("#qStatScannedSamples").innerHTML =
+    `Samples: <strong>${result.scannedSamples.toLocaleString()}</strong>`;
+  $("#qStatResultSeries").innerHTML = `Result: <strong>${result.series.length}</strong> series`;
+  $("#qStatQueryTime").innerHTML = `Time: <strong>${queryTime.toFixed(1)} ms</strong>`;
 
   const aggLabel = agg ? `${agg}(${metric})` : metric;
-  const groupLabel = groupBy ? ` by ${groupBy.join(', ')}` : '';
-  const stepLabel = step ? ` [${formatDuration(stepMs)} step]` : '';
+  const groupLabel = groupBy ? ` by ${groupBy.join(", ")}` : "";
+  const stepLabel = step ? ` [${formatDuration(stepMs)} step]` : "";
   const chartTitle = `${aggLabel}${groupLabel}${stepLabel}`;
 
-  renderChart($('#chartCanvas'), result.series, chartTitle);
+  renderChart($("#chartCanvas"), result.series, chartTitle);
   setupChartTooltip();
 
-  const legendEl = $('#chartLegend');
-  legendEl.innerHTML = '';
+  const legendEl = $("#chartLegend");
+  legendEl.innerHTML = "";
   for (let i = 0; i < result.series.length; i++) {
     const s = result.series[i];
     const color = CHART_COLORS[i % CHART_COLORS.length];
-    const labelStr = [...s.labels].filter(([k]) => k !== '__name__').map(([k, v]) => `${k}="${v}"`).join(', ') || 'all';
-    const item = document.createElement('div');
-    item.className = 'legend-item';
+    const labelStr =
+      [...s.labels]
+        .filter(([k]) => k !== "__name__")
+        .map(([k, v]) => `${k}="${v}"`)
+        .join(", ") || "all";
+    const item = document.createElement("div");
+    item.className = "legend-item";
     item.innerHTML = `<span class="legend-swatch" style="background:${color}"></span>${labelStr} (${s.timestamps.length.toLocaleString()} pts)`;
     legendEl.appendChild(item);
   }
@@ -208,19 +230,24 @@ function runQuery() {
 // ── Compression Breakdown ────────────────────────────────────────────
 
 function showCompressionBreakdown(rawBytes, compressedBytes) {
-  const el = $('#compressionBench');
-  el.style.display = '';
-  const bars = $('#compressionBars');
+  const el = $("#compressionBench");
+  el.style.display = "";
+  const bars = $("#compressionBars");
   const maxVal = rawBytes;
 
   const rows = [
-    { label: 'Raw (16 B/pt)', bytes: rawBytes, cls: 'raw' },
-    { label: currentStore instanceof ColumnStore ? 'ALP + shared ts' : 'XOR-Delta', bytes: compressedBytes, cls: 'compressed' },
+    { label: "Raw (16 B/pt)", bytes: rawBytes, cls: "raw" },
+    {
+      label: currentStore instanceof ColumnStore ? "ALP + shared ts" : "XOR-Delta",
+      bytes: compressedBytes,
+      cls: "compressed",
+    },
   ];
 
-  bars.innerHTML = rows.map(r => {
-    const pct = Math.max(2, (r.bytes / maxVal) * 100);
-    return `
+  bars.innerHTML = rows
+    .map((r) => {
+      const pct = Math.max(2, (r.bytes / maxVal) * 100);
+      return `
       <div class="comp-bar-row">
         <span class="comp-bar-label">${r.label}</span>
         <div class="comp-bar-track">
@@ -228,13 +255,16 @@ function showCompressionBreakdown(rawBytes, compressedBytes) {
         </div>
         <span class="comp-bar-value">${(rawBytes / r.bytes).toFixed(1)}×</span>
       </div>`;
-  }).join('');
+    })
+    .join("");
 }
 
 // ── Event Listeners ──────────────────────────────────────────────────
 
-for (const id of ['queryMetric', 'queryAgg', 'queryGroupBy', 'queryStep']) {
-  $(`#${id}`).addEventListener('change', () => { if (currentStore) runQuery(); });
+for (const id of ["queryMetric", "queryAgg", "queryGroupBy", "queryStep"]) {
+  $(`#${id}`).addEventListener("change", () => {
+    if (currentStore) runQuery();
+  });
 }
 
 let resizeController = null;
@@ -242,37 +272,44 @@ let resizeController = null;
 function installResizeListener() {
   if (resizeController) resizeController.abort();
   resizeController = new AbortController();
-  window.addEventListener('resize', () => {
-    if (currentStore && $('#queryResults').style.display !== 'none') runQuery();
-  }, { signal: resizeController.signal });
+  window.addEventListener(
+    "resize",
+    () => {
+      if (currentStore && $("#queryResults").style.display !== "none") runQuery();
+    },
+    { signal: resizeController.signal }
+  );
 }
 
 installResizeListener();
 
 // ── Initialization ───────────────────────────────────────────────────
 
-loadWasm().then(ok => {
-  const statusEl = $('#wasmStatus');
+loadWasm().then((ok) => {
+  const statusEl = $("#wasmStatus");
   if (ok) {
-    statusEl.style.display = 'inline-block';
-    statusEl.className = 'wasm-status wasm-ok';
-    statusEl.textContent = '✓ WASM loaded (26 KB)';
+    statusEl.style.display = "inline-block";
+    statusEl.className = "wasm-status wasm-ok";
+    statusEl.textContent = "✓ WASM loaded (26 KB)";
   } else {
-    statusEl.style.display = 'inline-block';
-    statusEl.className = 'wasm-status wasm-err';
-    statusEl.textContent = '✗ WASM unavailable';
+    statusEl.style.display = "inline-block";
+    statusEl.className = "wasm-status wasm-err";
+    statusEl.textContent = "✗ WASM unavailable";
     const colOpt = document.querySelector('#backend option[value="column"]');
-    if (colOpt) { colOpt.disabled = true; colOpt.textContent += ' (WASM required)'; }
+    if (colOpt) {
+      colOpt.disabled = true;
+      colOpt.textContent += " (WASM required)";
+    }
   }
 
   requestAnimationFrame(() => {
     setTimeout(() => {
       generateData(
-        parseInt($('#numSeries').value),
-        parseInt($('#numPoints').value),
-        $('#dataPattern').value,
-        $('#backend').value,
-        parseInt($('#sampleInterval').value),
+        parseInt($("#numSeries").value, 10),
+        parseInt($("#numPoints").value, 10),
+        $("#dataPattern").value,
+        $("#backend").value,
+        parseInt($("#sampleInterval").value, 10)
       );
     }, 100);
   });

--- a/site/tsdb-engine/js/byte-explorer-logic.js
+++ b/site/tsdb-engine/js/byte-explorer-logic.js
@@ -1,8 +1,15 @@
 // ── Pure logic for byte-level chunk exploration ──────────────────────
 // No DOM dependencies. Testable in isolation via vitest.
 
-import { readI64BE, readF64BE, formatEpochNs, formatBytes, superNum, formatHexByte } from './utils.js';
-import { BitReader } from './codec.js';
+import { BitReader } from "./codec.js";
+import {
+  formatBytes,
+  formatEpochNs,
+  formatHexByte,
+  readF64BE,
+  readI64BE,
+  superNum,
+} from "./utils.js";
 
 export const ALP_HEADER_SIZE = 14;
 export const TS_HEADER_SIZE = 10;
@@ -10,70 +17,100 @@ export const TS_HEADER_SIZE = 10;
 // ── ALP Insight HTML ─────────────────────────────────────────────────
 
 export function buildALPInsightHtml(p) {
-  const factor = '10' + superNum(p.exponent);
-  const excPct = p.count > 0 ? ((p.excCount / p.count) * 100).toFixed(1) : '0';
+  const factor = `10${superNum(p.exponent)}`;
+  const excPct = p.count > 0 ? ((p.excCount / p.count) * 100).toFixed(1) : "0";
   const rawValBits = p.count * 64;
   const compValBits = p.bitpackedBytes * 8;
-  const valRatio = rawValBits > 0 ? (rawValBits / Math.max(1, compValBits)).toFixed(1) : '-';
+  const valRatio = rawValBits > 0 ? (rawValBits / Math.max(1, compValBits)).toFixed(1) : "-";
 
   let html =
     '<div class="codec-insight">' +
-      '<div class="ci-title">\uD83E\uDDEC ALP \u00b7 Adaptive Lossless floating-Point <span class="ci-ref">(CWI Amsterdam, SIGMOD 2024)</span></div>' +
-      '<div class="ci-pipeline">' +
-        '<div class="ci-step">' +
-          '<div class="ci-num">1</div>' +
-          '<div class="ci-body">' +
-            '<div class="ci-step-title">Decimal Scaling</div>' +
-            '<div class="ci-detail">Multiply by ' + factor + ' \u2192 float64 becomes lossless int64</div>' +
-            '<div class="ci-example">e.g. 42.150 \u00d7 ' + factor + ' = ' + (42.15 * Math.pow(10, p.exponent)).toFixed(0) + '</div>' +
-          '</div>' +
-        '</div>' +
-        '<div class="ci-step">' +
-          '<div class="ci-num">2</div>' +
-          '<div class="ci-body">' +
-            '<div class="ci-step-title">Frame of Reference</div>' +
-            '<div class="ci-detail">min = ' + p.minInt.toString() + ', offsets need only ' + p.bitWidth + ' bits</div>' +
-            '<div class="ci-example">Each value stored as (int \u2212 min) in ' + p.bitWidth + ' bits vs 64 raw</div>' +
-          '</div>' +
-        '</div>' +
-        '<div class="ci-step">' +
-          '<div class="ci-num">3</div>' +
-          '<div class="ci-body">' +
-            '<div class="ci-step-title">Bit-Packing</div>' +
-            '<div class="ci-detail">' + p.count + ' \u00d7 ' + p.bitWidth + 'b = ' + formatBytes(p.bitpackedBytes) + '</div>' +
-            '<div class="ci-example">' + valRatio + '\u00d7 compression on values alone</div>' +
-          '</div>' +
-        '</div>' +
-      '</div>' +
-      '<div class="ci-exceptions">' +
-        (p.excCount === 0
-          ? '\u2705 0 exceptions \u2014 100% of values fit ALP perfectly'
-          : '\u26a0\ufe0f ' + p.excCount + ' exceptions (' + excPct + '%) stored as raw f64') +
-      '</div>' +
-    '</div>';
+    '<div class="ci-title">\uD83E\uDDEC ALP \u00b7 Adaptive Lossless floating-Point <span class="ci-ref">(CWI Amsterdam, SIGMOD 2024)</span></div>' +
+    '<div class="ci-pipeline">' +
+    '<div class="ci-step">' +
+    '<div class="ci-num">1</div>' +
+    '<div class="ci-body">' +
+    '<div class="ci-step-title">Decimal Scaling</div>' +
+    '<div class="ci-detail">Multiply by ' +
+    factor +
+    " \u2192 float64 becomes lossless int64</div>" +
+    '<div class="ci-example">e.g. 42.150 \u00d7 ' +
+    factor +
+    " = " +
+    (42.15 * 10 ** p.exponent).toFixed(0) +
+    "</div>" +
+    "</div>" +
+    "</div>" +
+    '<div class="ci-step">' +
+    '<div class="ci-num">2</div>' +
+    '<div class="ci-body">' +
+    '<div class="ci-step-title">Frame of Reference</div>' +
+    '<div class="ci-detail">min = ' +
+    p.minInt.toString() +
+    ", offsets need only " +
+    p.bitWidth +
+    " bits</div>" +
+    '<div class="ci-example">Each value stored as (int \u2212 min) in ' +
+    p.bitWidth +
+    " bits vs 64 raw</div>" +
+    "</div>" +
+    "</div>" +
+    '<div class="ci-step">' +
+    '<div class="ci-num">3</div>' +
+    '<div class="ci-body">' +
+    '<div class="ci-step-title">Bit-Packing</div>' +
+    '<div class="ci-detail">' +
+    p.count +
+    " \u00d7 " +
+    p.bitWidth +
+    "b = " +
+    formatBytes(p.bitpackedBytes) +
+    "</div>" +
+    '<div class="ci-example">' +
+    valRatio +
+    "\u00d7 compression on values alone</div>" +
+    "</div>" +
+    "</div>" +
+    "</div>" +
+    '<div class="ci-exceptions">' +
+    (p.excCount === 0
+      ? "\u2705 0 exceptions \u2014 100% of values fit ALP perfectly"
+      : `\u26a0\ufe0f ${p.excCount} exceptions (${excPct}%) stored as raw f64`) +
+    "</div>" +
+    "</div>";
 
   if (p.tsCount > 0) {
     html +=
       '<div class="codec-insight ts">' +
-        '<div class="ci-title">\uD83D\uDD70\uFE0F Delta-of-Delta Timestamps <span class="ci-ref">(shared across ' + p.sharedCount + ' series)</span></div>' +
-        '<div class="ci-pipeline">' +
-          '<div class="ci-step">' +
-            '<div class="ci-num">\u23F1</div>' +
-            '<div class="ci-body">' +
-              '<div class="ci-step-title">Base: ' + formatEpochNs(p.firstTs) + '</div>' +
-              '<div class="ci-detail">' + formatBytes(p.tsLen) + ' total \u00f7 ' + p.sharedCount + ' series = ' + formatBytes(p.amortizedTsLen) + ' amortized</div>' +
-            '</div>' +
-          '</div>' +
-          '<div class="ci-step">' +
-            '<div class="ci-num">\u0394</div>' +
-            '<div class="ci-body">' +
-              '<div class="ci-step-title">Gorilla-style prefix coding</div>' +
-              '<div class="ci-detail">0 = same \u0394 (1 bit) \u2502 10+7b \u2502 110+9b \u2502 1110+12b \u2502 1111+64b</div>' +
-              '<div class="ci-example">Regular intervals \u2192 most timestamps encode as a single 0 bit</div>' +
-            '</div>' +
-          '</div>' +
-        '</div>' +
-      '</div>';
+      '<div class="ci-title">\uD83D\uDD70\uFE0F Delta-of-Delta Timestamps <span class="ci-ref">(shared across ' +
+      p.sharedCount +
+      " series)</span></div>" +
+      '<div class="ci-pipeline">' +
+      '<div class="ci-step">' +
+      '<div class="ci-num">\u23F1</div>' +
+      '<div class="ci-body">' +
+      '<div class="ci-step-title">Base: ' +
+      formatEpochNs(p.firstTs) +
+      "</div>" +
+      '<div class="ci-detail">' +
+      formatBytes(p.tsLen) +
+      " total \u00f7 " +
+      p.sharedCount +
+      " series = " +
+      formatBytes(p.amortizedTsLen) +
+      " amortized</div>" +
+      "</div>" +
+      "</div>" +
+      '<div class="ci-step">' +
+      '<div class="ci-num">\u0394</div>' +
+      '<div class="ci-body">' +
+      '<div class="ci-step-title">Gorilla-style prefix coding</div>' +
+      '<div class="ci-detail">0 = same \u0394 (1 bit) \u2502 10+7b \u2502 110+9b \u2502 1110+12b \u2502 1111+64b</div>' +
+      '<div class="ci-example">Regular intervals \u2192 most timestamps encode as a single 0 bit</div>' +
+      "</div>" +
+      "</div>" +
+      "</div>" +
+      "</div>";
   }
   return html;
 }
@@ -82,30 +119,38 @@ export function buildALPInsightHtml(p) {
 
 export function buildXORInsightHtml(p) {
   const totalBits = (p.totalBytes - 18) * 8;
-  const bitsPerSample = p.count > 1 ? (totalBits / (p.count - 1)).toFixed(1) : '-';
+  const bitsPerSample = p.count > 1 ? (totalBits / (p.count - 1)).toFixed(1) : "-";
 
-  return '<div class="codec-insight">' +
+  return (
+    '<div class="codec-insight">' +
     '<div class="ci-title">\uD83E\uDDEC XOR-Delta \u00b7 Gorilla-style Compression <span class="ci-ref">(Facebook/Meta, VLDB 2015)</span></div>' +
     '<div class="ci-pipeline">' +
-      '<div class="ci-step">' +
-        '<div class="ci-num">\u23F1</div>' +
-        '<div class="ci-body">' +
-          '<div class="ci-step-title">Timestamps: Delta-of-Delta</div>' +
-          '<div class="ci-detail">Base: ' + formatEpochNs(p.firstTs) + '</div>' +
-          '<div class="ci-example">0 = same \u0394 (1 bit) \u2502 10+7b \u2502 110+9b \u2502 1110+12b \u2502 1111+64b</div>' +
-        '</div>' +
-      '</div>' +
-      '<div class="ci-step">' +
-        '<div class="ci-num">\u2295</div>' +
-        '<div class="ci-body">' +
-          '<div class="ci-step-title">Values: XOR of IEEE-754 bits</div>' +
-          '<div class="ci-detail">Base value: ' + p.firstVal.toPrecision(6) + '</div>' +
-          '<div class="ci-example">Similar floats share leading/trailing bits \u2192 only meaningful XOR bits stored</div>' +
-        '</div>' +
-      '</div>' +
-    '</div>' +
-    '<div class="ci-exceptions">\uD83D\uDCCA Interleaved stream: ~' + bitsPerSample + ' bits/sample (timestamps + values combined)</div>' +
-  '</div>';
+    '<div class="ci-step">' +
+    '<div class="ci-num">\u23F1</div>' +
+    '<div class="ci-body">' +
+    '<div class="ci-step-title">Timestamps: Delta-of-Delta</div>' +
+    '<div class="ci-detail">Base: ' +
+    formatEpochNs(p.firstTs) +
+    "</div>" +
+    '<div class="ci-example">0 = same \u0394 (1 bit) \u2502 10+7b \u2502 110+9b \u2502 1110+12b \u2502 1111+64b</div>' +
+    "</div>" +
+    "</div>" +
+    '<div class="ci-step">' +
+    '<div class="ci-num">\u2295</div>' +
+    '<div class="ci-body">' +
+    '<div class="ci-step-title">Values: XOR of IEEE-754 bits</div>' +
+    '<div class="ci-detail">Base value: ' +
+    p.firstVal.toPrecision(6) +
+    "</div>" +
+    '<div class="ci-example">Similar floats share leading/trailing bits \u2192 only meaningful XOR bits stored</div>' +
+    "</div>" +
+    "</div>" +
+    "</div>" +
+    '<div class="ci-exceptions">\uD83D\uDCCA Interleaved stream: ~' +
+    bitsPerSample +
+    " bits/sample (timestamps + values combined)</div>" +
+    "</div>"
+  );
 }
 
 // ── ALP header parser ────────────────────────────────────────────────
@@ -141,11 +186,17 @@ export function buildALPBitMap(primaryBlob, tsBlob, sampleCount) {
   const valBlobLen = primaryBlob.byteLength;
 
   const hdr = parseALPHeader(primaryBlob);
-  const { count: alpCount, exponent: alpExp, bitWidth: alpBW, minInt: alpMin, excCount: alpExc } = hdr;
+  const {
+    count: alpCount,
+    exponent: alpExp,
+    bitWidth: alpBW,
+    minInt: alpMin,
+    excCount: alpExc,
+  } = hdr;
 
   // Value bit positions (in the value blob)
   const headerBits = ALP_HEADER_SIZE * 8;
-  const bpBytes = Math.ceil(alpCount * alpBW / 8);
+  const bpBytes = Math.ceil((alpCount * alpBW) / 8);
 
   // Decode exception positions
   const excPositions = new Set();
@@ -168,7 +219,7 @@ export function buildALPBitMap(primaryBlob, tsBlob, sampleCount) {
   }
 
   // Build value entries from bit-packed offsets
-  const factor = Math.pow(10, alpExp);
+  const factor = 10 ** alpExp;
   let excIdx = 0;
   for (let i = 0; i < alpCount; i++) {
     const startBit = headerBits + i * alpBW;
@@ -189,14 +240,17 @@ export function buildALPBitMap(primaryBlob, tsBlob, sampleCount) {
     }
 
     const isException = excPositions.has(i);
-    const decodedValue = isException ? (excValues[excIdx] ?? NaN) : Number(offset + alpMin) / factor;
+    const decodedValue = isException
+      ? (excValues[excIdx] ?? NaN)
+      : Number(offset + alpMin) / factor;
     if (isException) excIdx++;
 
     bitMap.push({
       sampleIndex: i,
-      type: 'value',
-      startBit, endBit,
-      encoding: isException ? 'alp-exception' : 'alp-bitpacked',
+      type: "value",
+      startBit,
+      endBit,
+      encoding: isException ? "alp-exception" : "alp-bitpacked",
       decoded: decodedValue,
       offset: Number(offset),
       bitWidth: alpBW,
@@ -218,10 +272,10 @@ export function buildALPBitMap(primaryBlob, tsBlob, sampleCount) {
     if (posOff + 1 < valBlobLen) {
       bitMap.push({
         sampleIndex: sampleIdx,
-        type: 'value',
+        type: "value",
         startBit: posOff * 8,
         endBit: (posOff + 2) * 8,
-        encoding: 'alp-exc-position',
+        encoding: "alp-exc-position",
         decoded: excVal,
         isException: true,
       });
@@ -231,10 +285,10 @@ export function buildALPBitMap(primaryBlob, tsBlob, sampleCount) {
     if (valOff + 7 < valBlobLen) {
       bitMap.push({
         sampleIndex: sampleIdx,
-        type: 'value',
+        type: "value",
         startBit: valOff * 8,
         endBit: (valOff + 8) * 8,
-        encoding: 'alp-exc-rawvalue',
+        encoding: "alp-exc-rawvalue",
         decoded: excVal,
         isException: true,
       });
@@ -249,36 +303,41 @@ export function buildALPBitMap(primaryBlob, tsBlob, sampleCount) {
 
     bitMap.push({
       sampleIndex: 0,
-      type: 'timestamp',
+      type: "timestamp",
       startBit: 0,
       endBit: 80,
-      encoding: 'raw',
+      encoding: "raw",
       decoded: firstTs,
       blobOffset: valBlobLen,
     });
 
-    let prevTs = firstTs, prevDelta = 0n;
+    let prevTs = firstTs,
+      prevDelta = 0n;
     for (let i = 1; i < tsCount && i < sampleCount; i++) {
       const tsStart = tsR.totalBits;
       let dod;
       let enc;
       if (tsR.readBit() === 0) {
-        dod = 0n; enc = 'dod-zero';
+        dod = 0n;
+        enc = "dod-zero";
+        // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
       } else if (tsR.readBit() === 0) {
         const zz = tsR.readBitsNum(7);
         dod = BigInt.asIntN(64, BigInt((zz >>> 1) ^ -(zz & 1)));
-        enc = 'dod-7bit';
+        enc = "dod-7bit";
+        // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
       } else if (tsR.readBit() === 0) {
         const zz = tsR.readBitsNum(9);
         dod = BigInt.asIntN(64, BigInt((zz >>> 1) ^ -(zz & 1)));
-        enc = 'dod-9bit';
+        enc = "dod-9bit";
+        // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
       } else if (tsR.readBit() === 0) {
         const zz = tsR.readBitsNum(12);
         dod = BigInt.asIntN(64, BigInt((zz >>> 1) ^ -(zz & 1)));
-        enc = 'dod-12bit';
+        enc = "dod-12bit";
       } else {
         dod = BigInt.asIntN(64, tsR.readBits(64));
-        enc = 'dod-64bit';
+        enc = "dod-64bit";
       }
       const delta = prevDelta + dod;
       const ts = prevTs + delta;
@@ -287,12 +346,13 @@ export function buildALPBitMap(primaryBlob, tsBlob, sampleCount) {
 
       bitMap.push({
         sampleIndex: i,
-        type: 'timestamp',
+        type: "timestamp",
         startBit: tsStart,
         endBit: tsR.totalBits,
         encoding: enc,
         decoded: ts,
-        dod, delta,
+        dod,
+        delta,
         blobOffset: valBlobLen,
       });
     }
@@ -325,9 +385,13 @@ export function buildByteLookup(bitMap, totalBytes) {
   const lookup = new Array(totalBytes);
   for (let i = 0; i < totalBytes; i++) {
     if (!ownership[i]) continue;
-    let bestIdx = -1, bestCount = 0;
-    ownership[i].forEach(function(cnt, idx) {
-      if (cnt > bestCount) { bestCount = cnt; bestIdx = idx; }
+    let bestIdx = -1,
+      bestCount = 0;
+    ownership[i].forEach((cnt, idx) => {
+      if (cnt > bestCount) {
+        bestCount = cnt;
+        bestIdx = idx;
+      }
     });
     if (bestIdx >= 0) lookup[i] = bitMap[bestIdx];
   }
@@ -365,74 +429,102 @@ export function renderHexRowHTML(row, cols, bytes, byteRegion, regions, mode, by
   const startOffset = row * cols;
   const parts = [];
 
-  parts.push('<div class="hex-offset">0x' + startOffset.toString(16).toUpperCase().padStart(4, '0') + '</div>');
+  parts.push(
+    '<div class="hex-offset">0x' +
+      startOffset.toString(16).toUpperCase().padStart(4, "0") +
+      "</div>"
+  );
 
-  let asciiStr = '';
+  let asciiStr = "";
   for (let col = 0; col < cols; col++) {
     const byteIdx = startOffset + col;
-    let cls = 'hex-cell';
+    let cls = "hex-cell";
 
     if (byteIdx < bytes.length) {
       const val = bytes[byteIdx];
       const rIdx = byteRegion[byteIdx];
-      cls += ' region-' + regions[rIdx].cls;
+      cls += ` region-${regions[rIdx].cls}`;
 
-      let dataAttrs = ' data-offset="' + byteIdx + '" data-region="' + rIdx + '"';
+      let dataAttrs = ` data-offset="${byteIdx}" data-region="${rIdx}"`;
 
-      if (byteLookup && byteLookup[byteIdx]) {
+      if (byteLookup?.[byteIdx]) {
         const blEntry = byteLookup[byteIdx];
-        cls += ' hex-mapped';
-        cls += blEntry.type === 'timestamp' ? ' hex-ts' : ' hex-val';
-        cls += blEntry.sampleIndex % 2 === 0 ? ' hex-sample-even' : ' hex-sample-odd';
+        cls += " hex-mapped";
+        cls += blEntry.type === "timestamp" ? " hex-ts" : " hex-val";
+        cls += blEntry.sampleIndex % 2 === 0 ? " hex-sample-even" : " hex-sample-odd";
         if (byteIdx === 0 || !byteLookup[byteIdx - 1] || byteLookup[byteIdx - 1] !== blEntry) {
-          cls += ' hex-boundary';
+          cls += " hex-boundary";
         }
-        dataAttrs += ' data-sample-index="' + blEntry.sampleIndex + '" data-sample-type="' + blEntry.type + '"';
+        dataAttrs +=
+          ' data-sample-index="' +
+          blEntry.sampleIndex +
+          '" data-sample-type="' +
+          blEntry.type +
+          '"';
       }
 
       let content;
-      let style = '';
-      if (mode === 'hex') {
+      let style = "";
+      if (mode === "hex") {
         content = formatHexByte(val);
       } else {
-        content = val.toString().padStart(3, ' ');
+        content = val.toString().padStart(3, " ");
         style = ' style="font-size:8px"';
       }
-      parts.push('<div class="' + cls + '"' + dataAttrs + style + '>' + content + '</div>');
+      parts.push(`<div class="${cls}"${dataAttrs}${style}>${content}</div>`);
       if (val >= 32 && val <= 126) {
-        if (val === 38) asciiStr += '&amp;';
-        else if (val === 60) asciiStr += '&lt;';
-        else if (val === 62) asciiStr += '&gt;';
+        if (val === 38) asciiStr += "&amp;";
+        else if (val === 60) asciiStr += "&lt;";
+        else if (val === 62) asciiStr += "&gt;";
         else asciiStr += String.fromCharCode(val);
       } else {
-        asciiStr += '\u00b7';
+        asciiStr += "\u00b7";
       }
     } else {
-      parts.push('<div class="' + cls + ' region-padding">  </div>');
-      asciiStr += ' ';
+      parts.push(`<div class="${cls} region-padding">  </div>`);
+      asciiStr += " ";
     }
   }
 
-  parts.push('<div class="hex-ascii">' + asciiStr + '</div>');
-  return parts.join('');
+  parts.push(`<div class="hex-ascii">${asciiStr}</div>`);
+  return parts.join("");
 }
 
 // ── Encoding description ─────────────────────────────────────────────
 // Pure function: returns a human-readable description for a bitMap entry's encoding.
 
 export function encodingDescription(entry) {
-  if (entry.encoding === 'raw') return 'Raw (uncompressed first sample)';
-  if (entry.encoding === 'dod-zero') return '\u0394\u00b2 = 0 \u2192 prefix <code>0</code> (1 bit)';
-  if (entry.encoding === 'dod-7bit') return '\u0394\u00b2 \u2264 \u00b164 \u2192 prefix <code>10</code> + 7-bit zigzag';
-  if (entry.encoding === 'dod-9bit') return '\u0394\u00b2 \u2264 \u00b1256 \u2192 prefix <code>110</code> + 9-bit zigzag';
-  if (entry.encoding === 'dod-12bit') return '\u0394\u00b2 \u2264 \u00b12048 \u2192 prefix <code>1110</code> + 12-bit zigzag';
-  if (entry.encoding === 'dod-64bit') return 'Large \u0394\u00b2 \u2192 prefix <code>1111</code> + 64-bit raw';
-  if (entry.encoding === 'xor-zero') return 'XOR = 0 \u2192 prefix <code>0</code> (identical value)';
-  if (entry.encoding === 'xor-reuse') return 'XOR reuse window \u2192 prefix <code>10</code> + ' + entry.meaningful + ' meaningful bits';
-  if (entry.encoding === 'xor-new') return 'XOR new window \u2192 prefix <code>11</code> + 6b leading(' + entry.leading + ') + 6b length(' + entry.meaningful + ') + ' + entry.meaningful + ' bits';
-  if (entry.encoding === 'alp-bitpacked') return 'ALP bit-packed offset = ' + entry.offset + ' (' + entry.bitWidth + ' bits)';
-  if (entry.encoding === 'alp-exception') return '\u26a0\ufe0f ALP exception \u2014 stored as raw f64';
-  if (entry.encoding === 'alp-exc-position') return '\u26a0\ufe0f Exception position (u16 BE index)';
-  if (entry.encoding === 'alp-exc-rawvalue') return '\u26a0\ufe0f Exception raw value (f64 BE IEEE-754)';
-  return '';
+  if (entry.encoding === "raw") return "Raw (uncompressed first sample)";
+  if (entry.encoding === "dod-zero") return "\u0394\u00b2 = 0 \u2192 prefix <code>0</code> (1 bit)";
+  if (entry.encoding === "dod-7bit")
+    return "\u0394\u00b2 \u2264 \u00b164 \u2192 prefix <code>10</code> + 7-bit zigzag";
+  if (entry.encoding === "dod-9bit")
+    return "\u0394\u00b2 \u2264 \u00b1256 \u2192 prefix <code>110</code> + 9-bit zigzag";
+  if (entry.encoding === "dod-12bit")
+    return "\u0394\u00b2 \u2264 \u00b12048 \u2192 prefix <code>1110</code> + 12-bit zigzag";
+  if (entry.encoding === "dod-64bit")
+    return "Large \u0394\u00b2 \u2192 prefix <code>1111</code> + 64-bit raw";
+  if (entry.encoding === "xor-zero")
+    return "XOR = 0 \u2192 prefix <code>0</code> (identical value)";
+  if (entry.encoding === "xor-reuse")
+    return `XOR reuse window \u2192 prefix <code>10</code> + ${entry.meaningful} meaningful bits`;
+  if (entry.encoding === "xor-new")
+    return (
+      "XOR new window \u2192 prefix <code>11</code> + 6b leading(" +
+      entry.leading +
+      ") + 6b length(" +
+      entry.meaningful +
+      ") + " +
+      entry.meaningful +
+      " bits"
+    );
+  if (entry.encoding === "alp-bitpacked")
+    return `ALP bit-packed offset = ${entry.offset} (${entry.bitWidth} bits)`;
+  if (entry.encoding === "alp-exception")
+    return "\u26a0\ufe0f ALP exception \u2014 stored as raw f64";
+  if (entry.encoding === "alp-exc-position")
+    return "\u26a0\ufe0f Exception position (u16 BE index)";
+  if (entry.encoding === "alp-exc-rawvalue")
+    return "\u26a0\ufe0f Exception raw value (f64 BE IEEE-754)";
+  return "";
 }

--- a/site/tsdb-engine/js/byte-explorer.js
+++ b/site/tsdb-engine/js/byte-explorer.js
@@ -251,13 +251,24 @@ function _setupBitInteraction(container, bitLookup, explorer) {
     }
   });
 
-  // Escape to clear
-  function onKeyDown(e) {
-    if (e.key === "Escape") {
-      highlightBitRange(null);
+  // Escape to clear — use AbortController so the listener is removed when the bit-view is destroyed
+  var keyAbort = new AbortController();
+  document.addEventListener(
+    "keydown",
+    (e) => {
+      if (e.key === "Escape") highlightBitRange(null);
+    },
+    { signal: keyAbort.signal }
+  );
+  container.addEventListener("remove", () => keyAbort.abort());
+  // MutationObserver watches for the bit-view being removed from the DOM
+  var keyCleanupObserver = new MutationObserver(() => {
+    if (!container.isConnected) {
+      keyAbort.abort();
+      keyCleanupObserver.disconnect();
     }
-  }
-  document.addEventListener("keydown", onKeyDown);
+  });
+  keyCleanupObserver.observe(document.body, { childList: true, subtree: true });
 
   explorer.querySelector("#regionDetail").before(decodePanel);
   explorer.querySelector("#regionDetail").before(container);
@@ -294,9 +305,9 @@ function _buildExplorerShell(explorer, bytes, insightHtml) {
     bytes.length.toLocaleString() +
     " bytes</span></h4>" +
     '<div class="byte-explorer-controls">' +
-    '<button class="active" data-view="hex">Hex</button>' +
-    '<button data-view="decimal">Dec</button>' +
-    '<button data-view="bits">Bits</button>' +
+    '<button type="button" class="active" data-view="hex">Hex</button>' +
+    '<button type="button" data-view="decimal">Dec</button>' +
+    '<button type="button" data-view="bits">Bits</button>' +
     "</div>" +
     "</div>" +
     '<div id="codecInsight">' +
@@ -1132,9 +1143,9 @@ export function renderByteExplorerTs(tsBlob, sampleCount) {
     totalBytes.toLocaleString() +
     " bytes</span></h4>" +
     '<div class="byte-explorer-controls">' +
-    '<button class="active" data-view="hex">Hex</button>' +
-    '<button data-view="decimal">Dec</button>' +
-    '<button data-view="bits">Bits</button>' +
+    '<button type="button" class="active" data-view="hex">Hex</button>' +
+    '<button type="button" data-view="decimal">Dec</button>' +
+    '<button type="button" data-view="bits">Bits</button>' +
     "</div>" +
     "</div>" +
     '<div class="byte-minimap" id="byteMinimapTs"></div>' +

--- a/site/tsdb-engine/js/byte-explorer.js
+++ b/site/tsdb-engine/js/byte-explorer.js
@@ -1,14 +1,21 @@
 // ── Interactive Byte Explorer ──────────────────────────────────────
 
-import { $, formatBytes, readI64BE, readF64BE, formatEpochNs, superNum, formatHexByte } from './utils.js';
-import { decodeChunkAnnotated, BitReader } from './codec.js';
 import {
-  buildALPInsightHtml, buildXORInsightHtml,
-  parseALPHeader, parseXORHeader,
-  buildALPBitMap, buildByteLookup, entryByteRange,
-  buildByteRegionMap, renderHexRowHTML, encodingDescription,
-  ALP_HEADER_SIZE, TS_HEADER_SIZE,
-} from './byte-explorer-logic.js';
+  ALP_HEADER_SIZE,
+  buildALPBitMap,
+  buildALPInsightHtml,
+  buildByteLookup,
+  buildByteRegionMap,
+  buildXORInsightHtml,
+  encodingDescription,
+  entryByteRange,
+  parseALPHeader,
+  parseXORHeader,
+  renderHexRowHTML,
+  TS_HEADER_SIZE,
+} from "./byte-explorer-logic.js";
+import { BitReader, decodeChunkAnnotated } from "./codec.js";
+import { $, formatBytes, formatEpochNs, formatHexByte, readI64BE, superNum } from "./utils.js";
 
 const HEX_COLS = 32;
 const MAX_BITS = 2048;
@@ -19,38 +26,63 @@ const SCROLL_THRESHOLD = 200;
 // ── Shared highlight helpers ─────────────────────────────────────────
 
 function _buildDecodeHTML(entry, spanDesc) {
-  var bits = entry.endBit - entry.startBit;
+  var _bits = entry.endBit - entry.startBit;
   var decodedStr;
-  if (entry.type === 'timestamp') {
+  if (entry.type === "timestamp") {
     decodedStr = formatEpochNs(entry.decoded);
   } else {
-    decodedStr = typeof entry.decoded === 'number' ? entry.decoded.toPrecision(8) : String(entry.decoded);
+    decodedStr =
+      typeof entry.decoded === "number" ? entry.decoded.toPrecision(8) : String(entry.decoded);
   }
   var enc = encodingDescription(entry);
-  var typeIcon = entry.type === 'timestamp' ? '\u23f1' : '\uD83D\uDCCA';
-  var typeLabel = entry.type === 'timestamp' ? 'Timestamp' : 'Value';
+  var typeIcon = entry.type === "timestamp" ? "\u23f1" : "\uD83D\uDCCA";
+  var typeLabel = entry.type === "timestamp" ? "Timestamp" : "Value";
 
-  return '<div class="bdp-header">' +
-    '<span class="bdp-type ' + entry.type + '">' + typeIcon + ' ' + typeLabel + '</span>' +
-    '<span class="bdp-sample">Sample #' + entry.sampleIndex + '</span>' +
-    '<span class="bdp-bits">' + spanDesc + '</span>' +
-  '</div>' +
-  '<div class="bdp-value">' + decodedStr + '</div>' +
-  '<div class="bdp-encoding">' + enc + '</div>' +
-  (entry.dod !== undefined ? '<div class="bdp-detail">\u0394\u00b2 = ' + entry.dod.toString() + ', \u0394 = ' + entry.delta.toString() + '</div>' : '') +
-  (entry.xor !== undefined && entry.xor !== 0n ? '<div class="bdp-detail">XOR = 0x' + entry.xor.toString(16).padStart(16, '0') + '</div>' : '');
+  return (
+    '<div class="bdp-header">' +
+    '<span class="bdp-type ' +
+    entry.type +
+    '">' +
+    typeIcon +
+    " " +
+    typeLabel +
+    "</span>" +
+    '<span class="bdp-sample">Sample #' +
+    entry.sampleIndex +
+    "</span>" +
+    '<span class="bdp-bits">' +
+    spanDesc +
+    "</span>" +
+    "</div>" +
+    '<div class="bdp-value">' +
+    decodedStr +
+    "</div>" +
+    '<div class="bdp-encoding">' +
+    enc +
+    "</div>" +
+    (entry.dod !== undefined
+      ? '<div class="bdp-detail">\u0394\u00b2 = ' +
+        entry.dod.toString() +
+        ", \u0394 = " +
+        entry.delta.toString() +
+        "</div>"
+      : "") +
+    (entry.xor !== undefined && entry.xor !== 0n
+      ? `<div class="bdp-detail">XOR = 0x${entry.xor.toString(16).padStart(16, "0")}</div>`
+      : "")
+  );
 }
 
 function _highlightEntry(entry, decodePanel, clearFn, applyFn, setActiveFn) {
   clearFn();
   if (!entry) {
-    decodePanel.style.display = 'none';
+    decodePanel.style.display = "none";
     setActiveFn(null);
     return;
   }
   setActiveFn(entry);
   var spanDesc = applyFn(entry);
-  decodePanel.style.display = '';
+  decodePanel.style.display = "";
   decodePanel.innerHTML = _buildDecodeHTML(entry, spanDesc);
 }
 
@@ -71,10 +103,17 @@ function _buildBitLookup(bitMap) {
 }
 
 function _renderBitGrid(container, bytes, regions, maxBits, bitLookup) {
-  regions.forEach(function(region) {
-    var regionHeader = document.createElement('div');
-    regionHeader.style.cssText = 'margin:6px 0 4px;font-weight:700;font-size:11px;color:#f59e0b;';
-    regionHeader.textContent = '\u2500\u2500 ' + region.name + ' (bytes ' + region.start + '\u2013' + (region.end - 1) + ') \u2500\u2500';
+  regions.forEach((region) => {
+    var regionHeader = document.createElement("div");
+    regionHeader.style.cssText = "margin:6px 0 4px;font-weight:700;font-size:11px;color:#f59e0b;";
+    regionHeader.textContent =
+      "\u2500\u2500 " +
+      region.name +
+      " (bytes " +
+      region.start +
+      "\u2013" +
+      (region.end - 1) +
+      ") \u2500\u2500";
     container.appendChild(regionHeader);
 
     var regionBytes = bytes.slice(region.start, Math.min(region.end, Math.ceil(maxBits / 8)));
@@ -82,12 +121,12 @@ function _renderBitGrid(container, bytes, regions, maxBits, bitLookup) {
     var prevEntry = null;
 
     for (var rowStart = 0; rowStart < regionBytes.length * 8; rowStart += bitsPerRow) {
-      var rowEl = document.createElement('div');
-      rowEl.className = 'bit-row';
+      var rowEl = document.createElement("div");
+      rowEl.className = "bit-row";
 
-      var label = document.createElement('span');
-      label.className = 'bit-sample-label';
-      label.textContent = 'b' + (region.start * 8 + rowStart);
+      var label = document.createElement("span");
+      label.className = "bit-sample-label";
+      label.textContent = `b${region.start * 8 + rowStart}`;
       rowEl.appendChild(label);
 
       var rowEnd = Math.min(rowStart + bitsPerRow, regionBytes.length * 8);
@@ -97,35 +136,40 @@ function _renderBitGrid(container, bytes, regions, maxBits, bitLookup) {
         var bitVal = (regionBytes[byteOff] >> bitOff) & 1;
 
         var globalBitIdx = region.start * 8 + b;
-        var bitEl = document.createElement('span');
-        bitEl.className = 'bit ' + (bitVal ? 'b1' : 'b0');
+        var bitEl = document.createElement("span");
+        bitEl.className = `bit ${bitVal ? "b1" : "b0"}`;
         bitEl.textContent = bitVal;
         bitEl.dataset.bit = globalBitIdx;
 
         // Check if this bit belongs to a mapped sample
         var mapEntry = bitLookup[globalBitIdx];
         if (mapEntry) {
-          bitEl.classList.add('bit-mapped');
-          bitEl.classList.add(mapEntry.type === 'timestamp' ? 'bit-ts' : 'bit-val');
+          bitEl.classList.add("bit-mapped");
+          bitEl.classList.add(mapEntry.type === "timestamp" ? "bit-ts" : "bit-val");
           // Alternating sample shade
-          bitEl.classList.add(mapEntry.sampleIndex % 2 === 0 ? 'bit-sample-even' : 'bit-sample-odd');
+          bitEl.classList.add(
+            mapEntry.sampleIndex % 2 === 0 ? "bit-sample-even" : "bit-sample-odd"
+          );
           // Boundary: first bit of a new encoding entry
           if (mapEntry !== prevEntry && prevEntry !== null) {
-            bitEl.classList.add('bit-boundary');
+            bitEl.classList.add("bit-boundary");
           }
           // First mapped bit of the region also gets a boundary
           if (prevEntry === null) {
-            bitEl.classList.add('bit-boundary');
+            bitEl.classList.add("bit-boundary");
           }
-          bitEl.title = (mapEntry.type === 'timestamp' ? '\u23f1 ' : '\uD83D\uDCCA ') + 'Sample #' + mapEntry.sampleIndex;
+          bitEl.title =
+            (mapEntry.type === "timestamp" ? "\u23f1 " : "\uD83D\uDCCA ") +
+            "Sample #" +
+            mapEntry.sampleIndex;
           prevEntry = mapEntry;
         }
 
         rowEl.appendChild(bitEl);
 
         if ((b + 1) % 8 === 0 && b + 1 < rowEnd) {
-          var sep = document.createElement('span');
-          sep.style.cssText = 'width:4px;';
+          var sep = document.createElement("span");
+          sep.style.cssText = "width:4px;";
           rowEl.appendChild(sep);
         }
       }
@@ -137,54 +181,56 @@ function _renderBitGrid(container, bytes, regions, maxBits, bitLookup) {
   });
 
   if (bytes.length * 8 > maxBits) {
-    var note = document.createElement('div');
-    note.style.cssText = 'margin-top:8px;color:#94a3b8;font-size:10px;';
-    note.textContent = 'Showing first ' + maxBits + ' of ' + (bytes.length * 8) + ' bits...';
+    var note = document.createElement("div");
+    note.style.cssText = "margin-top:8px;color:#94a3b8;font-size:10px;";
+    note.textContent = `Showing first ${maxBits} of ${bytes.length * 8} bits...`;
     container.appendChild(note);
   }
 }
 
 function _setupBitInteraction(container, bitLookup, explorer) {
-  var decodePanel = document.createElement('div');
-  decodePanel.className = 'bit-decode-panel';
-  decodePanel.style.display = 'none';
+  var decodePanel = document.createElement("div");
+  decodePanel.className = "bit-decode-panel";
+  decodePanel.style.display = "none";
 
-  var activeEntry = null;
+  var _activeEntry = null;
 
   function highlightBitRange(entry) {
     _highlightEntry(
       entry,
       decodePanel,
-      function() {
-        container.querySelectorAll('.bit.bit-highlight').forEach(function(el) {
-          el.classList.remove('bit-highlight', 'bit-highlight-ts', 'bit-highlight-val');
+      () => {
+        container.querySelectorAll(".bit.bit-highlight").forEach((el) => {
+          el.classList.remove("bit-highlight", "bit-highlight-ts", "bit-highlight-val");
         });
       },
-      function(e) {
+      (e) => {
         var baseOffset = (e.blobOffset || 0) * 8;
         for (var b = e.startBit; b < e.endBit; b++) {
           var globalBit = baseOffset + b;
-          var el = container.querySelector('.bit[data-bit="' + globalBit + '"]');
+          var el = container.querySelector(`.bit[data-bit="${globalBit}"]`);
           if (el) {
-            el.classList.add('bit-highlight');
-            el.classList.add(e.type === 'timestamp' ? 'bit-highlight-ts' : 'bit-highlight-val');
+            el.classList.add("bit-highlight");
+            el.classList.add(e.type === "timestamp" ? "bit-highlight-ts" : "bit-highlight-val");
           }
         }
         var bits = e.endBit - e.startBit;
-        return bits + ' bits (bit ' + e.startBit + '\u2013' + (e.endBit - 1) + ')';
+        return `${bits} bits (bit ${e.startBit}\u2013${e.endBit - 1})`;
       },
-      function(v) { activeEntry = v; }
+      (v) => {
+        _activeEntry = v;
+      }
     );
   }
 
   // Click handler for bits
-  container.addEventListener('click', function(e) {
-    var bitEl = e.target.closest('.bit-mapped');
+  container.addEventListener("click", (e) => {
+    var bitEl = e.target.closest(".bit-mapped");
     if (!bitEl) {
       highlightBitRange(null);
       return;
     }
-    var globalBit = parseInt(bitEl.dataset.bit);
+    var globalBit = parseInt(bitEl.dataset.bit, 10);
     var entry = bitLookup[globalBit];
     if (entry) {
       highlightBitRange(entry);
@@ -192,42 +238,42 @@ function _setupBitInteraction(container, bitLookup, explorer) {
   });
 
   // Hover handler
-  container.addEventListener('mouseover', function(e) {
-    var bitEl = e.target.closest('.bit-mapped');
+  container.addEventListener("mouseover", (e) => {
+    var bitEl = e.target.closest(".bit-mapped");
     if (bitEl) {
-      bitEl.classList.add('bit-hover');
+      bitEl.classList.add("bit-hover");
     }
   });
-  container.addEventListener('mouseout', function(e) {
-    var bitEl = e.target.closest('.bit-mapped');
+  container.addEventListener("mouseout", (e) => {
+    var bitEl = e.target.closest(".bit-mapped");
     if (bitEl) {
-      bitEl.classList.remove('bit-hover');
+      bitEl.classList.remove("bit-hover");
     }
   });
 
   // Escape to clear
   function onKeyDown(e) {
-    if (e.key === 'Escape') {
+    if (e.key === "Escape") {
       highlightBitRange(null);
     }
   }
-  document.addEventListener('keydown', onKeyDown);
+  document.addEventListener("keydown", onKeyDown);
 
-  explorer.querySelector('#regionDetail').before(decodePanel);
-  explorer.querySelector('#regionDetail').before(container);
+  explorer.querySelector("#regionDetail").before(decodePanel);
+  explorer.querySelector("#regionDetail").before(container);
 }
 
 // ── Interactive Bit View ─────────────────────────────────────────────
 
-function renderBitView(explorer, bytes, byteRegion, regions, sampleCount, codec, bitMap) {
-  var scrollContainer = explorer.querySelector('.hex-grid-scroll');
-  scrollContainer.style.display = 'none';
+function renderBitView(explorer, bytes, _byteRegion, regions, _sampleCount, _codec, bitMap) {
+  var scrollContainer = explorer.querySelector(".hex-grid-scroll");
+  scrollContainer.style.display = "none";
 
-  var existing = explorer.querySelector('.bit-view');
+  var existing = explorer.querySelector(".bit-view");
   if (existing) existing.remove();
 
-  var container = document.createElement('div');
-  container.className = 'bit-view';
+  var container = document.createElement("div");
+  container.className = "bit-view";
 
   var maxBits = Math.min(bytes.length * 8, MAX_BITS);
   var bitLookup = _buildBitLookup(bitMap);
@@ -239,56 +285,83 @@ function renderBitView(explorer, bytes, byteRegion, regions, sampleCount, codec,
 // ── Explorer shell helpers ───────────────────────────────────────────
 
 function _buildExplorerShell(explorer, bytes, insightHtml) {
-  var viewId = 'hexView-' + Date.now();
+  var viewId = `hexView-${Date.now()}`;
   explorer.innerHTML =
     '<div class="byte-explorer-header">' +
-      '<h4>\uD83D\uDD2C Byte Explorer <span style="font-weight:400;color:#6b8a9e;font-size:11px">' + formatBytes(bytes.length) + ' \u00b7 ' + bytes.length.toLocaleString() + ' bytes</span></h4>' +
-      '<div class="byte-explorer-controls">' +
-        '<button class="active" data-view="hex">Hex</button>' +
-        '<button data-view="decimal">Dec</button>' +
-        '<button data-view="bits">Bits</button>' +
-      '</div>' +
-    '</div>' +
-    '<div id="codecInsight">' + insightHtml + '</div>' +
+    '<h4>\uD83D\uDD2C Byte Explorer <span style="font-weight:400;color:#6b8a9e;font-size:11px">' +
+    formatBytes(bytes.length) +
+    " \u00b7 " +
+    bytes.length.toLocaleString() +
+    " bytes</span></h4>" +
+    '<div class="byte-explorer-controls">' +
+    '<button class="active" data-view="hex">Hex</button>' +
+    '<button data-view="decimal">Dec</button>' +
+    '<button data-view="bits">Bits</button>' +
+    "</div>" +
+    "</div>" +
+    '<div id="codecInsight">' +
+    insightHtml +
+    "</div>" +
     '<div class="byte-minimap" id="byteMinimap"></div>' +
-    '<div class="hex-grid-scroll" id="' + viewId + '">' +
-      '<div class="hex-grid" id="hexGrid" style="grid-template-columns: 56px repeat(' + HEX_COLS + ', minmax(0, 1fr)) minmax(0, 220px);"></div>' +
-    '</div>' +
+    '<div class="hex-grid-scroll" id="' +
+    viewId +
+    '">' +
+    '<div class="hex-grid" id="hexGrid" style="grid-template-columns: 56px repeat(' +
+    HEX_COLS +
+    ', minmax(0, 1fr)) minmax(0, 220px);"></div>' +
+    "</div>" +
     '<div class="hex-decode-panel" id="hexDecodePanel" style="display:none"></div>' +
     '<div id="regionDetail"></div>';
 }
 
 function _buildMinimap(explorer, bytes, regions, showRegionDetail) {
-  var minimap = explorer.querySelector('#byteMinimap');
+  var minimap = explorer.querySelector("#byteMinimap");
   var totalLen = bytes.length;
-  regions.forEach(function(r) {
-    var seg = document.createElement('div');
-    seg.className = 'mm-seg';
-    seg.style.width = Math.max(1, ((r.end - r.start) / totalLen) * 100) + '%';
-    seg.style.background = r.cls === 'header' ? '#8b5cf6' : r.cls === 'timestamps' ? '#06b6d4' : r.cls === 'exceptions' ? '#f59e0b' : '#10b981';
-    seg.title = r.name + ': ' + formatBytes(r.end - r.start);
-    seg.addEventListener('click', function() {
+  regions.forEach((r) => {
+    var seg = document.createElement("div");
+    seg.className = "mm-seg";
+    seg.style.width = `${Math.max(1, ((r.end - r.start) / totalLen) * 100)}%`;
+    seg.style.background =
+      r.cls === "header"
+        ? "#8b5cf6"
+        : r.cls === "timestamps"
+          ? "#06b6d4"
+          : r.cls === "exceptions"
+            ? "#f59e0b"
+            : "#10b981";
+    seg.title = `${r.name}: ${formatBytes(r.end - r.start)}`;
+    seg.addEventListener("click", () => {
       var targetRow = Math.floor(r.start / HEX_COLS);
-      var gridEl = explorer.querySelector('.hex-grid-scroll');
-      var rowEls = gridEl.querySelectorAll('.hex-offset');
-      if (rowEls[targetRow]) rowEls[targetRow].scrollIntoView({ behavior: 'smooth', block: 'start' });
+      var gridEl = explorer.querySelector(".hex-grid-scroll");
+      var rowEls = gridEl.querySelectorAll(".hex-offset");
+      if (rowEls[targetRow])
+        rowEls[targetRow].scrollIntoView({ behavior: "smooth", block: "start" });
       showRegionDetail(r);
     });
     minimap.appendChild(seg);
   });
 
   // Viewport indicator
-  var viewport = document.createElement('div');
-  viewport.className = 'mm-viewport';
+  var viewport = document.createElement("div");
+  viewport.className = "mm-viewport";
   minimap.appendChild(viewport);
   return viewport;
 }
 
-function _renderHexContent(gridEl, scrollContainer, bytes, byteRegion, regions, byteLookup, totalRows, viewport) {
+function _renderHexContent(
+  gridEl,
+  scrollContainer,
+  bytes,
+  byteRegion,
+  regions,
+  byteLookup,
+  totalRows,
+  viewport
+) {
   var state = {
     cellsByOffset: {},
     renderedRows: 0,
-    currentMode: 'hex',
+    currentMode: "hex",
     sentinel: null,
   };
 
@@ -297,42 +370,44 @@ function _renderHexContent(gridEl, scrollContainer, bytes, byteRegion, regions, 
     for (var r = startRow; r < startRow + count; r++) {
       htmlParts.push(renderHexRowHTML(r, HEX_COLS, bytes, byteRegion, regions, mode, byteLookup));
     }
-    return htmlParts.join('');
+    return htmlParts.join("");
   }
 
   function indexCells() {
     state.cellsByOffset = {};
-    var cells = gridEl.querySelectorAll('.hex-cell[data-offset]');
+    var cells = gridEl.querySelectorAll(".hex-cell[data-offset]");
     for (var i = 0; i < cells.length; i++) {
       state.cellsByOffset[cells[i].dataset.offset] = cells[i];
     }
   }
 
   var initialRows = Math.min(totalRows, MAX_INITIAL_ROWS);
-  gridEl.innerHTML = renderBatch(0, initialRows, 'hex');
+  gridEl.innerHTML = renderBatch(0, initialRows, "hex");
   indexCells();
   state.renderedRows = initialRows;
 
   // Lazy render remaining rows
   if (totalRows > initialRows) {
-    state.sentinel = document.createElement('div');
-    state.sentinel.style.height = '1px';
-    state.sentinel.style.gridColumn = '1 / -1';
+    state.sentinel = document.createElement("div");
+    state.sentinel.style.height = "1px";
+    state.sentinel.style.gridColumn = "1 / -1";
     gridEl.appendChild(state.sentinel);
   }
 
   // Throttled scroll handler (combines lazy-load + viewport indicator)
   var scrollRAF = 0;
-  scrollContainer.addEventListener('scroll', function() {
+  scrollContainer.addEventListener("scroll", () => {
     if (scrollRAF) return;
-    scrollRAF = requestAnimationFrame(function() {
+    scrollRAF = requestAnimationFrame(() => {
       scrollRAF = 0;
 
       // Viewport indicator
-      var scrollFraction = scrollContainer.scrollTop / Math.max(1, scrollContainer.scrollHeight - scrollContainer.clientHeight);
+      var scrollFraction =
+        scrollContainer.scrollTop /
+        Math.max(1, scrollContainer.scrollHeight - scrollContainer.clientHeight);
       var vf = scrollContainer.clientHeight / Math.max(1, scrollContainer.scrollHeight);
-      viewport.style.left = (scrollFraction * (1 - vf) * 100) + '%';
-      viewport.style.width = Math.max(3, vf * 100) + '%';
+      viewport.style.left = `${scrollFraction * (1 - vf) * 100}%`;
+      viewport.style.width = `${Math.max(3, vf * 100)}%`;
 
       // Lazy load
       if (state.renderedRows < totalRows && state.sentinel && state.sentinel.parentNode) {
@@ -341,9 +416,12 @@ function _renderHexContent(gridEl, scrollContainer, bytes, byteRegion, regions, 
         if (sRect.top < cRect.bottom + SCROLL_THRESHOLD) {
           var batch = Math.min(50, totalRows - state.renderedRows);
           gridEl.removeChild(state.sentinel);
-          gridEl.insertAdjacentHTML('beforeend', renderBatch(state.renderedRows, batch, state.currentMode));
+          gridEl.insertAdjacentHTML(
+            "beforeend",
+            renderBatch(state.renderedRows, batch, state.currentMode)
+          );
           // Index new cells
-          var newCells = gridEl.querySelectorAll('.hex-cell[data-offset]');
+          var newCells = gridEl.querySelectorAll(".hex-cell[data-offset]");
           for (var i = 0; i < newCells.length; i++) {
             var off = newCells[i].dataset.offset;
             if (!state.cellsByOffset[off]) state.cellsByOffset[off] = newCells[i];
@@ -356,8 +434,8 @@ function _renderHexContent(gridEl, scrollContainer, bytes, byteRegion, regions, 
   });
 
   var initVF = scrollContainer.clientHeight / Math.max(1, scrollContainer.scrollHeight);
-  viewport.style.left = '0%';
-  viewport.style.width = Math.max(3, initVF * 100) + '%';
+  viewport.style.left = "0%";
+  viewport.style.width = `${Math.max(3, initVF * 100)}%`;
 
   function rerender(mode) {
     state.currentMode = mode;
@@ -366,9 +444,9 @@ function _renderHexContent(gridEl, scrollContainer, bytes, byteRegion, regions, 
     indexCells();
     if (state.renderedRows < totalRows) {
       if (!state.sentinel) {
-        state.sentinel = document.createElement('div');
-        state.sentinel.style.height = '1px';
-        state.sentinel.style.gridColumn = '1 / -1';
+        state.sentinel = document.createElement("div");
+        state.sentinel.style.height = "1px";
+        state.sentinel.style.gridColumn = "1 / -1";
       }
       gridEl.appendChild(state.sentinel);
     }
@@ -377,56 +455,77 @@ function _renderHexContent(gridEl, scrollContainer, bytes, byteRegion, regions, 
   return { state: state, grid: gridEl, scrollContainer: scrollContainer, rerender: rerender };
 }
 
-function _setupHexInteraction(explorer, bytes, byteRegion, regions, byteLookup, hexContent, showRegionDetail) {
+function _setupHexInteraction(
+  explorer,
+  bytes,
+  byteRegion,
+  regions,
+  byteLookup,
+  hexContent,
+  showRegionDetail
+) {
   var grid = hexContent.grid;
-  var hexDecodePanel = explorer.querySelector('.hex-decode-panel');
-  var activeHexEntry = null;
+  var hexDecodePanel = explorer.querySelector(".hex-decode-panel");
+  var _activeHexEntry = null;
 
   function highlightHexSample(entry) {
     _highlightEntry(
       entry,
       hexDecodePanel,
-      function() {
+      () => {
         if (highlightHexSample._prev) {
-          highlightHexSample._prev.forEach(function(c) {
-            c.classList.remove('hex-highlight', 'hex-highlight-ts', 'hex-highlight-val');
+          highlightHexSample._prev.forEach((c) => {
+            c.classList.remove("hex-highlight", "hex-highlight-ts", "hex-highlight-val");
           });
           highlightHexSample._prev = null;
         }
       },
-      function(e) {
+      (e) => {
         var range = entryByteRange(e, bytes.length);
         var highlighted = [];
         for (var bi = range.startByte; bi < range.endByte; bi++) {
           var cell = hexContent.state.cellsByOffset[bi];
           if (cell) {
-            cell.classList.add('hex-highlight');
-            cell.classList.add(e.type === 'timestamp' ? 'hex-highlight-ts' : 'hex-highlight-val');
+            cell.classList.add("hex-highlight");
+            cell.classList.add(e.type === "timestamp" ? "hex-highlight-ts" : "hex-highlight-val");
             highlighted.push(cell);
           }
         }
         highlightHexSample._prev = highlighted;
         var bits = e.endBit - e.startBit;
         var spanBytes = range.endByte - range.startByte;
-        return bits + ' bits across ' + spanBytes + ' byte' + (spanBytes !== 1 ? 's' : '') + ' (byte ' + range.startByte + '\u2013' + (range.endByte - 1) + ')';
+        return (
+          bits +
+          " bits across " +
+          spanBytes +
+          " byte" +
+          (spanBytes !== 1 ? "s" : "") +
+          " (byte " +
+          range.startByte +
+          "\u2013" +
+          (range.endByte - 1) +
+          ")"
+        );
       },
-      function(v) { activeHexEntry = v; }
+      (v) => {
+        _activeHexEntry = v;
+      }
     );
   }
 
   // Tooltip — pre-build structure, update via textContent where possible
-  var tooltip = document.querySelector('.byte-tooltip');
+  var tooltip = document.querySelector(".byte-tooltip");
   if (!tooltip) {
-    tooltip = document.createElement('div');
-    tooltip.className = 'byte-tooltip';
+    tooltip = document.createElement("div");
+    tooltip.className = "byte-tooltip";
     document.body.appendChild(tooltip);
   }
   var lastTooltipOffset = -1;
 
-  grid.addEventListener('mouseover', function(e) {
+  grid.addEventListener("mouseover", (e) => {
     var cell = e.target;
-    if (!cell.classList || !cell.classList.contains('hex-cell')) {
-      tooltip.classList.remove('visible');
+    if (!cell.classList?.contains("hex-cell")) {
+      tooltip.classList.remove("visible");
       lastTooltipOffset = -1;
       return;
     }
@@ -436,45 +535,64 @@ function _setupHexInteraction(explorer, bytes, byteRegion, regions, byteLookup, 
     var val = bytes[offset];
     var rIdx = byteRegion[offset];
     var region = regions[rIdx];
-    var sampleInfo = '';
-    if (byteLookup && byteLookup[offset]) {
+    var sampleInfo = "";
+    if (byteLookup?.[offset]) {
       var blE = byteLookup[offset];
-      sampleInfo = '<span class="bt-sample ' + blE.type + '">' +
-        (blE.type === 'timestamp' ? '\u23f1' : '\uD83D\uDCCA') + ' #' + blE.sampleIndex + '</span>';
+      sampleInfo =
+        '<span class="bt-sample ' +
+        blE.type +
+        '">' +
+        (blE.type === "timestamp" ? "\u23f1" : "\uD83D\uDCCA") +
+        " #" +
+        blE.sampleIndex +
+        "</span>";
     }
     tooltip.innerHTML =
-      '<span class="bt-offset">offset ' + offset + '</span> &nbsp;' +
-      '<span class="bt-hex">0x' + formatHexByte(val) + '</span>' +
-      '<span style="color:#94a3b8"> = ' + val + '</span>' +
-      '<span class="bt-region ' + region.cls + '">' + region.name + '</span>' +
+      '<span class="bt-offset">offset ' +
+      offset +
+      "</span> &nbsp;" +
+      '<span class="bt-hex">0x' +
+      formatHexByte(val) +
+      "</span>" +
+      '<span style="color:#94a3b8"> = ' +
+      val +
+      "</span>" +
+      '<span class="bt-region ' +
+      region.cls +
+      '">' +
+      region.name +
+      "</span>" +
       sampleInfo;
-    tooltip.classList.add('visible');
+    tooltip.classList.add("visible");
   });
 
   // Throttle mousemove for tooltip positioning
   var moveRAF = 0;
-  grid.addEventListener('mousemove', function(e) {
+  grid.addEventListener("mousemove", (e) => {
     if (moveRAF) return;
-    moveRAF = requestAnimationFrame(function() {
+    moveRAF = requestAnimationFrame(() => {
       moveRAF = 0;
-      tooltip.style.left = (e.clientX + 12) + 'px';
-      tooltip.style.top = (e.clientY - 40) + 'px';
+      tooltip.style.left = `${e.clientX + 12}px`;
+      tooltip.style.top = `${e.clientY - 40}px`;
     });
   });
 
-  grid.addEventListener('mouseleave', function() {
-    tooltip.classList.remove('visible');
+  grid.addEventListener("mouseleave", () => {
+    tooltip.classList.remove("visible");
     lastTooltipOffset = -1;
   });
 
   // Click handler: sample-aware for mapped bytes, region fallback otherwise
-  grid.addEventListener('click', function(e) {
+  grid.addEventListener("click", (e) => {
     var cell = e.target;
-    if (!cell.classList || !cell.classList.contains('hex-cell')) { highlightHexSample(null); return; }
+    if (!cell.classList?.contains("hex-cell")) {
+      highlightHexSample(null);
+      return;
+    }
     var offset = cell.dataset.offset | 0;
 
     // Try sample-level highlight first
-    if (byteLookup && byteLookup[offset]) {
+    if (byteLookup?.[offset]) {
       highlightHexSample(byteLookup[offset]);
       return;
     }
@@ -486,34 +604,48 @@ function _setupHexInteraction(explorer, bytes, byteRegion, regions, byteLookup, 
   });
 
   // Escape to clear hex highlights (tracked for cleanup on re-render)
-  renderByteExplorer._escHandler = function(e) {
-    if (e.key === 'Escape') highlightHexSample(null);
+  renderByteExplorer._escHandler = (e) => {
+    if (e.key === "Escape") highlightHexSample(null);
   };
-  document.addEventListener('keydown', renderByteExplorer._escHandler);
+  document.addEventListener("keydown", renderByteExplorer._escHandler);
 
   return highlightHexSample;
 }
 
-function _setupViewModeButtons(explorer, bytes, byteRegion, regions, sampleCount, codec, bitMap, byteLookup, totalRows, hexContent, highlightHexSample) {
-  var hexDecodePanel = explorer.querySelector('.hex-decode-panel');
-  var buttons = explorer.querySelectorAll('.byte-explorer-controls button');
+function _setupViewModeButtons(
+  explorer,
+  bytes,
+  byteRegion,
+  regions,
+  sampleCount,
+  codec,
+  bitMap,
+  _byteLookup,
+  _totalRows,
+  hexContent,
+  highlightHexSample
+) {
+  var hexDecodePanel = explorer.querySelector(".hex-decode-panel");
+  var buttons = explorer.querySelectorAll(".byte-explorer-controls button");
 
-  buttons.forEach(function(btn) {
-    btn.addEventListener('click', function() {
-      buttons.forEach(function(b) { b.classList.remove('active'); });
-      btn.classList.add('active');
+  buttons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      buttons.forEach((b) => {
+        b.classList.remove("active");
+      });
+      btn.classList.add("active");
       var mode = btn.dataset.view;
 
-      if (mode === 'bits') {
-        hexDecodePanel.style.display = 'none';
+      if (mode === "bits") {
+        hexDecodePanel.style.display = "none";
         renderBitView(explorer, bytes, byteRegion, regions, sampleCount, codec, bitMap);
       } else {
-        var bitView = explorer.querySelector('.bit-view');
+        var bitView = explorer.querySelector(".bit-view");
         if (bitView) bitView.remove();
-        var dp = explorer.querySelector('.bit-decode-panel');
+        var dp = explorer.querySelector(".bit-decode-panel");
         if (dp) dp.remove();
         highlightHexSample(null);
-        hexContent.scrollContainer.style.display = '';
+        hexContent.scrollContainer.style.display = "";
         hexContent.rerender(mode);
       }
     });
@@ -523,37 +655,45 @@ function _setupViewModeButtons(explorer, bytes, byteRegion, regions, sampleCount
 // ── Main Byte Explorer ───────────────────────────────────────────────
 
 export function renderByteExplorer(primaryBlob, tsBlob, sharedCount, sampleCount, codec) {
-  var explorer = $('#byteExplorer');
+  var explorer = $("#byteExplorer");
   if (!explorer) return;
 
   // Clean up previous keydown listener to prevent leaks
   if (renderByteExplorer._escHandler) {
-    document.removeEventListener('keydown', renderByteExplorer._escHandler);
+    document.removeEventListener("keydown", renderByteExplorer._escHandler);
     renderByteExplorer._escHandler = null;
   }
 
   var regions = [];
   var bytes;
-  var insightHtml = '';
+  var insightHtml = "";
   var bitMap = null;
 
-  if (codec === 'alp-values' || codec === 'alp') {
+  if (codec === "alp-values" || codec === "alp") {
     var valBlobLen = primaryBlob.byteLength;
     // For alp-values, we only render the value blob (no timestamp concatenation)
-    var includeTs = codec === 'alp' && tsBlob;
-    var tsLen = (includeTs && tsBlob) ? tsBlob.byteLength : 0;
-    var amortizedTsLen = includeTs ? (sharedCount > 0 ? Math.round(tsLen / sharedCount) : tsLen) : 0;
+    var includeTs = codec === "alp" && tsBlob;
+    var tsLen = includeTs && tsBlob ? tsBlob.byteLength : 0;
+    var amortizedTsLen = includeTs
+      ? sharedCount > 0
+        ? Math.round(tsLen / sharedCount)
+        : tsLen
+      : 0;
 
     var ALP_HDR = Math.min(ALP_HEADER_SIZE, valBlobLen);
     var alpHdr = parseALPHeader(primaryBlob);
-    var alpCount = alpHdr.count, alpExp = alpHdr.exponent, alpBW = alpHdr.bitWidth;
-    var alpMin = alpHdr.minInt, alpExc = alpHdr.excCount;
+    var alpCount = alpHdr.count,
+      alpExp = alpHdr.exponent,
+      alpBW = alpHdr.bitWidth;
+    var alpMin = alpHdr.minInt,
+      alpExc = alpHdr.excCount;
 
-    var bpBytes = Math.ceil(alpCount * alpBW / 8);
+    var bpBytes = Math.ceil((alpCount * alpBW) / 8);
     var excPosBytes = alpExc * 2;
     var excValBytes = alpExc * 8;
 
-    var tsCount = 0, firstTs = 0n;
+    var tsCount = 0,
+      firstTs = 0n;
     if (includeTs && tsBlob && tsBlob.byteLength >= TS_HEADER_SIZE) {
       tsCount = (tsBlob[0] << 8) | tsBlob[1];
       firstTs = readI64BE(tsBlob, 2);
@@ -566,27 +706,50 @@ export function renderByteExplorer(primaryBlob, tsBlob, sharedCount, sampleCount
       bytes.set(tsBlob.slice(0, amortizedTsLen), valBlobLen);
     }
 
-    var factor10 = '10' + superNum(alpExp);
+    var factor10 = `10${superNum(alpExp)}`;
     regions.push({
-      name: 'ALP Header (14 B)', cls: 'header', start: 0, end: ALP_HDR,
-      decode: function() {
-        return 'bytes 0\u20111: sample count = ' + alpCount +
-               '\nbyte 2: exponent = ' + alpExp + '  (\u00d7' + factor10 + ' to convert float\u2192int)' +
-               '\nbyte 3: bit width = ' + alpBW + '  (bits per FoR offset)' +
-               '\nbytes 4\u201311: min int = ' + alpMin.toString() + '  (frame-of-reference base)' +
-               '\nbytes 12\u201313: exceptions = ' + alpExc;
-      }
+      name: "ALP Header (14 B)",
+      cls: "header",
+      start: 0,
+      end: ALP_HDR,
+      decode: () =>
+        "bytes 0\u20111: sample count = " +
+        alpCount +
+        "\nbyte 2: exponent = " +
+        alpExp +
+        "  (\u00d7" +
+        factor10 +
+        " to convert float\u2192int)" +
+        "\nbyte 3: bit width = " +
+        alpBW +
+        "  (bits per FoR offset)" +
+        "\nbytes 4\u201311: min int = " +
+        alpMin.toString() +
+        "  (frame-of-reference base)" +
+        "\nbytes 12\u201313: exceptions = " +
+        alpExc,
     });
 
     if (bpBytes > 0) {
       var bpEnd = Math.min(ALP_HDR + bpBytes, valBlobLen);
       regions.push({
-        name: 'Bit-Packed Offsets', cls: 'values', start: ALP_HDR, end: bpEnd,
-        decode: function() {
-          return alpCount + ' offsets \u00d7 ' + alpBW + ' bits = ' + bpBytes + ' bytes' +
-                 '\nEach offset = (scaled_integer \u2212 ' + alpMin.toString() + ')' +
-                 '\nReconstruct: (offset + min) \u00f7 ' + factor10 + ' \u2192 original float64';
-        }
+        name: "Bit-Packed Offsets",
+        cls: "values",
+        start: ALP_HDR,
+        end: bpEnd,
+        decode: () =>
+          alpCount +
+          " offsets \u00d7 " +
+          alpBW +
+          " bits = " +
+          bpBytes +
+          " bytes" +
+          "\nEach offset = (scaled_integer \u2212 " +
+          alpMin.toString() +
+          ")" +
+          "\nReconstruct: (offset + min) \u00f7 " +
+          factor10 +
+          " \u2192 original float64",
       });
     }
 
@@ -595,87 +758,142 @@ export function renderByteExplorer(primaryBlob, tsBlob, sharedCount, sampleCount
       var epEnd = Math.min(epStart + excPosBytes, valBlobLen);
       var evEnd = Math.min(epEnd + excValBytes, valBlobLen);
       regions.push({
-        name: 'Exception Positions', cls: 'exceptions', start: epStart, end: epEnd,
-        decode: function() {
-          return alpExc + ' \u00d7 u16 BE indices of non-roundtrippable values' +
-                 '\nThese values couldn\u2019t survive \u00d7' + factor10 + ' \u2192 int \u2192 \u00f7' + factor10;
-        }
+        name: "Exception Positions",
+        cls: "exceptions",
+        start: epStart,
+        end: epEnd,
+        decode: () =>
+          alpExc +
+          " \u00d7 u16 BE indices of non-roundtrippable values" +
+          "\nThese values couldn\u2019t survive \u00d7" +
+          factor10 +
+          " \u2192 int \u2192 \u00f7" +
+          factor10,
       });
       regions.push({
-        name: 'Exception Raw Values', cls: 'exceptions', start: epEnd, end: evEnd,
-        decode: function() {
-          return alpExc + ' \u00d7 f64 BE (raw IEEE-754, 8 bytes each)' +
-                 '\nStored verbatim for lossless reconstruction';
-        }
+        name: "Exception Raw Values",
+        cls: "exceptions",
+        start: epEnd,
+        end: evEnd,
+        decode: () =>
+          alpExc +
+          " \u00d7 f64 BE (raw IEEE-754, 8 bytes each)" +
+          "\nStored verbatim for lossless reconstruction",
       });
     }
 
     if (includeTs && amortizedTsLen > 0) {
       var tsHdrEnd = Math.min(TS_HEADER_SIZE, amortizedTsLen);
       regions.push({
-        name: 'Timestamp Header', cls: 'timestamps', start: valBlobLen, end: valBlobLen + tsHdrEnd,
-        decode: function() {
-          return 'bytes 0\u20111: count = ' + tsCount +
-                 '\nbytes 2\u20119: first timestamp' +
-                 '\n  ' + formatEpochNs(firstTs) +
-                 '\n  epoch ns: ' + firstTs.toString();
-        }
+        name: "Timestamp Header",
+        cls: "timestamps",
+        start: valBlobLen,
+        end: valBlobLen + tsHdrEnd,
+        decode: () =>
+          "bytes 0\u20111: count = " +
+          tsCount +
+          "\nbytes 2\u20119: first timestamp" +
+          "\n  " +
+          formatEpochNs(firstTs) +
+          "\n  epoch ns: " +
+          firstTs.toString(),
       });
       if (amortizedTsLen > TS_HEADER_SIZE) {
         regions.push({
-          name: 'Timestamp \u0394\u0394 Body', cls: 'timestamps', start: valBlobLen + TS_HEADER_SIZE, end: valBlobLen + amortizedTsLen,
-          decode: function() {
+          name: "Timestamp \u0394\u0394 Body",
+          cls: "timestamps",
+          start: valBlobLen + TS_HEADER_SIZE,
+          end: valBlobLen + amortizedTsLen,
+          decode: () => {
             var body = amortizedTsLen - TS_HEADER_SIZE;
-            return body + ' bytes of delta-of-delta encoded timestamps' +
-                   '\nGorilla: 0=same\u0394 | 10+7b | 110+9b | 1110+12b | 1111+64b' +
-                   '\nFull blob: ' + formatBytes(tsLen) + ' shared \u00f7 ' + sharedCount + ' = ' + formatBytes(amortizedTsLen) + '/series';
-          }
+            return (
+              body +
+              " bytes of delta-of-delta encoded timestamps" +
+              "\nGorilla: 0=same\u0394 | 10+7b | 110+9b | 1110+12b | 1111+64b" +
+              "\nFull blob: " +
+              formatBytes(tsLen) +
+              " shared \u00f7 " +
+              sharedCount +
+              " = " +
+              formatBytes(amortizedTsLen) +
+              "/series"
+            );
+          },
         });
       }
     }
 
     insightHtml = buildALPInsightHtml({
-      count: alpCount, exponent: alpExp, bitWidth: alpBW, minInt: alpMin,
-      excCount: alpExc, bitpackedBytes: bpBytes, valBlobLen: valBlobLen,
-      tsLen: includeTs ? tsLen : 0, amortizedTsLen: amortizedTsLen, sharedCount: includeTs ? sharedCount : 0,
-      tsCount: tsCount, firstTs: firstTs
+      count: alpCount,
+      exponent: alpExp,
+      bitWidth: alpBW,
+      minInt: alpMin,
+      excCount: alpExc,
+      bitpackedBytes: bpBytes,
+      valBlobLen: valBlobLen,
+      tsLen: includeTs ? tsLen : 0,
+      amortizedTsLen: amortizedTsLen,
+      sharedCount: includeTs ? sharedCount : 0,
+      tsCount: tsCount,
+      firstTs: firstTs,
     });
 
     // Build ALP bit map for interactive bit view (values only for alp-values)
     bitMap = buildALPBitMap(primaryBlob, includeTs ? tsBlob : null, sampleCount);
-
   } else {
     bytes = primaryBlob;
     var totalBytes = bytes.byteLength;
     var hdrLen = Math.min(18, totalBytes);
     var xorHdr = parseXORHeader(bytes);
-    var xorCount = xorHdr.count, xorFirstTs = xorHdr.firstTs, xorFirstVal = xorHdr.firstVal;
+    var xorCount = xorHdr.count,
+      xorFirstTs = xorHdr.firstTs,
+      xorFirstVal = xorHdr.firstVal;
     var streamBytes = totalBytes - hdrLen;
 
     regions.push({
-      name: 'Header (18 B)', cls: 'header', start: 0, end: hdrLen,
-      decode: function() {
-        return 'bytes 0\u20111: sample count = ' + xorCount +
-               '\nbytes 2\u20119: first timestamp (i64 BE)' +
-               '\n  ' + formatEpochNs(xorFirstTs) +
-               '\nbytes 10\u201317: first value (f64 BE)' +
-               '\n  ' + xorFirstVal.toPrecision(8);
-      }
+      name: "Header (18 B)",
+      cls: "header",
+      start: 0,
+      end: hdrLen,
+      decode: () =>
+        "bytes 0\u20111: sample count = " +
+        xorCount +
+        "\nbytes 2\u20119: first timestamp (i64 BE)" +
+        "\n  " +
+        formatEpochNs(xorFirstTs) +
+        "\nbytes 10\u201317: first value (f64 BE)" +
+        "\n  " +
+        xorFirstVal.toPrecision(8),
     });
     regions.push({
-      name: 'Interleaved \u0394\u0394ts + XOR values', cls: 'timestamps', start: hdrLen, end: totalBytes,
-      decode: function() {
-        var bps = xorCount > 1 ? (streamBytes * 8 / (xorCount - 1)).toFixed(1) : '-';
-        return streamBytes + ' bytes (' + (streamBytes * 8) + ' bits) for ' + (xorCount - 1) + ' samples' +
-               '\n\nPer sample, interleaved:' +
-               '\n  \u23f1 Timestamp \u0394\u0394: 0=same | 10+7b | 110+9b | 1110+12b | 1111+64b' +
-               '\n  \u2295 Value XOR: 0=same | 10=reuse window | 11+6b+6b=new window' +
-               '\n\n~' + bps + ' bits/sample total';
-      }
+      name: "Interleaved \u0394\u0394ts + XOR values",
+      cls: "timestamps",
+      start: hdrLen,
+      end: totalBytes,
+      decode: () => {
+        var bps = xorCount > 1 ? ((streamBytes * 8) / (xorCount - 1)).toFixed(1) : "-";
+        return (
+          streamBytes +
+          " bytes (" +
+          streamBytes * 8 +
+          " bits) for " +
+          (xorCount - 1) +
+          " samples" +
+          "\n\nPer sample, interleaved:" +
+          "\n  \u23f1 Timestamp \u0394\u0394: 0=same | 10+7b | 110+9b | 1110+12b | 1111+64b" +
+          "\n  \u2295 Value XOR: 0=same | 10=reuse window | 11+6b+6b=new window" +
+          "\n\n~" +
+          bps +
+          " bits/sample total"
+        );
+      },
     });
 
     insightHtml = buildXORInsightHtml({
-      count: xorCount, firstTs: xorFirstTs, firstVal: xorFirstVal, totalBytes: totalBytes
+      count: xorCount,
+      firstTs: xorFirstTs,
+      firstVal: xorFirstVal,
+      totalBytes: totalBytes,
     });
 
     // Build XOR bit map using annotated decoder
@@ -683,7 +901,7 @@ export function renderByteExplorer(primaryBlob, tsBlob, sharedCount, sampleCount
       var annotated = decodeChunkAnnotated(primaryBlob);
       bitMap = annotated.bitMap;
     } catch (e) {
-      console.warn('Annotated decode failed:', e);
+      console.warn("Annotated decode failed:", e);
     }
   }
 
@@ -696,42 +914,81 @@ export function renderByteExplorer(primaryBlob, tsBlob, sharedCount, sampleCount
   var totalRows = Math.ceil(bytes.length / HEX_COLS);
 
   function showRegionDetail(region) {
-    var detail = explorer.querySelector('#regionDetail');
+    var detail = explorer.querySelector("#regionDetail");
     detail.innerHTML =
       '<div class="region-detail-card">' +
-        '<h5><span class="region-badge ' + region.cls + '">' + region.name + '</span> ' + formatBytes(region.end - region.start) + ' \u00b7 bytes ' + region.start + '\u2013' + (region.end - 1) + '</h5>' +
-        '<div class="region-detail-grid">' +
-          '<div class="rd-item"><div class="rd-label">Offset</div><div class="rd-value">' + region.start + '</div></div>' +
-          '<div class="rd-item"><div class="rd-label">Length</div><div class="rd-value">' + (region.end - region.start) + '</div></div>' +
-          '<div class="rd-item"><div class="rd-label">% of total</div><div class="rd-value">' + ((region.end - region.start) / bytes.length * 100).toFixed(1) + '%</div></div>' +
-        '</div>' +
-        '<div style="margin-top:8px;font-size:11px;color:#6b8a9e;white-space:pre-line;line-height:1.5;font-family:\'IBM Plex Mono\',monospace">' + region.decode() + '</div>' +
-      '</div>';
+      '<h5><span class="region-badge ' +
+      region.cls +
+      '">' +
+      region.name +
+      "</span> " +
+      formatBytes(region.end - region.start) +
+      " \u00b7 bytes " +
+      region.start +
+      "\u2013" +
+      (region.end - 1) +
+      "</h5>" +
+      '<div class="region-detail-grid">' +
+      '<div class="rd-item"><div class="rd-label">Offset</div><div class="rd-value">' +
+      region.start +
+      "</div></div>" +
+      '<div class="rd-item"><div class="rd-label">Length</div><div class="rd-value">' +
+      (region.end - region.start) +
+      "</div></div>" +
+      '<div class="rd-item"><div class="rd-label">% of total</div><div class="rd-value">' +
+      (((region.end - region.start) / bytes.length) * 100).toFixed(1) +
+      "%</div></div>" +
+      "</div>" +
+      "<div style=\"margin-top:8px;font-size:11px;color:#6b8a9e;white-space:pre-line;line-height:1.5;font-family:'IBM Plex Mono',monospace\">" +
+      region.decode() +
+      "</div>" +
+      "</div>";
   }
 
-  _buildExplorerShell(explorer, bytes, '');
+  _buildExplorerShell(explorer, bytes, "");
   // Place codec insight in outer container (above byte layout) if available, else inside explorer
-  var insightTarget = document.getElementById('codecInsightOuter') || explorer.querySelector('#codecInsight');
+  var insightTarget =
+    document.getElementById("codecInsightOuter") || explorer.querySelector("#codecInsight");
   if (insightTarget) insightTarget.innerHTML = insightHtml;
   var viewport = _buildMinimap(explorer, bytes, regions, showRegionDetail);
   var hexContent = _renderHexContent(
-    explorer.querySelector('.hex-grid'),
-    explorer.querySelector('.hex-grid-scroll'),
-    bytes, byteRegion, regions, byteLookup, totalRows, viewport
+    explorer.querySelector(".hex-grid"),
+    explorer.querySelector(".hex-grid-scroll"),
+    bytes,
+    byteRegion,
+    regions,
+    byteLookup,
+    totalRows,
+    viewport
   );
   var highlightHexSample = _setupHexInteraction(
-    explorer, bytes, byteRegion, regions, byteLookup, hexContent, showRegionDetail
+    explorer,
+    bytes,
+    byteRegion,
+    regions,
+    byteLookup,
+    hexContent,
+    showRegionDetail
   );
   _setupViewModeButtons(
-    explorer, bytes, byteRegion, regions, sampleCount, codec, bitMap,
-    byteLookup, totalRows, hexContent, highlightHexSample
+    explorer,
+    bytes,
+    byteRegion,
+    regions,
+    sampleCount,
+    codec,
+    bitMap,
+    byteLookup,
+    totalRows,
+    hexContent,
+    highlightHexSample
   );
 }
 
 // ── Separate Timestamp Byte Explorer (for ALP column store) ──────────
 
 export function renderByteExplorerTs(tsBlob, sampleCount) {
-  var explorer = document.getElementById('byteExplorerTs');
+  var explorer = document.getElementById("byteExplorerTs");
   if (!explorer || !tsBlob || tsBlob.byteLength === 0) return;
 
   var bytes = new Uint8Array(tsBlob);
@@ -739,7 +996,8 @@ export function renderByteExplorerTs(tsBlob, sampleCount) {
   var regions = [];
   var bitMap = null;
 
-  var tsCount = 0, firstTs = 0n;
+  var tsCount = 0,
+    firstTs = 0n;
   if (totalBytes >= TS_HEADER_SIZE) {
     tsCount = (tsBlob[0] << 8) | tsBlob[1];
     firstTs = readI64BE(tsBlob, 2);
@@ -747,22 +1005,33 @@ export function renderByteExplorerTs(tsBlob, sampleCount) {
 
   var hdrEnd = Math.min(TS_HEADER_SIZE, totalBytes);
   regions.push({
-    name: 'Timestamp Header (10 B)', cls: 'timestamps', start: 0, end: hdrEnd,
-    decode: function() {
-      return 'bytes 0\u20111: count = ' + tsCount +
-             '\nbytes 2\u20119: first timestamp' +
-             '\n  ' + formatEpochNs(firstTs) +
-             '\n  epoch ns: ' + firstTs.toString();
-    }
+    name: "Timestamp Header (10 B)",
+    cls: "timestamps",
+    start: 0,
+    end: hdrEnd,
+    decode: () =>
+      "bytes 0\u20111: count = " +
+      tsCount +
+      "\nbytes 2\u20119: first timestamp" +
+      "\n  " +
+      formatEpochNs(firstTs) +
+      "\n  epoch ns: " +
+      firstTs.toString(),
   });
   if (totalBytes > TS_HEADER_SIZE) {
     regions.push({
-      name: 'Timestamp \u0394\u0394 Body', cls: 'timestamps', start: TS_HEADER_SIZE, end: totalBytes,
-      decode: function() {
+      name: "Timestamp \u0394\u0394 Body",
+      cls: "timestamps",
+      start: TS_HEADER_SIZE,
+      end: totalBytes,
+      decode: () => {
         var body = totalBytes - TS_HEADER_SIZE;
-        return body + ' bytes of delta-of-delta encoded timestamps' +
-               '\nGorilla: 0=same\u0394 | 10+7b | 110+9b | 1110+12b | 1111+64b';
-      }
+        return (
+          body +
+          " bytes of delta-of-delta encoded timestamps" +
+          "\nGorilla: 0=same\u0394 | 10+7b | 110+9b | 1110+12b | 1111+64b"
+        );
+      },
     });
   }
 
@@ -772,24 +1041,59 @@ export function renderByteExplorerTs(tsBlob, sampleCount) {
     var tsBitMap = [];
     tsR.readBitsNum(16);
     var firstTsVal = BigInt.asIntN(64, tsR.readBits(64));
-    tsBitMap.push({ sampleIndex: 0, type: 'timestamp', startBit: 0, endBit: 80, encoding: 'raw', decoded: firstTsVal });
-    var prevTs = firstTsVal, prevDelta = 0n;
+    tsBitMap.push({
+      sampleIndex: 0,
+      type: "timestamp",
+      startBit: 0,
+      endBit: 80,
+      encoding: "raw",
+      decoded: firstTsVal,
+    });
+    var prevTs = firstTsVal,
+      prevDelta = 0n;
     for (var i = 1; i < tsCount && i < sampleCount; i++) {
       var tsStart = tsR.totalBits;
       var dod, enc;
-      if (tsR.readBit() === 0) { dod = 0n; enc = 'dod-zero'; }
-      else if (tsR.readBit() === 0) { var zz = tsR.readBitsNum(7); dod = BigInt.asIntN(64, BigInt((zz >>> 1) ^ -(zz & 1))); enc = 'dod-7bit'; }
-      else if (tsR.readBit() === 0) { var zz2 = tsR.readBitsNum(9); dod = BigInt.asIntN(64, BigInt((zz2 >>> 1) ^ -(zz2 & 1))); enc = 'dod-9bit'; }
-      else if (tsR.readBit() === 0) { var zz3 = tsR.readBitsNum(12); dod = BigInt.asIntN(64, BigInt((zz3 >>> 1) ^ -(zz3 & 1))); enc = 'dod-12bit'; }
-      else { dod = BigInt.asIntN(64, tsR.readBits(64)); enc = 'dod-64bit'; }
+      if (tsR.readBit() === 0) {
+        dod = 0n;
+        enc = "dod-zero";
+        // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
+      } else if (tsR.readBit() === 0) {
+        var zz = tsR.readBitsNum(7);
+        dod = BigInt.asIntN(64, BigInt((zz >>> 1) ^ -(zz & 1)));
+        enc = "dod-7bit";
+        // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
+      } else if (tsR.readBit() === 0) {
+        var zz2 = tsR.readBitsNum(9);
+        dod = BigInt.asIntN(64, BigInt((zz2 >>> 1) ^ -(zz2 & 1)));
+        enc = "dod-9bit";
+        // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
+      } else if (tsR.readBit() === 0) {
+        var zz3 = tsR.readBitsNum(12);
+        dod = BigInt.asIntN(64, BigInt((zz3 >>> 1) ^ -(zz3 & 1)));
+        enc = "dod-12bit";
+      } else {
+        dod = BigInt.asIntN(64, tsR.readBits(64));
+        enc = "dod-64bit";
+      }
       var delta = prevDelta + dod;
       var ts = prevTs + delta;
-      prevDelta = delta; prevTs = ts;
-      tsBitMap.push({ sampleIndex: i, type: 'timestamp', startBit: tsStart, endBit: tsR.totalBits, encoding: enc, decoded: ts, dod: dod, delta: delta });
+      prevDelta = delta;
+      prevTs = ts;
+      tsBitMap.push({
+        sampleIndex: i,
+        type: "timestamp",
+        startBit: tsStart,
+        endBit: tsR.totalBits,
+        encoding: enc,
+        decoded: ts,
+        dod: dod,
+        delta: delta,
+      });
     }
     bitMap = tsBitMap;
   } catch (e) {
-    console.warn('Timestamp bit map failed:', e);
+    console.warn("Timestamp bit map failed:", e);
   }
 
   var byteRegion = buildByteRegionMap(regions, totalBytes);
@@ -797,58 +1101,100 @@ export function renderByteExplorerTs(tsBlob, sampleCount) {
   var totalRows = Math.ceil(totalBytes / HEX_COLS);
 
   function showRegionDetail(region) {
-    var detail = explorer.querySelector('#regionDetailTs');
+    var detail = explorer.querySelector("#regionDetailTs");
     if (!detail) return;
     detail.innerHTML =
       '<div class="region-detail-card">' +
-        '<h5><span class="region-badge ' + region.cls + '">' + region.name + '</span> ' + formatBytes(region.end - region.start) + ' \u00b7 bytes ' + region.start + '\u2013' + (region.end - 1) + '</h5>' +
-        '<div style="margin-top:8px;font-size:11px;color:#6b8a9e;white-space:pre-line;line-height:1.5;font-family:\'IBM Plex Mono\',monospace">' + region.decode() + '</div>' +
-      '</div>';
+      '<h5><span class="region-badge ' +
+      region.cls +
+      '">' +
+      region.name +
+      "</span> " +
+      formatBytes(region.end - region.start) +
+      " \u00b7 bytes " +
+      region.start +
+      "\u2013" +
+      (region.end - 1) +
+      "</h5>" +
+      "<div style=\"margin-top:8px;font-size:11px;color:#6b8a9e;white-space:pre-line;line-height:1.5;font-family:'IBM Plex Mono',monospace\">" +
+      region.decode() +
+      "</div>" +
+      "</div>";
   }
 
   // Build shell
-  var viewId = 'hexViewTs-' + Date.now();
+  var viewId = `hexViewTs-${Date.now()}`;
   explorer.innerHTML =
     '<div class="byte-explorer-header">' +
-      '<h4>\uD83D\uDD2C Timestamp Explorer <span style="font-weight:400;color:#6b8a9e;font-size:11px">' + formatBytes(totalBytes) + ' \u00b7 ' + totalBytes.toLocaleString() + ' bytes</span></h4>' +
-      '<div class="byte-explorer-controls">' +
-        '<button class="active" data-view="hex">Hex</button>' +
-        '<button data-view="decimal">Dec</button>' +
-        '<button data-view="bits">Bits</button>' +
-      '</div>' +
-    '</div>' +
+    '<h4>\uD83D\uDD2C Timestamp Explorer <span style="font-weight:400;color:#6b8a9e;font-size:11px">' +
+    formatBytes(totalBytes) +
+    " \u00b7 " +
+    totalBytes.toLocaleString() +
+    " bytes</span></h4>" +
+    '<div class="byte-explorer-controls">' +
+    '<button class="active" data-view="hex">Hex</button>' +
+    '<button data-view="decimal">Dec</button>' +
+    '<button data-view="bits">Bits</button>' +
+    "</div>" +
+    "</div>" +
     '<div class="byte-minimap" id="byteMinimapTs"></div>' +
-    '<div class="hex-grid-scroll" id="' + viewId + '">' +
-      '<div class="hex-grid" id="hexGridTs" style="grid-template-columns: 56px repeat(' + HEX_COLS + ', minmax(0, 1fr)) minmax(0, 220px);"></div>' +
-    '</div>' +
+    '<div class="hex-grid-scroll" id="' +
+    viewId +
+    '">' +
+    '<div class="hex-grid" id="hexGridTs" style="grid-template-columns: 56px repeat(' +
+    HEX_COLS +
+    ', minmax(0, 1fr)) minmax(0, 220px);"></div>' +
+    "</div>" +
     '<div class="hex-decode-panel" id="hexDecodePanelTs" style="display:none"></div>' +
     '<div id="regionDetailTs"></div>';
 
   // Build minimap
-  var minimap = explorer.querySelector('.byte-minimap');
-  regions.forEach(function(r) {
-    var seg = document.createElement('div');
-    seg.className = 'mm-seg';
-    seg.style.width = Math.max(1, ((r.end - r.start) / totalBytes) * 100) + '%';
-    seg.style.background = '#06b6d4';
-    seg.title = r.name + ': ' + formatBytes(r.end - r.start);
-    seg.addEventListener('click', function() { showRegionDetail(r); });
+  var minimap = explorer.querySelector(".byte-minimap");
+  regions.forEach((r) => {
+    var seg = document.createElement("div");
+    seg.className = "mm-seg";
+    seg.style.width = `${Math.max(1, ((r.end - r.start) / totalBytes) * 100)}%`;
+    seg.style.background = "#06b6d4";
+    seg.title = `${r.name}: ${formatBytes(r.end - r.start)}`;
+    seg.addEventListener("click", () => {
+      showRegionDetail(r);
+    });
     minimap.appendChild(seg);
   });
-  var viewport = document.createElement('div');
-  viewport.className = 'mm-viewport';
+  var viewport = document.createElement("div");
+  viewport.className = "mm-viewport";
   minimap.appendChild(viewport);
 
   var hexContent = _renderHexContent(
-    explorer.querySelector('.hex-grid'),
-    explorer.querySelector('.hex-grid-scroll'),
-    bytes, byteRegion, regions, byteLookup, totalRows, viewport
+    explorer.querySelector(".hex-grid"),
+    explorer.querySelector(".hex-grid-scroll"),
+    bytes,
+    byteRegion,
+    regions,
+    byteLookup,
+    totalRows,
+    viewport
   );
   var highlightHexSample = _setupHexInteraction(
-    explorer, bytes, byteRegion, regions, byteLookup, hexContent, showRegionDetail
+    explorer,
+    bytes,
+    byteRegion,
+    regions,
+    byteLookup,
+    hexContent,
+    showRegionDetail
   );
   _setupViewModeButtons(
-    explorer, bytes, byteRegion, regions, sampleCount, 'xor', bitMap,
-    byteLookup, totalRows, hexContent, highlightHexSample
+    explorer,
+    bytes,
+    byteRegion,
+    regions,
+    sampleCount,
+    "xor",
+    bitMap,
+    byteLookup,
+    totalRows,
+    hexContent,
+    highlightHexSample
   );
 }

--- a/site/tsdb-engine/js/chart.js
+++ b/site/tsdb-engine/js/chart.js
@@ -1,11 +1,23 @@
 // ── Chart Renderer ───────────────────────────────────────────────────
 
-import { $, formatNum, setupCanvasDPR } from './utils.js';
+import { $, formatNum, setupCanvasDPR } from "./utils.js";
 
 export const CHART_COLORS = [
-  '#3b82f6', '#ef4444', '#10b981', '#f59e0b', '#8b5cf6',
-  '#ec4899', '#06b6d4', '#84cc16', '#f97316', '#6366f1',
-  '#14b8a6', '#e11d48', '#a855f7', '#0ea5e9', '#eab308',
+  "#3b82f6",
+  "#ef4444",
+  "#10b981",
+  "#f59e0b",
+  "#8b5cf6",
+  "#ec4899",
+  "#06b6d4",
+  "#84cc16",
+  "#f97316",
+  "#6366f1",
+  "#14b8a6",
+  "#e11d48",
+  "#a855f7",
+  "#0ea5e9",
+  "#eab308",
 ];
 
 export let lastChartState = null;
@@ -23,7 +35,10 @@ export function renderChart(canvas, seriesData, title) {
   const plotW = w - pad.left - pad.right;
   const plotH = h - pad.top - pad.bottom;
 
-  let minT = Infinity, maxT = -Infinity, minV = Infinity, maxV = -Infinity;
+  let minT = Infinity,
+    maxT = -Infinity,
+    minV = Infinity,
+    maxV = -Infinity;
   for (const s of seriesData) {
     for (let i = 0; i < s.timestamps.length; i++) {
       const t = Number(s.timestamps[i]);
@@ -35,7 +50,10 @@ export function renderChart(canvas, seriesData, title) {
     }
   }
 
-  if (minV === maxV) { minV -= 1; maxV += 1; }
+  if (minV === maxV) {
+    minV -= 1;
+    maxV += 1;
+  }
   const vPad = (maxV - minV) * 0.08;
   minV -= vPad;
   maxV += vPad;
@@ -44,15 +62,15 @@ export function renderChart(canvas, seriesData, title) {
   const vRange = maxV - minV || 1;
 
   // Background
-  ctx.fillStyle = '#ffffff';
+  ctx.fillStyle = "#ffffff";
   ctx.fillRect(0, 0, w, h);
 
   // Grid
-  ctx.strokeStyle = 'rgba(0,0,0,0.06)';
+  ctx.strokeStyle = "rgba(0,0,0,0.06)";
   ctx.lineWidth = 1;
   const yTicks = 6;
   for (let i = 0; i <= yTicks; i++) {
-    const y = pad.top + (plotH * i / yTicks);
+    const y = pad.top + (plotH * i) / yTicks;
     ctx.beginPath();
     ctx.moveTo(pad.left, y);
     ctx.lineTo(w - pad.right, y);
@@ -61,7 +79,7 @@ export function renderChart(canvas, seriesData, title) {
 
   const xTicks = Math.min(8, seriesData[0]?.timestamps.length || 8);
   for (let i = 0; i <= xTicks; i++) {
-    const x = pad.left + (plotW * i / xTicks);
+    const x = pad.left + (plotW * i) / xTicks;
     ctx.beginPath();
     ctx.moveTo(x, pad.top);
     ctx.lineTo(x, h - pad.bottom);
@@ -69,39 +87,43 @@ export function renderChart(canvas, seriesData, title) {
   }
 
   // Y-axis labels
-  ctx.fillStyle = '#6b8a9e';
+  ctx.fillStyle = "#6b8a9e";
   ctx.font = '11px "IBM Plex Mono", monospace';
-  ctx.textAlign = 'right';
-  ctx.textBaseline = 'middle';
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
   for (let i = 0; i <= yTicks; i++) {
-    const y = pad.top + (plotH * i / yTicks);
+    const y = pad.top + (plotH * i) / yTicks;
     const val = maxV - (i / yTicks) * vRange;
     ctx.fillText(formatNum(val), pad.left - 8, y);
   }
 
   // X-axis labels
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'top';
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
   for (let i = 0; i <= xTicks; i++) {
-    const x = pad.left + (plotW * i / xTicks);
+    const x = pad.left + (plotW * i) / xTicks;
     const tNs = minT + (i / xTicks) * tRange;
     const tMs = tNs / 1_000_000;
     const d = new Date(tMs);
-    ctx.fillText(d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }), x, h - pad.bottom + 8);
+    ctx.fillText(
+      d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" }),
+      x,
+      h - pad.bottom + 8
+    );
   }
 
   // Title
-  ctx.fillStyle = '#0f3a5e';
+  ctx.fillStyle = "#0f3a5e";
   ctx.font = '600 14px "Space Grotesk", sans-serif';
-  ctx.textAlign = 'left';
-  ctx.textBaseline = 'top';
-  ctx.fillText(title || 'Query Results', pad.left, 10);
+  ctx.textAlign = "left";
+  ctx.textBaseline = "top";
+  ctx.fillText(title || "Query Results", pad.left, 10);
 
   // Point count
   const totalPoints = seriesData.reduce((s, d) => s + d.timestamps.length, 0);
-  ctx.fillStyle = '#6b8a9e';
+  ctx.fillStyle = "#6b8a9e";
   ctx.font = '11px "IBM Plex Mono", monospace';
-  ctx.textAlign = 'right';
+  ctx.textAlign = "right";
   ctx.fillText(`${totalPoints.toLocaleString()} points rendered`, w - pad.right, 12);
 
   // Draw series
@@ -111,19 +133,23 @@ export function renderChart(canvas, seriesData, title) {
 
     // Area fill
     ctx.beginPath();
-    let firstX, firstY;
+    let firstX, _firstY;
     for (let i = 0; i < s.timestamps.length; i++) {
       const x = pad.left + ((Number(s.timestamps[i]) - minT) / tRange) * plotW;
       const y = pad.top + ((maxV - s.values[i]) / vRange) * plotH;
-      if (i === 0) { ctx.moveTo(x, y); firstX = x; firstY = y; }
-      else ctx.lineTo(x, y);
+      if (i === 0) {
+        ctx.moveTo(x, y);
+        firstX = x;
+        _firstY = y;
+      } else ctx.lineTo(x, y);
     }
     if (s.timestamps.length > 0) {
-      const lastX = pad.left + ((Number(s.timestamps[s.timestamps.length - 1]) - minT) / tRange) * plotW;
+      const lastX =
+        pad.left + ((Number(s.timestamps[s.timestamps.length - 1]) - minT) / tRange) * plotW;
       ctx.lineTo(lastX, pad.top + plotH);
       ctx.lineTo(firstX, pad.top + plotH);
       ctx.closePath();
-      ctx.fillStyle = color + '12';
+      ctx.fillStyle = `${color}12`;
       ctx.fill();
     }
 
@@ -132,16 +158,17 @@ export function renderChart(canvas, seriesData, title) {
     for (let i = 0; i < s.timestamps.length; i++) {
       const x = pad.left + ((Number(s.timestamps[i]) - minT) / tRange) * plotW;
       const y = pad.top + ((maxV - s.values[i]) / vRange) * plotH;
-      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
     }
     ctx.strokeStyle = color;
     ctx.lineWidth = 2;
-    ctx.lineJoin = 'round';
+    ctx.lineJoin = "round";
     ctx.stroke();
   }
 
   // Axes border
-  ctx.strokeStyle = 'rgba(0,0,0,0.15)';
+  ctx.strokeStyle = "rgba(0,0,0,0.15)";
   ctx.lineWidth = 1;
   ctx.beginPath();
   ctx.moveTo(pad.left, pad.top);
@@ -156,32 +183,49 @@ export function setupChartTooltip() {
   if (tooltipController) tooltipController.abort();
   tooltipController = new AbortController();
 
-  const canvas = $('#chartCanvas');
-  const container = canvas.closest('.chart-container');
-  container.style.position = 'relative';
+  const canvas = $("#chartCanvas");
+  const container = canvas.closest(".chart-container");
+  container.style.position = "relative";
 
   if (!crosshairEl) {
-    crosshairEl = document.createElement('div');
-    crosshairEl.className = 'chart-crosshair';
+    crosshairEl = document.createElement("div");
+    crosshairEl.className = "chart-crosshair";
     container.appendChild(crosshairEl);
   }
   if (!tooltipEl) {
-    tooltipEl = document.createElement('div');
-    tooltipEl.className = 'chart-tooltip';
+    tooltipEl = document.createElement("div");
+    tooltipEl.className = "chart-tooltip";
     container.appendChild(tooltipEl);
   }
 
   const opts = { signal: tooltipController.signal };
-  canvas.addEventListener('mousemove', handleChartHover, opts);
-  canvas.addEventListener('mouseleave', () => {
-    if (crosshairEl) crosshairEl.style.display = 'none';
-    if (tooltipEl) tooltipEl.style.display = 'none';
-  }, opts);
+  canvas.addEventListener("mousemove", handleChartHover, opts);
+  canvas.addEventListener(
+    "mouseleave",
+    () => {
+      if (crosshairEl) crosshairEl.style.display = "none";
+      if (tooltipEl) tooltipEl.style.display = "none";
+    },
+    opts
+  );
 }
 
 function handleChartHover(e) {
   if (!lastChartState || !tooltipEl || !crosshairEl) return;
-  const { seriesData, minT, maxT, pad, w, h, plotW, plotH, tRange, vRange, minV, maxV } = lastChartState;
+  const {
+    seriesData,
+    minT,
+    maxT: _maxT,
+    pad,
+    w,
+    h,
+    plotW,
+    plotH,
+    tRange,
+    vRange,
+    minV: _minV,
+    maxV,
+  } = lastChartState;
   const canvas = e.target;
   const rect = canvas.getBoundingClientRect();
   const scaleX = canvas.clientWidth / lastChartState.w;
@@ -190,8 +234,8 @@ function handleChartHover(e) {
   const my = (e.clientY - rect.top) / scaleY;
 
   if (mx < pad.left || mx > w - pad.right || my < pad.top || my > h - pad.bottom) {
-    crosshairEl.style.display = 'none';
-    tooltipEl.style.display = 'none';
+    crosshairEl.style.display = "none";
+    tooltipEl.style.display = "none";
     return;
   }
 
@@ -201,21 +245,29 @@ function handleChartHover(e) {
   for (let si = 0; si < seriesData.length; si++) {
     const s = seriesData[si];
     if (s.timestamps.length === 0) continue;
-    let lo = 0, hi = s.timestamps.length - 1;
+    let lo = 0,
+      hi = s.timestamps.length - 1;
     while (lo < hi) {
       const mid = (lo + hi) >>> 1;
-      if (Number(s.timestamps[mid]) < mouseT) lo = mid + 1; else hi = mid;
+      if (Number(s.timestamps[mid]) < mouseT) lo = mid + 1;
+      else hi = mid;
     }
     let nearest = lo;
-    if (lo > 0 && Math.abs(Number(s.timestamps[lo - 1]) - mouseT) < Math.abs(Number(s.timestamps[lo]) - mouseT)) {
+    if (
+      lo > 0 &&
+      Math.abs(Number(s.timestamps[lo - 1]) - mouseT) < Math.abs(Number(s.timestamps[lo]) - mouseT)
+    ) {
       nearest = lo - 1;
     }
     const labelStr = s.labels
-      ? [...s.labels].filter(([k]) => k !== '__name__').map(([k, v]) => `${k}="${v}"`).join(', ')
+      ? [...s.labels]
+          .filter(([k]) => k !== "__name__")
+          .map(([k, v]) => `${k}="${v}"`)
+          .join(", ")
       : `series ${si}`;
     points.push({
       value: s.values[nearest],
-      label: labelStr || 'all',
+      label: labelStr || "all",
       color: CHART_COLORS[si % CHART_COLORS.length],
       timestamp: Number(s.timestamps[nearest]),
       y: pad.top + ((maxV - s.values[nearest]) / vRange) * plotH,
@@ -227,23 +279,26 @@ function handleChartHover(e) {
   const cssLeft = mx * scaleX;
   const cssTop = pad.top * scaleY;
   const cssHeight = plotH * scaleY;
-  crosshairEl.style.display = 'block';
-  crosshairEl.style.left = cssLeft + 'px';
-  crosshairEl.style.top = cssTop + 'px';
-  crosshairEl.style.height = cssHeight + 'px';
+  crosshairEl.style.display = "block";
+  crosshairEl.style.left = `${cssLeft}px`;
+  crosshairEl.style.top = `${cssTop}px`;
+  crosshairEl.style.height = `${cssHeight}px`;
 
   const time = new Date(points[0].timestamp / 1_000_000);
-  let html = `<div class="tooltip-time">${time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}</div>`;
+  let html = `<div class="tooltip-time">${time.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}</div>`;
   for (const p of points) {
     html += `<div class="tooltip-row"><span class="tooltip-swatch" style="background:${p.color}"></span><span class="tooltip-label">${p.label}</span><strong>${p.value.toFixed(2)}</strong></div>`;
   }
   tooltipEl.innerHTML = html;
-  tooltipEl.style.display = 'block';
+  tooltipEl.style.display = "block";
 
   const tooltipW = tooltipEl.offsetWidth;
-  const containerW = canvas.closest('.chart-container').offsetWidth;
+  const containerW = canvas.closest(".chart-container").offsetWidth;
   const left = cssLeft + 20 + tooltipW > containerW ? cssLeft - tooltipW - 12 : cssLeft + 20;
-  const top = Math.max(4, (e.clientY - canvas.closest('.chart-container').getBoundingClientRect().top) - 30);
-  tooltipEl.style.left = left + 'px';
-  tooltipEl.style.top = top + 'px';
+  const top = Math.max(
+    4,
+    e.clientY - canvas.closest(".chart-container").getBoundingClientRect().top - 30
+  );
+  tooltipEl.style.left = `${left}px`;
+  tooltipEl.style.top = `${top}px`;
 }

--- a/site/tsdb-engine/js/codec.js
+++ b/site/tsdb-engine/js/codec.js
@@ -11,32 +11,66 @@ export function floatToBits(f) {
 }
 
 export function bitsToFloat(bits) {
-  f64View.setUint32(0, Number((bits >> 32n) & 0xFFFFFFFFn), false);
-  f64View.setUint32(4, Number(bits & 0xFFFFFFFFn), false);
+  f64View.setUint32(0, Number((bits >> 32n) & 0xffffffffn), false);
+  f64View.setUint32(4, Number(bits & 0xffffffffn), false);
   return f64View.getFloat64(0, false);
 }
 
 export function clz64(x) {
   if (x === 0n) return 64;
   let n = 0;
-  if ((x & 0xFFFFFFFF00000000n) === 0n) { n += 32; x <<= 32n; }
-  if ((x & 0xFFFF000000000000n) === 0n) { n += 16; x <<= 16n; }
-  if ((x & 0xFF00000000000000n) === 0n) { n += 8; x <<= 8n; }
-  if ((x & 0xF000000000000000n) === 0n) { n += 4; x <<= 4n; }
-  if ((x & 0xC000000000000000n) === 0n) { n += 2; x <<= 2n; }
-  if ((x & 0x8000000000000000n) === 0n) { n += 1; }
+  if ((x & 0xffffffff00000000n) === 0n) {
+    n += 32;
+    x <<= 32n;
+  }
+  if ((x & 0xffff000000000000n) === 0n) {
+    n += 16;
+    x <<= 16n;
+  }
+  if ((x & 0xff00000000000000n) === 0n) {
+    n += 8;
+    x <<= 8n;
+  }
+  if ((x & 0xf000000000000000n) === 0n) {
+    n += 4;
+    x <<= 4n;
+  }
+  if ((x & 0xc000000000000000n) === 0n) {
+    n += 2;
+    x <<= 2n;
+  }
+  if ((x & 0x8000000000000000n) === 0n) {
+    n += 1;
+  }
   return n;
 }
 
 export function ctz64(x) {
   if (x === 0n) return 64;
   let n = 0;
-  if ((x & 0xFFFFFFFFn) === 0n) { n += 32; x >>= 32n; }
-  if ((x & 0xFFFFn) === 0n) { n += 16; x >>= 16n; }
-  if ((x & 0xFFn) === 0n) { n += 8; x >>= 8n; }
-  if ((x & 0xFn) === 0n) { n += 4; x >>= 4n; }
-  if ((x & 0x3n) === 0n) { n += 2; x >>= 2n; }
-  if ((x & 0x1n) === 0n) { n += 1; }
+  if ((x & 0xffffffffn) === 0n) {
+    n += 32;
+    x >>= 32n;
+  }
+  if ((x & 0xffffn) === 0n) {
+    n += 16;
+    x >>= 16n;
+  }
+  if ((x & 0xffn) === 0n) {
+    n += 8;
+    x >>= 8n;
+  }
+  if ((x & 0xfn) === 0n) {
+    n += 4;
+    x >>= 4n;
+  }
+  if ((x & 0x3n) === 0n) {
+    n += 2;
+    x >>= 2n;
+  }
+  if ((x & 0x1n) === 0n) {
+    n += 1;
+  }
   return n;
 }
 
@@ -54,7 +88,10 @@ export class BitWriter {
     }
     if (bit) this.buf[this.bytePos] |= 0x80 >>> this.bitPos;
     this.bitPos++;
-    if (this.bitPos === 8) { this.bitPos = 0; this.bytePos++; }
+    if (this.bitPos === 8) {
+      this.bitPos = 0;
+      this.bytePos++;
+    }
   }
   writeBits(value, count) {
     for (let i = count - 1; i >= 0; i--) this.writeBit(Number((value >> BigInt(i)) & 1n));
@@ -73,11 +110,18 @@ export class BitWriter {
 }
 
 export class BitReader {
-  constructor(buf) { this.buf = buf; this.bytePos = 0; this.bitPos = 0; }
+  constructor(buf) {
+    this.buf = buf;
+    this.bytePos = 0;
+    this.bitPos = 0;
+  }
   readBit() {
     const bit = (this.buf[this.bytePos] >>> (7 - this.bitPos)) & 1;
     this.bitPos++;
-    if (this.bitPos === 8) { this.bitPos = 0; this.bytePos++; }
+    if (this.bitPos === 8) {
+      this.bitPos = 0;
+      this.bytePos++;
+    }
     return bit;
   }
   readBits(count) {
@@ -101,12 +145,15 @@ export function encodeChunk(timestamps, values) {
   if (n === 0) return new Uint8Array(0);
   const w = new BitWriter(n * 2);
   w.writeBitsNum(n, 16);
-  w.writeBits(BigInt(timestamps[0]) & 0xFFFFFFFFFFFFFFFFn, 64);
+  w.writeBits(BigInt(timestamps[0]) & 0xffffffffffffffffn, 64);
   w.writeBits(floatToBits(values[0]), 64);
   if (n === 1) return w.finish();
 
-  let prevTs = timestamps[0], prevDelta = 0n;
-  let prevValBits = floatToBits(values[0]), prevLeading = 64, prevTrailing = 0;
+  let prevTs = timestamps[0],
+    prevDelta = 0n;
+  let prevValBits = floatToBits(values[0]),
+    prevLeading = 64,
+    prevTrailing = 0;
 
   for (let i = 1; i < n; i++) {
     const ts = timestamps[i];
@@ -118,16 +165,25 @@ export function encodeChunk(timestamps, values) {
     } else {
       const absDod = dod < 0n ? -dod : dod;
       if (absDod <= 64n) {
-        w.writeBit(1); w.writeBit(0);
-        w.writeBitsNum(Number((dod << 1n) ^ (dod >> 63n)) & 0x7F, 7);
+        w.writeBit(1);
+        w.writeBit(0);
+        w.writeBitsNum(Number((dod << 1n) ^ (dod >> 63n)) & 0x7f, 7);
       } else if (absDod <= 256n) {
-        w.writeBit(1); w.writeBit(1); w.writeBit(0);
-        w.writeBitsNum(Number((dod << 1n) ^ (dod >> 63n)) & 0x1FF, 9);
+        w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(0);
+        w.writeBitsNum(Number((dod << 1n) ^ (dod >> 63n)) & 0x1ff, 9);
       } else if (absDod <= 2048n) {
-        w.writeBit(1); w.writeBit(1); w.writeBit(1); w.writeBit(0);
-        w.writeBitsNum(Number((dod << 1n) ^ (dod >> 63n)) & 0xFFF, 12);
+        w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(0);
+        w.writeBitsNum(Number((dod << 1n) ^ (dod >> 63n)) & 0xfff, 12);
       } else {
-        w.writeBit(1); w.writeBit(1); w.writeBit(1); w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(1);
         w.writeBits(BigInt.asUintN(64, dod), 64);
       }
     }
@@ -143,11 +199,13 @@ export function encodeChunk(timestamps, values) {
       const trailing = ctz64(xor);
       const meaningful = 64 - leading - trailing;
       if (leading >= prevLeading && trailing >= prevTrailing) {
-        w.writeBit(1); w.writeBit(0);
+        w.writeBit(1);
+        w.writeBit(0);
         const prevMeaningful = 64 - prevLeading - prevTrailing;
         w.writeBits(xor >> BigInt(prevTrailing), prevMeaningful);
       } else {
-        w.writeBit(1); w.writeBit(1);
+        w.writeBit(1);
+        w.writeBit(1);
         w.writeBitsNum(leading, 6);
         w.writeBitsNum(meaningful - 1, 6);
         w.writeBits(xor >> BigInt(trailing), meaningful);
@@ -170,19 +228,25 @@ export function decodeChunk(buf) {
   values[0] = bitsToFloat(r.readBits(64));
   if (n === 1) return { timestamps, values };
 
-  let prevTs = timestamps[0], prevDelta = 0n;
-  let prevValBits = floatToBits(values[0]), prevLeading = 0, prevTrailing = 0;
+  let prevTs = timestamps[0],
+    prevDelta = 0n;
+  let prevValBits = floatToBits(values[0]),
+    prevLeading = 0,
+    prevTrailing = 0;
 
   for (let i = 1; i < n; i++) {
     let dod;
     if (r.readBit() === 0) {
       dod = 0n;
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
     } else if (r.readBit() === 0) {
       const zz = r.readBitsNum(7);
       dod = BigInt.asIntN(64, BigInt((zz >>> 1) ^ -(zz & 1)));
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
     } else if (r.readBit() === 0) {
       const zz = r.readBitsNum(9);
       dod = BigInt.asIntN(64, BigInt((zz >>> 1) ^ -(zz & 1)));
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
     } else if (r.readBit() === 0) {
       const zz = r.readBitsNum(12);
       dod = BigInt.asIntN(64, BigInt((zz >>> 1) ^ -(zz & 1)));
@@ -196,6 +260,7 @@ export function decodeChunk(buf) {
 
     if (r.readBit() === 0) {
       values[i] = bitsToFloat(prevValBits);
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
     } else if (r.readBit() === 0) {
       const meaningful = 64 - prevLeading - prevTrailing;
       const xor = r.readBits(meaningful) << BigInt(prevTrailing);
@@ -231,7 +296,7 @@ export function decodeChunkAnnotated(buf) {
   const bitMap = [];
 
   // Header: 16 bits count
-  const headerEnd = r.totalBits; // 16
+  const _headerEnd = r.totalBits; // 16
 
   // Sample 0: raw ts (64 bits) + raw value (64 bits)
   const ts0Start = r.totalBits;
@@ -244,14 +309,23 @@ export function decodeChunkAnnotated(buf) {
 
   bitMap.push({
     sampleIndex: 0,
-    timestamp: { startBit: ts0Start, endBit: ts0End, encoding: 'raw', bits: 64, decoded: timestamps[0] },
-    value: { startBit: val0Start, endBit: val0End, encoding: 'raw', bits: 64, decoded: values[0] },
+    timestamp: {
+      startBit: ts0Start,
+      endBit: ts0End,
+      encoding: "raw",
+      bits: 64,
+      decoded: timestamps[0],
+    },
+    value: { startBit: val0Start, endBit: val0End, encoding: "raw", bits: 64, decoded: values[0] },
   });
 
   if (n === 1) return { timestamps, values, bitMap };
 
-  let prevTs = timestamps[0], prevDelta = 0n;
-  let prevValBits = floatToBits(values[0]), prevLeading = 0, prevTrailing = 0;
+  let prevTs = timestamps[0],
+    prevDelta = 0n;
+  let prevValBits = floatToBits(values[0]),
+    prevLeading = 0,
+    prevTrailing = 0;
 
   for (let i = 1; i < n; i++) {
     // ── Timestamp ──
@@ -261,26 +335,29 @@ export function decodeChunkAnnotated(buf) {
     let tsBits;
     if (r.readBit() === 0) {
       dod = 0n;
-      tsEncoding = 'dod-zero';
+      tsEncoding = "dod-zero";
       tsBits = 1;
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
     } else if (r.readBit() === 0) {
       const zz = r.readBitsNum(7);
       dod = BigInt.asIntN(64, BigInt((zz >>> 1) ^ -(zz & 1)));
-      tsEncoding = 'dod-7bit';
+      tsEncoding = "dod-7bit";
       tsBits = 9; // 2 prefix + 7 data
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
     } else if (r.readBit() === 0) {
       const zz = r.readBitsNum(9);
       dod = BigInt.asIntN(64, BigInt((zz >>> 1) ^ -(zz & 1)));
-      tsEncoding = 'dod-9bit';
+      tsEncoding = "dod-9bit";
       tsBits = 12; // 3 prefix + 9 data
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
     } else if (r.readBit() === 0) {
       const zz = r.readBitsNum(12);
       dod = BigInt.asIntN(64, BigInt((zz >>> 1) ^ -(zz & 1)));
-      tsEncoding = 'dod-12bit';
+      tsEncoding = "dod-12bit";
       tsBits = 16; // 4 prefix + 12 data
     } else {
       dod = BigInt.asIntN(64, r.readBits(64));
-      tsEncoding = 'dod-64bit';
+      tsEncoding = "dod-64bit";
       tsBits = 68; // 4 prefix + 64 data
     }
     const delta = prevDelta + dod;
@@ -294,18 +371,21 @@ export function decodeChunkAnnotated(buf) {
     let valEncoding;
     let valBits;
     let xorBits = 0n;
-    let leading = 0, trailing = 0, meaningful = 0;
+    let leading = 0,
+      trailing = 0,
+      meaningful = 0;
 
     if (r.readBit() === 0) {
       values[i] = bitsToFloat(prevValBits);
-      valEncoding = 'xor-zero';
+      valEncoding = "xor-zero";
       valBits = 1;
+      // biome-ignore lint/suspicious/noDuplicateElseIf: intentional bit-width dispatch
     } else if (r.readBit() === 0) {
       meaningful = 64 - prevLeading - prevTrailing;
       xorBits = r.readBits(meaningful) << BigInt(prevTrailing);
       prevValBits ^= xorBits;
       values[i] = bitsToFloat(prevValBits);
-      valEncoding = 'xor-reuse';
+      valEncoding = "xor-reuse";
       valBits = 2 + meaningful;
       leading = prevLeading;
       trailing = prevTrailing;
@@ -316,7 +396,7 @@ export function decodeChunkAnnotated(buf) {
       xorBits = r.readBits(meaningful) << BigInt(trailing);
       prevValBits ^= xorBits;
       values[i] = bitsToFloat(prevValBits);
-      valEncoding = 'xor-new';
+      valEncoding = "xor-new";
       valBits = 2 + 6 + 6 + meaningful;
       prevLeading = leading;
       prevTrailing = trailing;
@@ -326,13 +406,24 @@ export function decodeChunkAnnotated(buf) {
     bitMap.push({
       sampleIndex: i,
       timestamp: {
-        startBit: tsStart, endBit: tsEnd, encoding: tsEncoding,
-        bits: tsBits, decoded: timestamps[i], dod: dod, delta: delta,
+        startBit: tsStart,
+        endBit: tsEnd,
+        encoding: tsEncoding,
+        bits: tsBits,
+        decoded: timestamps[i],
+        dod: dod,
+        delta: delta,
       },
       value: {
-        startBit: valStart, endBit: valEnd, encoding: valEncoding,
-        bits: valBits, decoded: values[i], xor: xorBits,
-        leading, trailing, meaningful,
+        startBit: valStart,
+        endBit: valEnd,
+        encoding: valEncoding,
+        bits: valBits,
+        decoded: values[i],
+        xor: xorBits,
+        leading,
+        trailing,
+        meaningful,
       },
     });
   }

--- a/site/tsdb-engine/js/data-gen.js
+++ b/site/tsdb-engine/js/data-gen.js
@@ -17,7 +17,6 @@ export const METRICS = ["http_requests_total", "cpu_usage_percent", "memory_usag
 
 export function generateValue(pattern, i, seriesIdx, total) {
   const phase = seriesIdx * 0.7;
-  const _t = i / total;
   switch (pattern) {
     case "sine":
       return (

--- a/site/tsdb-engine/js/data-gen.js
+++ b/site/tsdb-engine/js/data-gen.js
@@ -1,35 +1,49 @@
 // ── Data Generators ──────────────────────────────────────────────────
 
-export const REGIONS = ['us-east', 'us-west', 'eu-west', 'ap-south', 'ap-east'];
-export const INSTANCES = ['web-01', 'web-02', 'web-03', 'api-01', 'api-02', 'worker-01', 'worker-02', 'cache-01', 'db-01', 'db-02'];
-export const METRICS = [
-  'http_requests_total',
-  'cpu_usage_percent',
-  'memory_usage_bytes',
+export const REGIONS = ["us-east", "us-west", "eu-west", "ap-south", "ap-east"];
+export const INSTANCES = [
+  "web-01",
+  "web-02",
+  "web-03",
+  "api-01",
+  "api-02",
+  "worker-01",
+  "worker-02",
+  "cache-01",
+  "db-01",
+  "db-02",
 ];
+export const METRICS = ["http_requests_total", "cpu_usage_percent", "memory_usage_bytes"];
 
 export function generateValue(pattern, i, seriesIdx, total) {
-  const phase = (seriesIdx * 0.7);
-  const t = i / total;
+  const phase = seriesIdx * 0.7;
+  const _t = i / total;
   switch (pattern) {
-    case 'sine':
-      return 100 + Math.sin((i / 50) + phase) * 40 + Math.sin((i / 200) + phase) * 20 + (Math.random() - 0.5) * 8;
-    case 'sawtooth':
+    case "sine":
+      return (
+        100 +
+        Math.sin(i / 50 + phase) * 40 +
+        Math.sin(i / 200 + phase) * 20 +
+        (Math.random() - 0.5) * 8
+      );
+    case "sawtooth":
       return ((i + seriesIdx * 100) % 200) + Math.random() * 5;
-    case 'random-walk': {
+    case "random-walk": {
       const seed = seriesIdx * 7919 + 1;
-      const v = 50 + seriesIdx * 10
-        + Math.sin(i * 0.01 + seed) * 30
-        + Math.sin(i * 0.003 + seed * 1.7) * 20
-        + Math.cos(i * 0.0007 + seed * 2.3) * 15;
+      const v =
+        50 +
+        seriesIdx * 10 +
+        Math.sin(i * 0.01 + seed) * 30 +
+        Math.sin(i * 0.003 + seed * 1.7) * 20 +
+        Math.cos(i * 0.0007 + seed * 2.3) * 15;
       return Math.max(0, v);
     }
-    case 'spiky': {
+    case "spiky": {
       const base = 20 + seriesIdx * 5;
-      const spike = (i % 100 < 5) ? 200 + Math.random() * 100 : 0;
+      const spike = i % 100 < 5 ? 200 + Math.random() * 100 : 0;
       return base + Math.random() * 10 + spike;
     }
-    case 'constant':
+    case "constant":
       return 42.0 + seriesIdx * 0.001;
     default:
       return Math.random() * 100;

--- a/site/tsdb-engine/js/query.js
+++ b/site/tsdb-engine/js/query.js
@@ -119,12 +119,18 @@ export class ScanEngine {
   _stepAggregate(ranges, fn, step) {
     let minT = BigInt("9223372036854775807");
     let maxT = -minT;
+    let hasSamples = false;
+
     for (const r of ranges) {
       if (r.timestamps.length === 0) continue;
+      hasSamples = true;
       if (r.timestamps[0] < minT) minT = r.timestamps[0];
       if (r.timestamps[r.timestamps.length - 1] > maxT)
         maxT = r.timestamps[r.timestamps.length - 1];
     }
+
+    if (!hasSamples) return [];
+
     const bucketCount = Number((maxT - minT) / step) + 1;
     const timestamps = new BigInt64Array(bucketCount);
     const values = new Float64Array(bucketCount);

--- a/site/tsdb-engine/js/query.js
+++ b/site/tsdb-engine/js/query.js
@@ -1,35 +1,40 @@
 // ── Query Engine ─────────────────────────────────────────────────────
 
-import { lowerBound, upperBound } from './utils.js';
-
 function aggInit(fn) {
-  if (fn === 'min') return Infinity;
-  if (fn === 'max') return -Infinity;
+  if (fn === "min") return Infinity;
+  if (fn === "max") return -Infinity;
   return 0;
 }
 
 function aggAccum(acc, v, fn) {
   switch (fn) {
-    case 'sum': case 'avg': return acc + v;
-    case 'min': return v < acc ? v : acc;
-    case 'max': return v > acc ? v : acc;
-    case 'count': return acc + 1;
-    case 'last': return v;
-    default: return acc;
+    case "sum":
+    case "avg":
+      return acc + v;
+    case "min":
+      return v < acc ? v : acc;
+    case "max":
+      return v > acc ? v : acc;
+    case "count":
+      return acc + 1;
+    case "last":
+      return v;
+    default:
+      return acc;
   }
 }
 
 function aggFinalize(vals, counts, fn) {
-  if (fn === 'avg') for (let i = 0; i < vals.length; i++) if (counts[i] > 0) vals[i] /= counts[i];
+  if (fn === "avg") for (let i = 0; i < vals.length; i++) if (counts[i] > 0) vals[i] /= counts[i];
 }
 
 export class ScanEngine {
   query(storage, opts) {
-    let ids = storage.matchLabel('__name__', opts.metric);
+    let ids = storage.matchLabel("__name__", opts.metric);
     if (opts.matchers) {
       for (const m of opts.matchers) {
         const s = new Set(storage.matchLabel(m.label, m.value));
-        ids = ids.filter(id => s.has(id));
+        ids = ids.filter((id) => s.has(id));
       }
     }
     let scannedSamples = 0;
@@ -38,7 +43,11 @@ export class ScanEngine {
       for (const id of ids) {
         const data = storage.read(id, opts.start, opts.end);
         scannedSamples += data.timestamps.length;
-        series.push({ labels: storage.labels(id) ?? new Map(), timestamps: data.timestamps, values: data.values });
+        series.push({
+          labels: storage.labels(id) ?? new Map(),
+          timestamps: data.timestamps,
+          values: data.values,
+        });
       }
       return { series, scannedSeries: ids.length, scannedSamples };
     }
@@ -48,11 +57,18 @@ export class ScanEngine {
       const data = storage.read(id, opts.start, opts.end);
       scannedSamples += data.timestamps.length;
       const labels = storage.labels(id) ?? new Map();
-      const groupKey = opts.groupBy ? opts.groupBy.map(k => labels.get(k) ?? '').join('\0') : '__all__';
+      const groupKey = opts.groupBy
+        ? opts.groupBy.map((k) => labels.get(k) ?? "").join("\0")
+        : "__all__";
       let group = groups.get(groupKey);
       if (!group) {
-        const gl = new Map(); gl.set('__name__', opts.metric);
-        if (opts.groupBy) for (const k of opts.groupBy) { const v = labels.get(k); if (v) gl.set(k, v); }
+        const gl = new Map();
+        gl.set("__name__", opts.metric);
+        if (opts.groupBy)
+          for (const k of opts.groupBy) {
+            const v = labels.get(k);
+            if (v) gl.set(k, v);
+          }
         group = { labels: gl, ranges: [] };
         groups.set(groupKey, group);
       }
@@ -68,7 +84,8 @@ export class ScanEngine {
   }
 
   _aggregate(ranges, fn, step) {
-    if (ranges.length === 0) return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
+    if (ranges.length === 0)
+      return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
     if (!step) return this._pointAggregate(ranges, fn);
     return this._stepAggregate(ranges, fn, step);
   }
@@ -78,7 +95,7 @@ export class ScanEngine {
     for (const r of ranges) if (r.timestamps.length > longest.timestamps.length) longest = r;
     const timestamps = longest.timestamps;
     const values = new Float64Array(timestamps.length);
-    if (fn === 'rate') {
+    if (fn === "rate") {
       const src = ranges[0];
       for (let i = 1; i < src.timestamps.length; i++) {
         const dt = Number(src.timestamps[i] - src.timestamps[i - 1]) / 1_000_000;
@@ -90,19 +107,23 @@ export class ScanEngine {
     const counts = new Float64Array(timestamps.length);
     for (const r of ranges) {
       const len = Math.min(r.values.length, timestamps.length);
-      for (let i = 0; i < len; i++) { values[i] = aggAccum(values[i], r.values[i], fn); counts[i]++; }
+      for (let i = 0; i < len; i++) {
+        values[i] = aggAccum(values[i], r.values[i], fn);
+        counts[i]++;
+      }
     }
     aggFinalize(values, counts, fn);
     return { timestamps, values };
   }
 
   _stepAggregate(ranges, fn, step) {
-    let minT = BigInt('9223372036854775807');
+    let minT = BigInt("9223372036854775807");
     let maxT = -minT;
     for (const r of ranges) {
       if (r.timestamps.length === 0) continue;
       if (r.timestamps[0] < minT) minT = r.timestamps[0];
-      if (r.timestamps[r.timestamps.length - 1] > maxT) maxT = r.timestamps[r.timestamps.length - 1];
+      if (r.timestamps[r.timestamps.length - 1] > maxT)
+        maxT = r.timestamps[r.timestamps.length - 1];
     }
     const bucketCount = Number((maxT - minT) / step) + 1;
     const timestamps = new BigInt64Array(bucketCount);

--- a/site/tsdb-engine/js/storage-explorer.js
+++ b/site/tsdb-engine/js/storage-explorer.js
@@ -198,16 +198,16 @@ function _buildChunkDetailHTML(
   const html = `
       <div class="chunk-detail-header">
         <div class="chunk-nav">
-          <button class="chunk-nav-btn" id="chunkPrev" ${hasPrev ? "" : "disabled"} title="Previous chunk">‹</button>
+          <button type="button" class="chunk-nav-btn" id="chunkPrev" ${hasPrev ? "" : "disabled"} title="Previous chunk">‹</button>
           <span class="chunk-nav-label">Chunk ${chunkIndex} of ${totalFrozen}</span>
-          <button class="chunk-nav-btn" id="chunkNext" ${hasNext ? "" : "disabled"} title="Next chunk">›</button>
+          <button type="button" class="chunk-nav-btn" id="chunkNext" ${hasNext ? "" : "disabled"} title="Next chunk">›</button>
         </div>
         <div class="chunk-detail-title">
           <span class="tag-frozen">Frozen</span> ${metricName}
           <span class="chunk-detail-labels">{${labelStr}}</span>
           <span class="tag-codec">${codecName}</span>
         </div>
-        <button class="chunk-close" onclick="this.closest('.chunk-detail-panel').style.display='none'">✕</button>
+        <button type="button" class="chunk-close" onclick="this.closest('.chunk-detail-panel').style.display='none'">✕</button>
       </div>
       <div class="chunk-sparkline-container">
         <h4>Decoded Values</h4>
@@ -319,7 +319,7 @@ export function showChunkDetail(seriesInfo, chunkIndex, type, store) {
           <span class="tag-hot">Hot Buffer</span> — ${metricName}
           <span class="chunk-detail-labels">{${labelStr}}</span>
         </div>
-        <button class="chunk-close" onclick="this.closest('.chunk-detail-panel').style.display='none'">✕</button>
+        <button type="button" class="chunk-close" onclick="this.closest('.chunk-detail-panel').style.display='none'">✕</button>
       </div>
       <div class="chunk-detail-grid">
         <div class="detail-stat">

--- a/site/tsdb-engine/js/storage-explorer.js
+++ b/site/tsdb-engine/js/storage-explorer.js
@@ -1,13 +1,13 @@
 // ── Storage Explorer ─────────────────────────────────────────────────
 
-import { $, formatBytes, formatTimeRange, setupCanvasDPR } from './utils.js';
-import { decodeChunk } from './codec.js';
-import { wasmDecodeValuesALP, wasmDecodeTimestamps } from './wasm.js';
-import { renderByteExplorer, renderByteExplorerTs } from './byte-explorer.js';
-import { ALP_HEADER_SIZE } from './byte-explorer-logic.js';
+import { renderByteExplorer, renderByteExplorerTs } from "./byte-explorer.js";
+import { ALP_HEADER_SIZE } from "./byte-explorer-logic.js";
+import { decodeChunk } from "./codec.js";
+import { $, formatBytes, formatTimeRange, setupCanvasDPR } from "./utils.js";
+import { wasmDecodeTimestamps, wasmDecodeValuesALP } from "./wasm.js";
 
-function renderByteMap(compressed, sampleCount) {
-  const container = $('#byteMap');
+function renderByteMap(compressed, _sampleCount) {
+  const container = $("#byteMap");
   if (!container) return;
 
   const totalBytes = compressed.byteLength;
@@ -17,57 +17,64 @@ function renderByteMap(compressed, sampleCount) {
   const valXorBytes = remainingBytes - tsDeltaBytes;
 
   const segments = [
-    { label: 'Header', bytes: headerBytes, cls: 'header' },
-    { label: 'Timestamps', bytes: tsDeltaBytes, cls: 'timestamps' },
-    { label: 'XOR Values', bytes: valXorBytes, cls: 'values' },
+    { label: "Header", bytes: headerBytes, cls: "header" },
+    { label: "Timestamps", bytes: tsDeltaBytes, cls: "timestamps" },
+    { label: "XOR Values", bytes: valXorBytes, cls: "values" },
   ];
 
-  container.innerHTML = segments.map(seg => {
-    const pct = Math.max(1, (seg.bytes / totalBytes) * 100);
-    return `<div class="byte-segment ${seg.cls}" style="width:${pct}%" title="${seg.label}: ${formatBytes(seg.bytes)}">${seg.bytes > 20 ? formatBytes(seg.bytes) : ''}</div>`;
-  }).join('');
+  container.innerHTML = segments
+    .map((seg) => {
+      const pct = Math.max(1, (seg.bytes / totalBytes) * 100);
+      return `<div class="byte-segment ${seg.cls}" style="width:${pct}%" title="${seg.label}: ${formatBytes(seg.bytes)}">${seg.bytes > 20 ? formatBytes(seg.bytes) : ""}</div>`;
+    })
+    .join("");
 }
 
-function renderByteMapALP(compressedValues, compressedTs, sharedCount) {
-  const container = $('#byteMap');
+function renderByteMapALP(compressedValues, _compressedTs, _sharedCount) {
+  const container = $("#byteMap");
   if (!container) return;
 
   const valBytes = compressedValues.byteLength;
 
   const alpBW = valBytes >= 4 ? compressedValues[3] : 0;
   const alpCount = valBytes >= 2 ? (compressedValues[0] << 8) | compressedValues[1] : 0;
-  const alpExc = valBytes >= ALP_HEADER_SIZE ? (compressedValues[12] << 8) | compressedValues[13] : 0;
+  const alpExc =
+    valBytes >= ALP_HEADER_SIZE ? (compressedValues[12] << 8) | compressedValues[13] : 0;
   const headerBytes = Math.min(ALP_HEADER_SIZE, valBytes);
-  const bpBytes = Math.ceil(alpCount * alpBW / 8);
+  const bpBytes = Math.ceil((alpCount * alpBW) / 8);
   const excBytes = alpExc * 10;
 
   const totalBytes = headerBytes + bpBytes + excBytes;
   const segments = [
-    { label: 'Header', bytes: headerBytes, cls: 'header' },
-    { label: 'Offsets', bytes: bpBytes, cls: 'values' },
+    { label: "Header", bytes: headerBytes, cls: "header" },
+    { label: "Offsets", bytes: bpBytes, cls: "values" },
   ];
-  if (excBytes > 0) segments.push({ label: 'Exceptions', bytes: excBytes, cls: 'exceptions' });
+  if (excBytes > 0) segments.push({ label: "Exceptions", bytes: excBytes, cls: "exceptions" });
 
-  container.innerHTML = segments.map(seg => {
-    const pct = Math.max(1, (seg.bytes / totalBytes) * 100);
-    return `<div class="byte-segment ${seg.cls}" style="width:${pct}%" title="${seg.label}: ${formatBytes(seg.bytes)}">${seg.bytes > 20 ? formatBytes(seg.bytes) : ''}</div>`;
-  }).join('');
+  container.innerHTML = segments
+    .map((seg) => {
+      const pct = Math.max(1, (seg.bytes / totalBytes) * 100);
+      return `<div class="byte-segment ${seg.cls}" style="width:${pct}%" title="${seg.label}: ${formatBytes(seg.bytes)}">${seg.bytes > 20 ? formatBytes(seg.bytes) : ""}</div>`;
+    })
+    .join("");
 }
 
-function _renderTsByteMap(tsBlob, sharedCount) {
-  const container = document.getElementById('byteMapTs');
+function _renderTsByteMap(tsBlob, _sharedCount) {
+  const container = document.getElementById("byteMapTs");
   if (!container || !tsBlob) return;
   const tsLen = tsBlob.byteLength;
   const hdrBytes = Math.min(10, tsLen);
   const bodyBytes = tsLen - hdrBytes;
   const segments = [
-    { label: 'Header', bytes: hdrBytes, cls: 'timestamps' },
-    { label: 'Δ² Body', bytes: bodyBytes, cls: 'timestamps' },
+    { label: "Header", bytes: hdrBytes, cls: "timestamps" },
+    { label: "Δ² Body", bytes: bodyBytes, cls: "timestamps" },
   ];
-  container.innerHTML = segments.map(seg => {
-    const pct = Math.max(1, (seg.bytes / tsLen) * 100);
-    return `<div class="byte-segment ${seg.cls}" style="width:${pct}%" title="${seg.label}: ${formatBytes(seg.bytes)}">${seg.bytes > 20 ? formatBytes(seg.bytes) : ''}</div>`;
-  }).join('');
+  container.innerHTML = segments
+    .map((seg) => {
+      const pct = Math.max(1, (seg.bytes / tsLen) * 100);
+      return `<div class="byte-segment ${seg.cls}" style="width:${pct}%" title="${seg.label}: ${formatBytes(seg.bytes)}">${seg.bytes > 20 ? formatBytes(seg.bytes) : ""}</div>`;
+    })
+    .join("");
 }
 
 function renderSparkline(canvasId, decoded) {
@@ -82,12 +89,16 @@ function renderSparkline(canvasId, decoded) {
   const n = values.length;
   if (n === 0) return;
 
-  let minV = Infinity, maxV = -Infinity;
+  let minV = Infinity,
+    maxV = -Infinity;
   for (let i = 0; i < n; i++) {
     if (values[i] < minV) minV = values[i];
     if (values[i] > maxV) maxV = values[i];
   }
-  if (minV === maxV) { minV -= 1; maxV += 1; }
+  if (minV === maxV) {
+    minV -= 1;
+    maxV += 1;
+  }
   const vRange = maxV - minV;
   const pad = 8;
   const plotW = w - pad * 2;
@@ -95,14 +106,15 @@ function renderSparkline(canvasId, decoded) {
 
   // Gradient fill
   const grad = ctx.createLinearGradient(0, pad, 0, h - pad);
-  grad.addColorStop(0, 'rgba(59, 130, 246, 0.15)');
-  grad.addColorStop(1, 'rgba(59, 130, 246, 0.01)');
+  grad.addColorStop(0, "rgba(59, 130, 246, 0.15)");
+  grad.addColorStop(1, "rgba(59, 130, 246, 0.01)");
 
   ctx.beginPath();
   for (let i = 0; i < n; i++) {
     const x = pad + (i / (n - 1)) * plotW;
     const y = pad + ((maxV - values[i]) / vRange) * plotH;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
   }
   const lastX = pad + plotW;
   ctx.lineTo(lastX, h - pad);
@@ -116,9 +128,10 @@ function renderSparkline(canvasId, decoded) {
   for (let i = 0; i < n; i++) {
     const x = pad + (i / (n - 1)) * plotW;
     const y = pad + ((maxV - values[i]) / vRange) * plotH;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
   }
-  ctx.strokeStyle = '#3b82f6';
+  ctx.strokeStyle = "#3b82f6";
   ctx.lineWidth = 1.5;
   ctx.stroke();
 }
@@ -132,13 +145,22 @@ function _decodeChunkData(chunk, isColumn) {
   return decodeChunk(chunk.compressed);
 }
 
-function _buildChunkDetailHTML(chunk, decoded, isColumn, labelStr, metricName, chunkIndex, totalFrozen) {
-  const sparkId = 'sparkline-' + Date.now();
-  const codecName = isColumn ? 'ALP' : 'XOR-Delta';
+function _buildChunkDetailHTML(
+  chunk,
+  _decoded,
+  isColumn,
+  labelStr,
+  metricName,
+  chunkIndex,
+  totalFrozen
+) {
+  const sparkId = `sparkline-${Date.now()}`;
+  const codecName = isColumn ? "ALP" : "XOR-Delta";
   const hasPrev = chunkIndex > 0;
   const hasNext = chunkIndex < totalFrozen - 1;
 
-  const columnExtra = isColumn ? `
+  const columnExtra = isColumn
+    ? `
         <div class="detail-stat">
           <div class="detail-stat-label">Values (ALP)</div>
           <div class="detail-stat-value">${formatBytes(chunk.valuesBytes)}</div>
@@ -146,18 +168,22 @@ function _buildChunkDetailHTML(chunk, decoded, isColumn, labelStr, metricName, c
         <div class="detail-stat">
           <div class="detail-stat-label">Timestamps (shared)</div>
           <div class="detail-stat-value">${formatBytes(chunk.timestampBytes)} ÷ ${chunk.sharedTsSeries} = ${formatBytes(chunk.amortizedTsBytes)}</div>
-        </div>` : '';
+        </div>`
+    : "";
 
-  const byteLayoutLegend = isColumn ? `
+  const byteLayoutLegend = isColumn
+    ? `
           <span class="byte-legend-item"><span class="byte-swatch header"></span>ALP header (14 B)</span>
           <span class="byte-legend-item"><span class="byte-swatch values"></span>Bit-packed offsets</span>
           <span class="byte-legend-item"><span class="byte-swatch exceptions"></span>Exceptions</span>
-        ` : `
+        `
+    : `
           <span class="byte-legend-item"><span class="byte-swatch header"></span>Header (18 B: count + ts₀ + v₀)</span>
           <span class="byte-legend-item"><span class="byte-swatch timestamps"></span>Interleaved Δ²ts + XOR values</span>
         `;
 
-  const tsLegend = isColumn ? `
+  const tsLegend = isColumn
+    ? `
       <div class="chunk-byte-layout">
         <h4>Timestamps Store <span class="store-badge ts">Gorilla Δ² · shared ÷ ${chunk.sharedTsSeries}</span></h4>
         <div class="byte-map" id="byteMapTs"></div>
@@ -166,14 +192,15 @@ function _buildChunkDetailHTML(chunk, decoded, isColumn, labelStr, metricName, c
           <span class="byte-legend-item"><span class="byte-swatch timestamps"></span>Δ² body</span>
         </div>
       </div>
-      <div class="byte-explorer" id="byteExplorerTs"></div>` : '';
+      <div class="byte-explorer" id="byteExplorerTs"></div>`
+    : "";
 
   const html = `
       <div class="chunk-detail-header">
         <div class="chunk-nav">
-          <button class="chunk-nav-btn" id="chunkPrev" ${hasPrev ? '' : 'disabled'} title="Previous chunk">‹</button>
+          <button class="chunk-nav-btn" id="chunkPrev" ${hasPrev ? "" : "disabled"} title="Previous chunk">‹</button>
           <span class="chunk-nav-label">Chunk ${chunkIndex} of ${totalFrozen}</span>
-          <button class="chunk-nav-btn" id="chunkNext" ${hasNext ? '' : 'disabled'} title="Next chunk">›</button>
+          <button class="chunk-nav-btn" id="chunkNext" ${hasNext ? "" : "disabled"} title="Next chunk">›</button>
         </div>
         <div class="chunk-detail-title">
           <span class="tag-frozen">Frozen</span> ${metricName}
@@ -215,7 +242,7 @@ function _buildChunkDetailHTML(chunk, decoded, isColumn, labelStr, metricName, c
         ${columnExtra}
       </div>
       <div class="chunk-byte-layout">
-        <h4>${isColumn ? 'Values Store' : 'Byte Layout'} <span class="store-badge val">${isColumn ? 'ALP · ' + formatBytes(chunk.valuesBytes) : ''}</span></h4>
+        <h4>${isColumn ? "Values Store" : "Byte Layout"} <span class="store-badge val">${isColumn ? `ALP · ${formatBytes(chunk.valuesBytes)}` : ""}</span></h4>
         <div class="byte-map" id="byteMap"></div>
         <div class="byte-legend">
           ${byteLayoutLegend}
@@ -228,47 +255,61 @@ function _buildChunkDetailHTML(chunk, decoded, isColumn, labelStr, metricName, c
 }
 
 export function showChunkDetail(seriesInfo, chunkIndex, type, store) {
-  const panel = $('#chunkDetailPanel');
-  panel.style.display = '';
-  panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  const panel = $("#chunkDetailPanel");
+  panel.style.display = "";
+  panel.scrollIntoView({ behavior: "smooth", block: "nearest" });
 
-  const metricName = seriesInfo.labels.get('__name__') || 'unknown';
+  const metricName = seriesInfo.labels.get("__name__") || "unknown";
   const labelStr = [...seriesInfo.labels]
-    .filter(([k]) => k !== '__name__')
+    .filter(([k]) => k !== "__name__")
     .map(([k, v]) => `${k}="${v}"`)
-    .join(', ');
+    .join(", ");
 
-  if (type === 'frozen') {
+  if (type === "frozen") {
     const chunk = seriesInfo.info.frozen[chunkIndex];
     const isColumn = !!chunk.compressedValues;
     const decoded = _decodeChunkData(chunk, isColumn);
     const totalFrozen = seriesInfo.info.frozen.length;
-    const { html, sparkId } = _buildChunkDetailHTML(chunk, decoded, isColumn, labelStr, metricName, chunkIndex, totalFrozen);
+    const { html, sparkId } = _buildChunkDetailHTML(
+      chunk,
+      decoded,
+      isColumn,
+      labelStr,
+      metricName,
+      chunkIndex,
+      totalFrozen
+    );
     panel.innerHTML = html;
 
     // Prev/Next navigation
-    const prevBtn = panel.querySelector('#chunkPrev');
-    const nextBtn = panel.querySelector('#chunkNext');
-    if (prevBtn) prevBtn.addEventListener('click', () => showChunkDetail(seriesInfo, chunkIndex - 1, 'frozen', store));
-    if (nextBtn) nextBtn.addEventListener('click', () => showChunkDetail(seriesInfo, chunkIndex + 1, 'frozen', store));
+    const prevBtn = panel.querySelector("#chunkPrev");
+    const nextBtn = panel.querySelector("#chunkNext");
+    if (prevBtn)
+      prevBtn.addEventListener("click", () =>
+        showChunkDetail(seriesInfo, chunkIndex - 1, "frozen", store)
+      );
+    if (nextBtn)
+      nextBtn.addEventListener("click", () =>
+        showChunkDetail(seriesInfo, chunkIndex + 1, "frozen", store)
+      );
 
     if (isColumn) {
       // Values store — ALP blob only (no timestamp concatenation)
       renderByteMapALP(chunk.compressedValues, chunk.tsChunkCompressed, chunk.sharedTsSeries);
-      renderByteExplorer(chunk.compressedValues, null, 0, chunk.count, 'alp-values');
+      renderByteExplorer(chunk.compressedValues, null, 0, chunk.count, "alp-values");
 
       // Timestamp store — separate explorer
       _renderTsByteMap(chunk.tsChunkCompressed, chunk.sharedTsSeries);
       renderByteExplorerTs(chunk.tsChunkCompressed, chunk.count);
     } else {
       renderByteMap(chunk.compressed, chunk.count);
-      renderByteExplorer(chunk.compressed, null, 0, chunk.count, 'xor');
+      renderByteExplorer(chunk.compressed, null, 0, chunk.count, "xor");
     }
 
     requestAnimationFrame(() => renderSparkline(sparkId, decoded));
   } else {
     const hot = seriesInfo.info.hot;
-    const sparkId = 'sparkline-' + Date.now();
+    const sparkId = `sparkline-${Date.now()}`;
     const minT = hot.count > 0 ? hot.timestamps[0] : 0n;
     const maxT = hot.count > 0 ? hot.timestamps[hot.count - 1] : 0n;
 
@@ -287,7 +328,7 @@ export function showChunkDetail(seriesInfo, chunkIndex, type, store) {
         </div>
         <div class="detail-stat">
           <div class="detail-stat-label">Time range</div>
-          <div class="detail-stat-value detail-stat-small">${hot.count > 0 ? formatTimeRange(minT, maxT) : '—'}</div>
+          <div class="detail-stat-value detail-stat-small">${hot.count > 0 ? formatTimeRange(minT, maxT) : "—"}</div>
         </div>
         <div class="detail-stat">
           <div class="detail-stat-label">Raw size</div>
@@ -321,14 +362,18 @@ export function showChunkDetail(seriesInfo, chunkIndex, type, store) {
 }
 
 export function buildStorageExplorer(store) {
-  const explorer = $('#storageExplorer');
-  const overview = $('#storageOverview');
-  const seriesList = $('#storageSeriesList');
-  const detailPanel = $('#chunkDetailPanel');
-  explorer.style.display = '';
-  detailPanel.style.display = 'none';
+  const explorer = $("#storageExplorer");
+  const overview = $("#storageOverview");
+  const seriesList = $("#storageSeriesList");
+  const detailPanel = $("#chunkDetailPanel");
+  explorer.style.display = "";
+  detailPanel.style.display = "none";
 
-  let totalChunks = 0, totalFrozen = 0, totalHotSamples = 0, totalCompressedBytes = 0, totalRawBytes = 0;
+  let totalChunks = 0,
+    totalFrozen = 0,
+    _totalHotSamples = 0,
+    totalCompressedBytes = 0,
+    totalRawBytes = 0;
   const seriesInfos = [];
 
   for (let id = 0; id < store.seriesCount; id++) {
@@ -339,7 +384,7 @@ export function buildStorageExplorer(store) {
     const frozenRaw = info.frozen.reduce((s, c) => s + c.rawBytes, 0);
     totalFrozen += info.frozen.length;
     totalChunks += info.frozen.length + (info.hot.count > 0 ? 1 : 0);
-    totalHotSamples += info.hot.count;
+    _totalHotSamples += info.hot.count;
     totalCompressedBytes += frozenBytes + (info.hot.count > 0 ? info.hot.rawBytes : 0);
     totalRawBytes += frozenRaw + info.hot.rawBytes;
 
@@ -347,8 +392,9 @@ export function buildStorageExplorer(store) {
   }
 
   const firstInfo = seriesInfos.length > 0 ? seriesInfos[0].info : null;
-  const isColumnStore = firstInfo && firstInfo._isColumnStore;
-  const columnStatsHtml = isColumnStore ? `
+  const isColumnStore = firstInfo?._isColumnStore;
+  const columnStatsHtml = isColumnStore
+    ? `
       <div class="explorer-stat column-stat">
         <span class="explorer-stat-value">${firstInfo._groupMembers}</span>
         <span class="explorer-stat-label">Series sharing timestamps</span>
@@ -360,7 +406,8 @@ export function buildStorageExplorer(store) {
       <div class="explorer-stat column-stat">
         <span class="explorer-stat-value">${formatBytes(firstInfo._sharedTsTotalBytes)}</span>
         <span class="explorer-stat-label">Shared ts storage</span>
-      </div>` : '';
+      </div>`
+    : "";
 
   overview.innerHTML = `
     <div class="explorer-stats">
@@ -381,22 +428,25 @@ export function buildStorageExplorer(store) {
         <span class="explorer-stat-label">Total storage</span>
       </div>
       <div class="explorer-stat">
-        <span class="explorer-stat-value">${totalRawBytes > 0 ? (totalRawBytes / totalCompressedBytes).toFixed(1) + '×' : '—'}</span>
+        <span class="explorer-stat-value">${totalRawBytes > 0 ? `${(totalRawBytes / totalCompressedBytes).toFixed(1)}×` : "—"}</span>
         <span class="explorer-stat-label">Avg compression</span>
       </div>
       ${columnStatsHtml}
     </div>`;
 
-  seriesList.innerHTML = '';
+  seriesList.innerHTML = "";
   for (const si of seriesInfos) {
-    const row = document.createElement('div');
-    row.className = 'storage-series-row';
+    const row = document.createElement("div");
+    row.className = "storage-series-row";
 
     const labelStr = [...si.labels]
-      .filter(([k]) => k !== '__name__')
-      .map(([k, v]) => `<span class="label-pair"><span class="label-key">${k}</span>=<span class="label-val">${v}</span></span>`)
-      .join(' ');
-    const metricName = si.labels.get('__name__') || 'unknown';
+      .filter(([k]) => k !== "__name__")
+      .map(
+        ([k, v]) =>
+          `<span class="label-pair"><span class="label-key">${k}</span>=<span class="label-val">${v}</span></span>`
+      )
+      .join(" ");
+    const metricName = si.labels.get("__name__") || "unknown";
 
     const totalSamples = si.frozenSamples + si.info.hot.count;
     const totalBytes = si.frozenBytes + (si.info.hot.count > 0 ? si.info.hot.rawBytes : 0);
@@ -405,49 +455,52 @@ export function buildStorageExplorer(store) {
       <div class="series-header">
         <span class="series-metric">${metricName}</span>
         <span class="series-labels">${labelStr}</span>
-        <span class="series-summary">${totalSamples.toLocaleString()} pts · ${formatBytes(totalBytes)} · ${si.info.frozen.length} chunks${si.info.hot.count > 0 ? ' + hot' : ''}</span>
+        <span class="series-summary">${totalSamples.toLocaleString()} pts · ${formatBytes(totalBytes)} · ${si.info.frozen.length} chunks${si.info.hot.count > 0 ? " + hot" : ""}</span>
       </div>
       <div class="chunk-bar-container"></div>`;
 
-    const barContainer = row.querySelector('.chunk-bar-container');
-    const maxSamples = Math.max(...seriesInfos.map(s => s.frozenSamples + s.info.hot.count));
+    const barContainer = row.querySelector(".chunk-bar-container");
+    const maxSamples = Math.max(...seriesInfos.map((s) => s.frozenSamples + s.info.hot.count));
     const totalChunksInSeries = si.info.frozen.length + (si.info.hot.count > 0 ? 1 : 0);
     const compact = totalChunksInSeries > 40;
-    if (compact) barContainer.classList.add('compact-chunks');
+    if (compact) barContainer.classList.add("compact-chunks");
 
     const isCol = si.info._isColumnStore;
     for (let ci = 0; ci < si.info.frozen.length; ci++) {
       const chunk = si.info.frozen[ci];
-      const block = document.createElement('div');
-      block.className = isCol ? 'chunk-block frozen column-store' : 'chunk-block frozen';
+      const block = document.createElement("div");
+      block.className = isCol ? "chunk-block frozen column-store" : "chunk-block frozen";
       if (!compact) {
         const widthPct = Math.max(2, (chunk.count / maxSamples) * 100);
-        block.style.width = widthPct + '%';
+        block.style.width = `${widthPct}%`;
       }
       block.title = `Chunk ${ci}: ${chunk.count} pts, ${formatBytes(chunk.compressedBytes)}, ${chunk.ratio.toFixed(1)}× compression`;
       if (!compact) block.innerHTML = `<span class="chunk-label">${chunk.count}</span>`;
-      block.addEventListener('click', () => showChunkDetail(si, ci, 'frozen', store));
+      block.addEventListener("click", () => showChunkDetail(si, ci, "frozen", store));
       barContainer.appendChild(block);
     }
 
     if (si.info.hot.count > 0) {
-      const block = document.createElement('div');
-      block.className = 'chunk-block hot';
+      const block = document.createElement("div");
+      block.className = "chunk-block hot";
       if (!compact) {
         const widthPct = Math.max(2, (si.info.hot.count / maxSamples) * 100);
-        block.style.width = widthPct + '%';
+        block.style.width = `${widthPct}%`;
       }
       block.title = `Hot buffer: ${si.info.hot.count} pts, ${formatBytes(si.info.hot.rawBytes)} (uncompressed)`;
       if (!compact) block.innerHTML = `<span class="chunk-label">${si.info.hot.count}</span>`;
-      block.addEventListener('click', () => showChunkDetail(si, -1, 'hot', store));
+      block.addEventListener("click", () => showChunkDetail(si, -1, "hot", store));
       barContainer.appendChild(block);
     }
 
     if (compact) {
-      const summary = document.createElement('div');
-      summary.className = 'chunk-summary-bar';
-      summary.innerHTML = `<span class="chunk-count-badge">${si.info.frozen.length} frozen</span>` +
-        (si.info.hot.count > 0 ? `<span class="chunk-count-badge hot">1 hot (${si.info.hot.count.toLocaleString()} pts)</span>` : '') +
+      const summary = document.createElement("div");
+      summary.className = "chunk-summary-bar";
+      summary.innerHTML =
+        `<span class="chunk-count-badge">${si.info.frozen.length} frozen</span>` +
+        (si.info.hot.count > 0
+          ? `<span class="chunk-count-badge hot">1 hot (${si.info.hot.count.toLocaleString()} pts)</span>`
+          : "") +
         `<span>Click any block to explore</span>`;
       row.appendChild(summary);
     }

--- a/site/tsdb-engine/js/stores.js
+++ b/site/tsdb-engine/js/stores.js
@@ -1,8 +1,13 @@
 // ── Storage Backends ─────────────────────────────────────────────────
 
-import { encodeChunk, decodeChunk } from './codec.js';
-import { lowerBound, upperBound, makeLabelKey } from './utils.js';
-import { wasmEncodeValuesALP, wasmDecodeValuesALP, wasmEncodeTimestamps, wasmDecodeTimestamps } from './wasm.js';
+import { decodeChunk, encodeChunk } from "./codec.js";
+import { lowerBound, makeLabelKey, upperBound } from "./utils.js";
+import {
+  wasmDecodeTimestamps,
+  wasmDecodeValuesALP,
+  wasmEncodeTimestamps,
+  wasmEncodeValuesALP,
+} from "./wasm.js";
 
 // ── Shared helpers ───────────────────────────────────────────────────
 
@@ -26,24 +31,35 @@ function _registerLabels(id, labels, labelsList, postings) {
 
 export class FlatStore {
   constructor() {
-    this.name = 'FlatStore';
+    this.name = "FlatStore";
     this._series = [];
     this._labels = [];
     this._postings = new Map();
     this._labelKeyMap = new Map();
     this._sampleCount = 0;
   }
-  get seriesCount() { return this._series.length; }
-  get sampleCount() { return this._sampleCount; }
+  get seriesCount() {
+    return this._series.length;
+  }
+  get sampleCount() {
+    return this._sampleCount;
+  }
 
   getOrCreateSeries(labels) {
     const key = makeLabelKey(labels);
     const cached = this._labelKeyMap.get(key);
     if (cached !== undefined) return cached;
     const existing = _findExistingSeriesId(this._labels, key);
-    if (existing >= 0) { this._labelKeyMap.set(key, existing); return existing; }
+    if (existing >= 0) {
+      this._labelKeyMap.set(key, existing);
+      return existing;
+    }
     const id = this._series.length;
-    this._series.push({ timestamps: new BigInt64Array(128), values: new Float64Array(128), count: 0 });
+    this._series.push({
+      timestamps: new BigInt64Array(128),
+      values: new Float64Array(128),
+      count: 0,
+    });
     _registerLabels(id, labels, this._labels, this._postings);
     this._labelKeyMap.set(key, id);
     return id;
@@ -51,7 +67,7 @@ export class FlatStore {
 
   appendBatch(id, timestamps, values) {
     const s = this._series[id];
-    let need = s.count + timestamps.length;
+    const need = s.count + timestamps.length;
     while (need > s.timestamps.length) {
       const newLen = s.timestamps.length * 2;
       const newTs = new BigInt64Array(newLen);
@@ -78,7 +94,9 @@ export class FlatStore {
     return { timestamps: s.timestamps.slice(lo, hi), values: s.values.slice(lo, hi) };
   }
 
-  labels(id) { return this._labels[id]; }
+  labels(id) {
+    return this._labels[id];
+  }
 
   memoryBytes() {
     let bytes = 0;
@@ -103,7 +121,7 @@ export class FlatStore {
 
 export class ChunkedStore {
   constructor(chunkSize = 640) {
-    this.name = 'ChunkedStore';
+    this.name = "ChunkedStore";
     this.chunkSize = chunkSize;
     this._series = [];
     this._labels = [];
@@ -111,18 +129,29 @@ export class ChunkedStore {
     this._labelKeyMap = new Map();
     this._sampleCount = 0;
   }
-  get seriesCount() { return this._series.length; }
-  get sampleCount() { return this._sampleCount; }
+  get seriesCount() {
+    return this._series.length;
+  }
+  get sampleCount() {
+    return this._sampleCount;
+  }
 
   getOrCreateSeries(labels) {
     const key = makeLabelKey(labels);
     const cached = this._labelKeyMap.get(key);
     if (cached !== undefined) return cached;
     const existing = _findExistingSeriesId(this._labels, key);
-    if (existing >= 0) { this._labelKeyMap.set(key, existing); return existing; }
+    if (existing >= 0) {
+      this._labelKeyMap.set(key, existing);
+      return existing;
+    }
     const id = this._series.length;
     this._series.push({
-      hot: { timestamps: new BigInt64Array(this.chunkSize), values: new Float64Array(this.chunkSize), count: 0 },
+      hot: {
+        timestamps: new BigInt64Array(this.chunkSize),
+        values: new Float64Array(this.chunkSize),
+        count: 0,
+      },
       frozen: [],
     });
     _registerLabels(id, labels, this._labels, this._postings);
@@ -170,24 +199,39 @@ export class ChunkedStore {
       const decoded = decodeChunk(chunk.compressed);
       const lo = lowerBound(decoded.timestamps, start, 0, decoded.timestamps.length);
       const hi = upperBound(decoded.timestamps, end, lo, decoded.timestamps.length);
-      if (hi > lo) parts.push({ timestamps: decoded.timestamps.slice(lo, hi), values: decoded.values.slice(lo, hi) });
+      if (hi > lo)
+        parts.push({
+          timestamps: decoded.timestamps.slice(lo, hi),
+          values: decoded.values.slice(lo, hi),
+        });
     }
     if (s.hot.count > 0) {
       const lo = lowerBound(s.hot.timestamps, start, 0, s.hot.count);
       const hi = upperBound(s.hot.timestamps, end, lo, s.hot.count);
-      if (hi > lo) parts.push({ timestamps: s.hot.timestamps.slice(lo, hi), values: s.hot.values.slice(lo, hi) });
+      if (hi > lo)
+        parts.push({
+          timestamps: s.hot.timestamps.slice(lo, hi),
+          values: s.hot.values.slice(lo, hi),
+        });
     }
-    if (parts.length === 0) return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
+    if (parts.length === 0)
+      return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
     if (parts.length === 1) return parts[0];
     const totalLen = parts.reduce((s, p) => s + p.timestamps.length, 0);
     const ts = new BigInt64Array(totalLen);
     const vs = new Float64Array(totalLen);
     let off = 0;
-    for (const p of parts) { ts.set(p.timestamps, off); vs.set(p.values, off); off += p.timestamps.length; }
+    for (const p of parts) {
+      ts.set(p.timestamps, off);
+      vs.set(p.values, off);
+      off += p.timestamps.length;
+    }
     return { timestamps: ts, values: vs };
   }
 
-  labels(id) { return this._labels[id]; }
+  labels(id) {
+    return this._labels[id];
+  }
 
   memoryBytes() {
     let bytes = 0;
@@ -226,7 +270,7 @@ export class ChunkedStore {
 
 export class ColumnStore {
   constructor(chunkSize = 640) {
-    this.name = 'ColumnStore (ALP)';
+    this.name = "ColumnStore (ALP)";
     this.chunkSize = chunkSize;
     this._allSeries = [];
     this._groups = [];
@@ -236,15 +280,22 @@ export class ColumnStore {
     this._sampleCount = 0;
   }
 
-  get seriesCount() { return this._allSeries.length; }
-  get sampleCount() { return this._sampleCount; }
+  get seriesCount() {
+    return this._allSeries.length;
+  }
+  get sampleCount() {
+    return this._sampleCount;
+  }
 
   getOrCreateSeries(labels) {
     const key = makeLabelKey(labels);
     const cached = this._labelKeyMap.get(key);
     if (cached !== undefined) return cached;
     const existing = _findExistingSeriesId(this._labels, key);
-    if (existing >= 0) { this._labelKeyMap.set(key, existing); return existing; }
+    if (existing >= 0) {
+      this._labelKeyMap.set(key, existing);
+      return existing;
+    }
     const id = this._allSeries.length;
 
     const groupId = 0;
@@ -408,17 +459,24 @@ export class ColumnStore {
       }
     }
 
-    if (parts.length === 0) return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
+    if (parts.length === 0)
+      return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
     if (parts.length === 1) return parts[0];
     const totalLen = parts.reduce((s, p) => s + p.timestamps.length, 0);
     const ts = new BigInt64Array(totalLen);
     const vs = new Float64Array(totalLen);
     let off = 0;
-    for (const p of parts) { ts.set(p.timestamps, off); vs.set(p.values, off); off += p.timestamps.length; }
+    for (const p of parts) {
+      ts.set(p.timestamps, off);
+      vs.set(p.values, off);
+      off += p.timestamps.length;
+    }
     return { timestamps: ts, values: vs };
   }
 
-  labels(id) { return this._labels[id]; }
+  labels(id) {
+    return this._labels[id];
+  }
 
   memoryBytes() {
     let bytes = 0;
@@ -468,14 +526,19 @@ export class ColumnStore {
       hot: {
         count: s.hot.count,
         rawBytes: s.hot.count * 16,
-        allocatedBytes: (s.hot.values.byteLength) + (group.hotTimestamps.byteLength / Math.max(1, group.members.length)),
+        allocatedBytes:
+          s.hot.values.byteLength +
+          group.hotTimestamps.byteLength / Math.max(1, group.members.length),
         timestamps: group.hotTimestamps,
         values: s.hot.values,
       },
       _isColumnStore: true,
       _groupMembers: group.members.length,
       _sharedTsChunks: group.frozenTimestamps.length,
-      _sharedTsTotalBytes: group.frozenTimestamps.reduce((s, tc) => s + tc.compressed.byteLength, 0),
+      _sharedTsTotalBytes: group.frozenTimestamps.reduce(
+        (s, tc) => s + tc.compressed.byteLength,
+        0
+      ),
     };
   }
 }

--- a/site/tsdb-engine/js/utils.js
+++ b/site/tsdb-engine/js/utils.js
@@ -3,49 +3,60 @@
 export const $ = (sel) => document.querySelector(sel);
 
 export function formatBytes(b) {
-  if (b >= 1024 * 1024) return (b / (1024 * 1024)).toFixed(2) + ' MB';
-  if (b >= 1024) return (b / 1024).toFixed(1) + ' KB';
-  return b + ' B';
+  if (b >= 1024 * 1024) return `${(b / (1024 * 1024)).toFixed(2)} MB`;
+  if (b >= 1024) return `${(b / 1024).toFixed(1)} KB`;
+  return `${b} B`;
 }
 
 export function formatNum(n) {
-  if (Math.abs(n) >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
-  if (Math.abs(n) >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+  if (Math.abs(n) >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (Math.abs(n) >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   if (Math.abs(n) < 0.01 && n !== 0) return n.toExponential(1);
   return n.toFixed(1);
 }
 
 export function formatDuration(ms) {
-  if (ms >= 86400000) return (ms / 86400000) + 'd';
-  if (ms >= 3600000) return (ms / 3600000) + 'h';
-  if (ms >= 60000) return (ms / 60000) + 'm';
-  return (ms / 1000) + 's';
+  if (ms >= 86400000) return `${ms / 86400000}d`;
+  if (ms >= 3600000) return `${ms / 3600000}h`;
+  if (ms >= 60000) return `${ms / 60000}m`;
+  return `${ms / 1000}s`;
 }
 
 export function formatTimeRange(nsStart, nsEnd) {
   const start = new Date(Number(nsStart) / 1_000_000);
   const end = new Date(Number(nsEnd) / 1_000_000);
   const sameDay = start.toDateString() === end.toDateString();
-  const dateOpts = { month: 'short', day: 'numeric' };
-  const timeOpts = { hour: '2-digit', minute: '2-digit', hour12: false };
+  const dateOpts = { month: "short", day: "numeric" };
+  const timeOpts = { hour: "2-digit", minute: "2-digit", hour12: false };
   if (sameDay) {
     return `${start.toLocaleDateString([], dateOpts)} ${start.toLocaleTimeString([], timeOpts)}–${end.toLocaleTimeString([], timeOpts)}`;
   }
-  const fullOpts = { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false };
+  const fullOpts = {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  };
   return `${start.toLocaleString([], fullOpts)} → ${end.toLocaleString([], fullOpts)}`;
 }
 
 export function autoSelectQueryStep(intervalMs, numPoints) {
   const totalMs = intervalMs * numPoints;
-  const stepSelect = $('#queryStep');
+  const stepSelect = $("#queryStep");
   const targetBuckets = 100;
   const idealStepMs = totalMs / targetBuckets;
-  const stepOptions = [...stepSelect.options].map(o => parseInt(o.value)).filter(v => v > 0);
+  const stepOptions = [...stepSelect.options]
+    .map((o) => parseInt(o.value, 10))
+    .filter((v) => v > 0);
   let bestStep = stepOptions[0];
   let bestDiff = Infinity;
   for (const s of stepOptions) {
     const diff = Math.abs(s - idealStepMs);
-    if (diff < bestDiff) { bestDiff = diff; bestStep = s; }
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      bestStep = s;
+    }
   }
   stepSelect.value = String(bestStep);
 }
@@ -54,7 +65,8 @@ export function autoSelectQueryStep(intervalMs, numPoints) {
 export function lowerBound(arr, target, lo, hi) {
   while (lo < hi) {
     const mid = (lo + hi) >>> 1;
-    if (arr[mid] < target) lo = mid + 1; else hi = mid;
+    if (arr[mid] < target) lo = mid + 1;
+    else hi = mid;
   }
   return lo;
 }
@@ -62,7 +74,8 @@ export function lowerBound(arr, target, lo, hi) {
 export function upperBound(arr, target, lo, hi) {
   while (lo < hi) {
     const mid = (lo + hi) >>> 1;
-    if (arr[mid] <= target) lo = mid + 1; else hi = mid;
+    if (arr[mid] <= target) lo = mid + 1;
+    else hi = mid;
   }
   return lo;
 }
@@ -87,25 +100,31 @@ export function formatEpochNs(ns) {
 }
 
 export function superNum(n) {
-  const sup = '\u2070\u00B9\u00B2\u00B3\u2074\u2075\u2076\u2077\u2078\u2079';
-  return String(n).split('').map(c => sup[parseInt(c)] || c).join('');
+  const sup = "\u2070\u00B9\u00B2\u00B3\u2074\u2075\u2076\u2077\u2078\u2079";
+  return String(n)
+    .split("")
+    .map((c) => sup[parseInt(c, 10)] || c)
+    .join("");
 }
 
 export function formatHexByte(val) {
-  return val.toString(16).toUpperCase().padStart(2, '0');
+  return val.toString(16).toUpperCase().padStart(2, "0");
 }
 
 export function setupCanvasDPR(canvas, w, h) {
   const dpr = window.devicePixelRatio || 1;
   canvas.width = w * dpr;
   canvas.height = h * dpr;
-  canvas.style.width = w + 'px';
-  canvas.style.height = h + 'px';
-  const ctx = canvas.getContext('2d');
+  canvas.style.width = `${w}px`;
+  canvas.style.height = `${h}px`;
+  const ctx = canvas.getContext("2d");
   ctx.scale(dpr, dpr);
   return ctx;
 }
 
 export function makeLabelKey(labels) {
-  return [...labels].sort((a, b) => a[0] < b[0] ? -1 : 1).map(([k, v]) => k + '=' + v).join(',');
+  return [...labels]
+    .sort((a, b) => (a[0] < b[0] ? -1 : 1))
+    .map(([k, v]) => `${k}=${v}`)
+    .join(",");
 }

--- a/site/tsdb-engine/js/utils.js
+++ b/site/tsdb-engine/js/utils.js
@@ -49,6 +49,7 @@ export function autoSelectQueryStep(intervalMs, numPoints) {
   const stepOptions = [...stepSelect.options]
     .map((o) => parseInt(o.value, 10))
     .filter((v) => v > 0);
+  if (stepOptions.length === 0) return;
   let bestStep = stepOptions[0];
   let bestDiff = Infinity;
   for (const s of stepOptions) {

--- a/site/tsdb-engine/js/wasm.js
+++ b/site/tsdb-engine/js/wasm.js
@@ -6,7 +6,7 @@ export let wasmLoadError = null;
 
 export async function loadWasm() {
   try {
-    const wasmUrl = new URL('../o11ytsdb.wasm', import.meta.url).href;
+    const wasmUrl = new URL("../o11ytsdb.wasm", import.meta.url).href;
     const resp = await fetch(wasmUrl);
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     const { instance } = await WebAssembly.instantiate(await resp.arrayBuffer(), { env: {} });
@@ -15,12 +15,14 @@ export async function loadWasm() {
     return true;
   } catch (e) {
     wasmLoadError = e;
-    console.warn('WASM load failed:', e);
+    console.warn("WASM load failed:", e);
     return false;
   }
 }
 
-function wasmMem() { return new Uint8Array(wasmExports.memory.buffer); }
+function wasmMem() {
+  return new Uint8Array(wasmExports.memory.buffer);
+}
 
 export function wasmEncodeValuesALP(values) {
   const n = values.length;
@@ -49,7 +51,10 @@ export function wasmEncodeTimestamps(timestamps) {
   const tsPtr = wasmExports.allocScratch(n * 8);
   const outCap = n * 20;
   const outPtr = wasmExports.allocScratch(outCap);
-  wasmMem().set(new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength), tsPtr);
+  wasmMem().set(
+    new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength),
+    tsPtr
+  );
   const bytesWritten = wasmExports.encodeTimestamps(tsPtr, n, outPtr, outCap);
   return new Uint8Array(wasmExports.memory.buffer.slice(outPtr, outPtr + bytesWritten));
 }

--- a/site/tsdb-engine/learn/alp/alp-experience.css
+++ b/site/tsdb-engine/learn/alp/alp-experience.css
@@ -142,8 +142,12 @@
   background: var(--xp-success-glow);
 }
 
-.alp-check { color: var(--xp-success); }
-.alp-cross { color: var(--xp-error); }
+.alp-check {
+  color: var(--xp-success);
+}
+.alp-cross {
+  color: var(--xp-error);
+}
 
 /* ─── Quantize Two-Column ─────────────────────────────────────────── */
 .alp-quant-grid {
@@ -164,7 +168,8 @@
   font-size: 16px;
 }
 
-.alp-quant-grid .from, .alp-quant-grid .to {
+.alp-quant-grid .from,
+.alp-quant-grid .to {
   padding: 6px 10px;
   background: var(--xp-surface-raised);
   border-radius: var(--xp-radius-xs);
@@ -295,10 +300,20 @@
 }
 
 /* Alternating value colors for packed bits */
-.alp-packed-bit.v-even { background: rgba(96, 165, 250, 0.15); color: var(--xp-accent-light); }
-.alp-packed-bit.v-odd  { background: rgba(52, 211, 153, 0.15); color: var(--xp-success); }
-.alp-packed-bit.v-even[data-b="0"] { color: rgba(96, 165, 250, 0.35); }
-.alp-packed-bit.v-odd[data-b="0"]  { color: rgba(52, 211, 153, 0.35); }
+.alp-packed-bit.v-even {
+  background: rgba(96, 165, 250, 0.15);
+  color: var(--xp-accent-light);
+}
+.alp-packed-bit.v-odd {
+  background: rgba(52, 211, 153, 0.15);
+  color: var(--xp-success);
+}
+.alp-packed-bit.v-even[data-b="0"] {
+  color: rgba(96, 165, 250, 0.35);
+}
+.alp-packed-bit.v-odd[data-b="0"] {
+  color: rgba(52, 211, 153, 0.35);
+}
 
 /* ─── Exceptions Panel ────────────────────────────────────────────── */
 .alp-exc-list {
@@ -355,10 +370,22 @@
   min-width: 2px;
 }
 
-.alp-wire-seg.seg-header    { background: var(--region-header); color: #fff; }
-.alp-wire-seg.seg-packed    { background: var(--region-values); color: #fff; }
-.alp-wire-seg.seg-exc-pos   { background: var(--region-exceptions); color: #000; }
-.alp-wire-seg.seg-exc-val   { background: var(--xp-warn); color: #000; }
+.alp-wire-seg.seg-header {
+  background: var(--region-header);
+  color: #fff;
+}
+.alp-wire-seg.seg-packed {
+  background: var(--region-values);
+  color: #fff;
+}
+.alp-wire-seg.seg-exc-pos {
+  background: var(--region-exceptions);
+  color: #000;
+}
+.alp-wire-seg.seg-exc-val {
+  background: var(--xp-warn);
+  color: #000;
+}
 
 .alp-wire-legend {
   display: flex;
@@ -408,7 +435,8 @@
     gap: 4px 8px;
   }
 
-  .alp-quant-grid .from, .alp-quant-grid .to {
+  .alp-quant-grid .from,
+  .alp-quant-grid .to {
     padding: 4px 6px;
   }
 

--- a/site/tsdb-engine/learn/alp/index.html
+++ b/site/tsdb-engine/learn/alp/index.html
@@ -41,7 +41,7 @@
         <div id="custom-input-wrap" class="custom-input-wrap" hidden>
           <textarea id="custom-textarea" class="alp-textarea" rows="3"
             placeholder="Enter comma-separated floats, e.g. 3.14, 2.71, 1.41, 98.6, 0.577"></textarea>
-          <button class="xp-btn xp-btn-primary" id="apply-custom">Apply</button>
+          <button type="button" class="xp-btn xp-btn-primary" id="apply-custom">Apply</button>
         </div>
         <div class="xp-card alp-values-card" id="values-card">
           <div class="alp-values-scroll xp-scroll-x" id="values-scroll"></div>
@@ -54,10 +54,10 @@
         <p>Click any stage or use the controls to step through.</p>
         <div class="xp-pipeline" id="pipeline-bar"></div>
         <div class="xp-controls">
-          <button class="xp-btn" id="btn-prev">← Prev</button>
-          <button class="xp-btn" id="btn-next">Next →</button>
-          <button class="xp-btn" id="btn-play">▶ Play All</button>
-          <button class="xp-btn" id="btn-reset">Reset</button>
+          <button type="button" class="xp-btn" id="btn-prev">← Prev</button>
+          <button type="button" class="xp-btn" id="btn-next">Next →</button>
+          <button type="button" class="xp-btn" id="btn-play">▶ Play All</button>
+          <button type="button" class="xp-btn" id="btn-reset">Reset</button>
         </div>
       </section>
 

--- a/site/tsdb-engine/learn/delta-of-delta/dod-experience.css
+++ b/site/tsdb-engine/learn/delta-of-delta/dod-experience.css
@@ -62,22 +62,53 @@
 }
 
 /* Tier row tinting */
-.dod-table tr.tier-row-0 td { border-left: 3px solid var(--tier-0); }
-.dod-table tr.tier-row-1 td { border-left: 3px solid var(--tier-1); }
-.dod-table tr.tier-row-2 td { border-left: 3px solid var(--tier-2); }
-.dod-table tr.tier-row-3 td { border-left: 3px solid var(--tier-3); }
-.dod-table tr.tier-row-4 td { border-left: 3px solid var(--tier-4); }
-.dod-table tr.tier-row-header td { border-left: 3px solid var(--region-header); }
+.dod-table tr.tier-row-0 td {
+  border-left: 3px solid var(--tier-0);
+}
+.dod-table tr.tier-row-1 td {
+  border-left: 3px solid var(--tier-1);
+}
+.dod-table tr.tier-row-2 td {
+  border-left: 3px solid var(--tier-2);
+}
+.dod-table tr.tier-row-3 td {
+  border-left: 3px solid var(--tier-3);
+}
+.dod-table tr.tier-row-4 td {
+  border-left: 3px solid var(--tier-4);
+}
+.dod-table tr.tier-row-header td {
+  border-left: 3px solid var(--region-header);
+}
 
-.dod-table tr.tier-row-0 td:first-child { border-left-width: 3px; }
-.dod-table tr.tier-row-1 td:first-child { border-left-width: 3px; }
+.dod-table tr.tier-row-0 td:first-child {
+  border-left-width: 3px;
+}
+.dod-table tr.tier-row-1 td:first-child {
+  border-left-width: 3px;
+}
 
 /* Tier badge — base from .xp-badge in shared.css */
-.dod-tier-badge.t0 { background: rgba(52, 211, 153, 0.15); color: var(--tier-0); }
-.dod-tier-badge.t1 { background: rgba(96, 165, 250, 0.15); color: var(--tier-1); }
-.dod-tier-badge.t2 { background: rgba(167, 139, 250, 0.15); color: var(--tier-2); }
-.dod-tier-badge.t3 { background: rgba(251, 191, 36, 0.15); color: var(--tier-3); }
-.dod-tier-badge.t4 { background: rgba(248, 113, 113, 0.15); color: var(--tier-4); }
+.dod-tier-badge.t0 {
+  background: rgba(52, 211, 153, 0.15);
+  color: var(--tier-0);
+}
+.dod-tier-badge.t1 {
+  background: rgba(96, 165, 250, 0.15);
+  color: var(--tier-1);
+}
+.dod-tier-badge.t2 {
+  background: rgba(167, 139, 250, 0.15);
+  color: var(--tier-2);
+}
+.dod-tier-badge.t3 {
+  background: rgba(251, 191, 36, 0.15);
+  color: var(--tier-3);
+}
+.dod-tier-badge.t4 {
+  background: rgba(248, 113, 113, 0.15);
+  color: var(--tier-4);
+}
 
 /* ─── Tier Distribution Bar ───────────────────────────────────────── */
 .dod-tier-bar {
@@ -101,11 +132,26 @@
   overflow: hidden;
 }
 
-.dod-tier-seg.seg-0 { background: var(--tier-0); color: #0a1624; }
-.dod-tier-seg.seg-1 { background: var(--tier-1); color: #0a1624; }
-.dod-tier-seg.seg-2 { background: var(--tier-2); color: #0a1624; }
-.dod-tier-seg.seg-3 { background: var(--tier-3); color: #0a1624; }
-.dod-tier-seg.seg-4 { background: var(--tier-4); color: #0a1624; }
+.dod-tier-seg.seg-0 {
+  background: var(--tier-0);
+  color: #0a1624;
+}
+.dod-tier-seg.seg-1 {
+  background: var(--tier-1);
+  color: #0a1624;
+}
+.dod-tier-seg.seg-2 {
+  background: var(--tier-2);
+  color: #0a1624;
+}
+.dod-tier-seg.seg-3 {
+  background: var(--tier-3);
+  color: #0a1624;
+}
+.dod-tier-seg.seg-4 {
+  background: var(--tier-4);
+  color: #0a1624;
+}
 
 .dod-tier-legend {
   display: flex;
@@ -128,11 +174,21 @@
   flex-shrink: 0;
 }
 
-.dod-tier-dot.d0 { background: var(--tier-0); }
-.dod-tier-dot.d1 { background: var(--tier-1); }
-.dod-tier-dot.d2 { background: var(--tier-2); }
-.dod-tier-dot.d3 { background: var(--tier-3); }
-.dod-tier-dot.d4 { background: var(--tier-4); }
+.dod-tier-dot.d0 {
+  background: var(--tier-0);
+}
+.dod-tier-dot.d1 {
+  background: var(--tier-1);
+}
+.dod-tier-dot.d2 {
+  background: var(--tier-2);
+}
+.dod-tier-dot.d3 {
+  background: var(--tier-3);
+}
+.dod-tier-dot.d4 {
+  background: var(--tier-4);
+}
 
 /* ─── Bit Cost Profile Chart ──────────────────────────────────────── */
 .dod-bitcost-chart {
@@ -171,12 +227,24 @@
   position: relative;
 }
 
-.dod-bitcost-bar.bc-0 { background: var(--tier-0); }
-.dod-bitcost-bar.bc-1 { background: var(--tier-1); }
-.dod-bitcost-bar.bc-2 { background: var(--tier-2); }
-.dod-bitcost-bar.bc-3 { background: var(--tier-3); }
-.dod-bitcost-bar.bc-4 { background: var(--tier-4); }
-.dod-bitcost-bar.bc-header { background: var(--region-header); }
+.dod-bitcost-bar.bc-0 {
+  background: var(--tier-0);
+}
+.dod-bitcost-bar.bc-1 {
+  background: var(--tier-1);
+}
+.dod-bitcost-bar.bc-2 {
+  background: var(--tier-2);
+}
+.dod-bitcost-bar.bc-3 {
+  background: var(--tier-3);
+}
+.dod-bitcost-bar.bc-4 {
+  background: var(--tier-4);
+}
+.dod-bitcost-bar.bc-header {
+  background: var(--region-header);
+}
 
 .dod-bitcost-bits {
   font-family: var(--xp-mono);

--- a/site/tsdb-engine/learn/delta-of-delta/index.html
+++ b/site/tsdb-engine/learn/delta-of-delta/index.html
@@ -58,7 +58,7 @@
                 <span class="xp-slider-value" id="jitter-value">0 ms</span>
               </div>
             </div>
-            <button class="xp-btn xp-btn-primary" id="btn-regenerate">⟳ Regenerate</button>
+            <button type="button" class="xp-btn xp-btn-primary" id="btn-regenerate">⟳ Regenerate</button>
           </div>
         </div>
       </section>

--- a/site/tsdb-engine/learn/delta-of-delta/index.html
+++ b/site/tsdb-engine/learn/delta-of-delta/index.html
@@ -85,7 +85,7 @@
                 <tr>
                   <th>#</th>
                   <th>Timestamp</th>
-                  <th><span class="xp-term" data-term="delta">Δ</span> (delta)</th>
+                  <th><span class="xp-term" data-term="delta">Δ</span></th>
                   <th><span class="xp-term" data-term="delta-of-delta">ΔoΔ</span></th>
                   <th><span class="xp-term" data-term="zigzag">ZigZag</span></th>
                   <th><span class="xp-term" data-term="tier">Tier</span></th>

--- a/site/tsdb-engine/learn/query-engine/query-experience.css
+++ b/site/tsdb-engine/learn/query-engine/query-experience.css
@@ -576,6 +576,7 @@
     padding: 8px 10px;
   }
 
+  /* biome-ignore lint/style/noDescendingSpecificity: nested selector inside media query intentionally overrides base */
   #pipeline-bar .xp-pipe-stage .stage-label {
     font-size: 9px;
   }

--- a/site/tsdb-engine/learn/shared.css
+++ b/site/tsdb-engine/learn/shared.css
@@ -22,11 +22,11 @@
   --xp-error-glow: rgba(248, 113, 113, 0.12);
 
   /* Tier colors for encoding */
-  --tier-0: #34d399;   /* best compression */
-  --tier-1: #60a5fa;   /* good */
-  --tier-2: #a78bfa;   /* moderate */
-  --tier-3: #fbbf24;   /* poor */
-  --tier-4: #f87171;   /* worst / raw */
+  --tier-0: #34d399; /* best compression */
+  --tier-1: #60a5fa; /* good */
+  --tier-2: #a78bfa; /* moderate */
+  --tier-3: #fbbf24; /* poor */
+  --tier-4: #f87171; /* worst / raw */
 
   /* Region colors (from byte explorer) */
   --region-header: #8b5cf6;
@@ -45,7 +45,9 @@
   --xp-radius-xs: 4px;
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
 
 body {
   margin: 0;
@@ -224,7 +226,8 @@ body {
   border-color: var(--xp-accent);
 }
 
-.xp-btn.active, .xp-btn[aria-pressed="true"] {
+.xp-btn.active,
+.xp-btn[aria-pressed="true"] {
   background: var(--xp-accent-glow);
   border-color: var(--xp-accent);
   color: var(--xp-accent-light);
@@ -502,37 +505,86 @@ body {
 }
 
 /* ─── Tier Color Utilities ────────────────────────────────────────── */
-.tier-0 { color: var(--tier-0); }
-.tier-1 { color: var(--tier-1); }
-.tier-2 { color: var(--tier-2); }
-.tier-3 { color: var(--tier-3); }
-.tier-4 { color: var(--tier-4); }
+.tier-0 {
+  color: var(--tier-0);
+}
+.tier-1 {
+  color: var(--tier-1);
+}
+.tier-2 {
+  color: var(--tier-2);
+}
+.tier-3 {
+  color: var(--tier-3);
+}
+.tier-4 {
+  color: var(--tier-4);
+}
 
-.tier-0-bg { background: rgba(52, 211, 153, 0.12); border-color: rgba(52, 211, 153, 0.3); }
-.tier-1-bg { background: rgba(96, 165, 250, 0.12); border-color: rgba(96, 165, 250, 0.3); }
-.tier-2-bg { background: rgba(167, 139, 250, 0.12); border-color: rgba(167, 139, 250, 0.3); }
-.tier-3-bg { background: rgba(251, 191, 36, 0.12); border-color: rgba(251, 191, 36, 0.3); }
-.tier-4-bg { background: rgba(248, 113, 113, 0.12); border-color: rgba(248, 113, 113, 0.3); }
+.tier-0-bg {
+  background: rgba(52, 211, 153, 0.12);
+  border-color: rgba(52, 211, 153, 0.3);
+}
+.tier-1-bg {
+  background: rgba(96, 165, 250, 0.12);
+  border-color: rgba(96, 165, 250, 0.3);
+}
+.tier-2-bg {
+  background: rgba(167, 139, 250, 0.12);
+  border-color: rgba(167, 139, 250, 0.3);
+}
+.tier-3-bg {
+  background: rgba(251, 191, 36, 0.12);
+  border-color: rgba(251, 191, 36, 0.3);
+}
+.tier-4-bg {
+  background: rgba(248, 113, 113, 0.12);
+  border-color: rgba(248, 113, 113, 0.3);
+}
 
 /* ─── Responsive ──────────────────────────────────────────────────── */
 @media (max-width: 640px) {
-  .xp-page { padding: 0 14px 40px; }
-  .xp-card { padding: 16px; }
-  .xp-hero h1 { font-size: 26px; }
-  .xp-pipeline { gap: 0; }
-  .xp-stats-row { gap: 8px; }
-  .xp-stat { min-width: 80px; padding: 10px 12px; }
+  .xp-page {
+    padding: 0 14px 40px;
+  }
+  .xp-card {
+    padding: 16px;
+  }
+  .xp-hero h1 {
+    font-size: 26px;
+  }
+  .xp-pipeline {
+    gap: 0;
+  }
+  .xp-stats-row {
+    gap: 8px;
+  }
+  .xp-stat {
+    min-width: 80px;
+    padding: 10px 12px;
+  }
 }
 
 /* ─── Animations ──────────────────────────────────────────────────── */
 @keyframes xp-fade-in {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes xp-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }
 
 .xp-animate-in {
@@ -559,12 +611,27 @@ body {
 
 /* ─── Reveal pulse (gentle attention without forced scroll) ─────── */
 
-@keyframes xp-reveal-pulse {
-  0% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.4); }
-  70% { box-shadow: 0 0 0 8px rgba(99, 102, 241, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0); }
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes xp-reveal-pulse {
+    0% {
+      box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.4);
+    }
+    70% {
+      box-shadow: 0 0 0 8px rgba(99, 102, 241, 0);
+    }
+    100% {
+      box-shadow: 0 0 0 0 rgba(99, 102, 241, 0);
+    }
+  }
+  .xp-reveal {
+    animation: xp-reveal-pulse 0.6s ease-out;
+  }
 }
-.xp-reveal { animation: xp-reveal-pulse 0.6s ease-out; }
+@media (prefers-reduced-motion: reduce) {
+  .xp-reveal {
+    animation: none;
+  }
+}
 
 /* ─── Scrollable Container Utilities ─────────────────────────────── */
 

--- a/site/tsdb-engine/learn/shared.js
+++ b/site/tsdb-engine/learn/shared.js
@@ -5,7 +5,7 @@
 
 /** Format a number with locale-aware thousands separators. */
 export function fmt(n, decimals = 0) {
-  return Number(n).toLocaleString('en-US', {
+  return Number(n).toLocaleString("en-US", {
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,
   });
@@ -30,9 +30,9 @@ export function float64ToBits(value) {
   const buf = new ArrayBuffer(8);
   new Float64Array(buf)[0] = value;
   const bytes = new Uint8Array(buf);
-  let bits = '';
+  let bits = "";
   for (let i = 7; i >= 0; i--) {
-    bits += bytes[i].toString(2).padStart(8, '0');
+    bits += bytes[i].toString(2).padStart(8, "0");
   }
   return bits;
 }
@@ -40,9 +40,9 @@ export function float64ToBits(value) {
 /** Convert a BigInt (int64) to its bit string (64 chars). */
 export function int64ToBits(value) {
   const big = BigInt(value);
-  let s = '';
+  let s = "";
   for (let i = 63; i >= 0; i--) {
-    s += (big >> BigInt(i)) & 1n ? '1' : '0';
+    s += (big >> BigInt(i)) & 1n ? "1" : "0";
   }
   return s;
 }
@@ -50,13 +50,13 @@ export function int64ToBits(value) {
 /** ZigZag encode a signed value. */
 export function zigzagEncode(n) {
   const big = BigInt(n);
-  return big >= 0n ? big * 2n : (-big) * 2n - 1n;
+  return big >= 0n ? big * 2n : -big * 2n - 1n;
 }
 
 /** ZigZag decode an unsigned value. */
 export function zigzagDecode(n) {
   const big = BigInt(n);
-  return (big & 1n) ? -(big >> 1n) - 1n : big >> 1n;
+  return big & 1n ? -(big >> 1n) - 1n : big >> 1n;
 }
 
 /** Count leading zero bits in a 64-bit value. */
@@ -101,22 +101,27 @@ export function generateSamples(pattern, count, opts = {}) {
     timestamps[i] = now - BigInt(count - i) * interval + jitterNs;
 
     switch (pattern) {
-      case 'gauge':
+      case "gauge":
         values[i] = base + Math.sin(i * 0.05) * 20 + (Math.random() - 0.5) * noise * base;
         break;
-      case 'counter':
+      case "counter":
         values[i] = i === 0 ? base : values[i - 1] + Math.random() * 5 + 1;
         break;
-      case 'percentage':
-        values[i] = Math.round(Math.max(0, Math.min(100, 50 + Math.sin(i * 0.08) * 30 + (Math.random() - 0.5) * 10)) * 10) / 10;
+      case "percentage":
+        values[i] =
+          Math.round(
+            Math.max(0, Math.min(100, 50 + Math.sin(i * 0.08) * 30 + (Math.random() - 0.5) * 10)) *
+              10
+          ) / 10;
         break;
-      case 'temperature':
-        values[i] = Math.round((20 + Math.sin(i * 0.03) * 8 + (Math.random() - 0.5) * 2) * 100) / 100;
+      case "temperature":
+        values[i] =
+          Math.round((20 + Math.sin(i * 0.03) * 8 + (Math.random() - 0.5) * 2) * 100) / 100;
         break;
-      case 'sine':
+      case "sine":
         values[i] = Math.sin(i * 0.1) * base;
         break;
-      case 'random':
+      case "random":
         values[i] = Math.random() * base * 2;
         break;
       default:
@@ -154,21 +159,33 @@ export class Stepper {
     this.onStep(this.current);
   }
 
-  next() { if (this.current < this.total - 1) this.goto(this.current + 1); }
-  prev() { if (this.current > -1) this.goto(this.current - 1); }
-  reset() { this.goto(-1); }
+  next() {
+    if (this.current < this.total - 1) this.goto(this.current + 1);
+  }
+  prev() {
+    if (this.current > -1) this.goto(this.current - 1);
+  }
+  reset() {
+    this.goto(-1);
+  }
 
   play(intervalMs = 1200) {
     this.stop();
     this.reset();
     this._timer = setInterval(() => {
-      if (this.current >= this.total - 1) { this.stop(); return; }
+      if (this.current >= this.total - 1) {
+        this.stop();
+        return;
+      }
       this.next();
     }, intervalMs);
   }
 
   stop() {
-    if (this._timer) { clearInterval(this._timer); this._timer = null; }
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
   }
 }
 
@@ -180,13 +197,13 @@ export const $$ = (sel, root = document) => [...root.querySelectorAll(sel)];
 export function el(tag, attrs = {}, ...children) {
   const e = document.createElement(tag);
   for (const [k, v] of Object.entries(attrs)) {
-    if (k === 'class') e.className = v;
-    else if (k === 'style' && typeof v === 'object') Object.assign(e.style, v);
-    else if (k.startsWith('on')) e.addEventListener(k.slice(2).toLowerCase(), v);
+    if (k === "class") e.className = v;
+    else if (k === "style" && typeof v === "object") Object.assign(e.style, v);
+    else if (k.startsWith("on")) e.addEventListener(k.slice(2).toLowerCase(), v);
     else e.setAttribute(k, v);
   }
   for (const c of children) {
-    if (typeof c === 'string') e.appendChild(document.createTextNode(c));
+    if (typeof c === "string") e.appendChild(document.createTextNode(c));
     else if (c) e.appendChild(c);
   }
   return e;
@@ -209,7 +226,8 @@ export function buildBreadcrumb(title) {
 /** Gently reveal a section — only scrolls if not already visible, adds a brief highlight pulse. */
 export function revealSection(el) {
   const rect = el.getBoundingClientRect();
-  const inView = rect.top >= 0 && rect.bottom <= window.innerHeight;
+  const visibleHeight = Math.min(rect.bottom, window.innerHeight) - Math.max(rect.top, 0);
+  const inView = visibleHeight / rect.height >= 0.5;
   if (!inView) {
     el.scrollIntoView({ behavior: "smooth", block: "nearest" });
   }
@@ -219,8 +237,8 @@ export function revealSection(el) {
 
 /** Render a sparkline to a canvas element. */
 export function drawSparkline(canvas, values, opts = {}) {
-  const { color = '#60a5fa', fillAlpha = 0.1, lineWidth = 1.5 } = opts;
-  const ctx = canvas.getContext('2d');
+  const { color = "#60a5fa", fillAlpha = 0.1, lineWidth = 1.5 } = opts;
+  const ctx = canvas.getContext("2d");
   const dpr = window.devicePixelRatio || 1;
   const w = canvas.clientWidth;
   const h = canvas.clientHeight;
@@ -249,7 +267,7 @@ export function drawSparkline(canvas, values, opts = {}) {
   ctx.lineTo(w, h);
   ctx.lineTo(0, h);
   ctx.closePath();
-  ctx.fillStyle = color.replace(')', `, ${fillAlpha})`).replace('rgb', 'rgba');
+  ctx.fillStyle = color.replace(")", `, ${fillAlpha})`).replace("rgb", "rgba");
   ctx.fill();
 }
 
@@ -263,15 +281,21 @@ export function drawSparkline(canvas, values, opts = {}) {
  * @param {object} [opts]  – opts.cls (extra class on value), opts.color (inline color on value)
  * @returns {HTMLElement}
  */
-export function buildStat(label, value, unit = '', opts = {}) {
-  const valueEl = el('div', {
-    class: ['xp-stat-value', opts.cls].filter(Boolean).join(' '),
-    ...(opts.color ? { style: { color: opts.color } } : {}),
-  }, String(value));
-  return el('div', { class: 'xp-stat' },
-    el('div', { class: 'xp-stat-label' }, label),
+export function buildStat(label, value, unit = "", opts = {}) {
+  const valueEl = el(
+    "div",
+    {
+      class: ["xp-stat-value", opts.cls].filter(Boolean).join(" "),
+      ...(opts.color ? { style: { color: opts.color } } : {}),
+    },
+    String(value)
+  );
+  return el(
+    "div",
+    { class: "xp-stat" },
+    el("div", { class: "xp-stat-label" }, label),
     valueEl,
-    unit ? el('div', { class: 'xp-stat-unit' }, unit) : null,
+    unit ? el("div", { class: "xp-stat-unit" }, unit) : null
   );
 }
 
@@ -279,7 +303,7 @@ export function buildStat(label, value, unit = '', opts = {}) {
 
 /** Promise-based sleep. */
 export function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /* ─── Glossary Definitions ─────────────────────────────────── */

--- a/site/tsdb-engine/learn/xor-delta/index.html
+++ b/site/tsdb-engine/learn/xor-delta/index.html
@@ -75,6 +75,10 @@
             </table>
           </div>
         </div>
+        <p class="xor-ieee-note">
+          <span class="xp-term" data-term="IEEE 754">IEEE 754</span> float64 layout:
+          <strong>1</strong> sign bit · <strong>11</strong> exponent bits · <strong>52</strong> fraction bits
+        </p>
       </section>
 
       <!-- D. Encoding Decision Tree -->

--- a/site/tsdb-engine/learn/xor-delta/xor-experience.css
+++ b/site/tsdb-engine/learn/xor-delta/xor-experience.css
@@ -517,3 +517,13 @@
     font-size: 9px;
   }
 }
+
+/* ─── IEEE 754 note ───────────────────────────────────────────────── */
+
+.xor-ieee-note {
+  font-size: 0.75rem;
+  color: var(--xp-text-muted, #94a3b8);
+  margin: 4px 0 8px;
+  letter-spacing: 0.02em;
+}
+.xor-ieee-note strong { color: var(--xp-accent); }

--- a/site/tsdb-engine/test/byte-explorer-logic.test.js
+++ b/site/tsdb-engine/test/byte-explorer-logic.test.js
@@ -1,23 +1,32 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from "vitest";
 import {
+  buildALPBitMap,
+  buildALPInsightHtml,
+  buildByteLookup,
+  buildByteRegionMap,
+  buildXORInsightHtml,
+  encodingDescription,
+  entryByteRange,
   parseALPHeader,
   parseXORHeader,
-  buildALPBitMap,
-  buildByteLookup,
-  entryByteRange,
-  buildByteRegionMap,
   renderHexRowHTML,
-  encodingDescription,
-  buildALPInsightHtml,
-  buildXORInsightHtml,
-} from '../js/byte-explorer-logic.js';
-import { encodeChunk, BitWriter } from '../js/codec.js';
+} from "../js/byte-explorer-logic.js";
+import { BitWriter, encodeChunk } from "../js/codec.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function makeALPBlob({ count, exponent, bitWidth, minInt, excCount, offsets, excPositions, excValues }) {
+function makeALPBlob({
+  count,
+  exponent,
+  bitWidth,
+  minInt,
+  excCount,
+  offsets,
+  excPositions,
+  excValues,
+}) {
   // 14-byte header + bit-packed offsets + exception positions + exception values
-  const bpBytes = Math.ceil(count * bitWidth / 8);
+  const bpBytes = Math.ceil((count * bitWidth) / 8);
   const totalLen = 14 + bpBytes + excCount * 2 + excCount * 8;
   const buf = new Uint8Array(totalLen);
   const dv = new DataView(buf.buffer);
@@ -37,7 +46,7 @@ function makeALPBlob({ count, exponent, bitWidth, minInt, excCount, offsets, exc
       const byteIdx = Math.floor(globalBit / 8);
       const bitIdx = 7 - (globalBit % 8);
       if (Number((val >> BigInt(bitWidth - 1 - b)) & 1n)) {
-        buf[byteIdx] |= (1 << bitIdx);
+        buf[byteIdx] |= 1 << bitIdx;
       }
     }
   }
@@ -76,16 +85,25 @@ function makeTimestampBlob(timestamps) {
       const absDod = dod < 0n ? -dod : dod;
       const zz = Number(dod < 0n ? absDod * 2n - 1n : absDod * 2n);
       if (absDod <= 64n) {
-        bw.writeBit(1); bw.writeBit(0); // prefix: 10
+        bw.writeBit(1);
+        bw.writeBit(0); // prefix: 10
         bw.writeBitsNum(zz, 7);
       } else if (absDod <= 256n) {
-        bw.writeBit(1); bw.writeBit(1); bw.writeBit(0); // prefix: 110
+        bw.writeBit(1);
+        bw.writeBit(1);
+        bw.writeBit(0); // prefix: 110
         bw.writeBitsNum(zz, 9);
       } else if (absDod <= 2048n) {
-        bw.writeBit(1); bw.writeBit(1); bw.writeBit(1); bw.writeBit(0); // prefix: 1110
+        bw.writeBit(1);
+        bw.writeBit(1);
+        bw.writeBit(1);
+        bw.writeBit(0); // prefix: 1110
         bw.writeBitsNum(zz, 12);
       } else {
-        bw.writeBit(1); bw.writeBit(1); bw.writeBit(1); bw.writeBit(1); // prefix: 1111
+        bw.writeBit(1);
+        bw.writeBit(1);
+        bw.writeBit(1);
+        bw.writeBit(1); // prefix: 1111
         bw.writeBits(BigInt.asUintN(64, dod), 64);
       }
     }
@@ -98,11 +116,17 @@ function makeTimestampBlob(timestamps) {
 
 // ── Tests ────────────────────────────────────────────────────────────
 
-describe('parseALPHeader', () => {
-  it('parses a valid 14-byte ALP header', () => {
+describe("parseALPHeader", () => {
+  it("parses a valid 14-byte ALP header", () => {
     const blob = makeALPBlob({
-      count: 100, exponent: 3, bitWidth: 11, minInt: 42000n,
-      excCount: 0, offsets: new Array(100).fill(0), excPositions: [], excValues: [],
+      count: 100,
+      exponent: 3,
+      bitWidth: 11,
+      minInt: 42000n,
+      excCount: 0,
+      offsets: new Array(100).fill(0),
+      excPositions: [],
+      excValues: [],
     });
     const hdr = parseALPHeader(blob);
     expect(hdr.count).toBe(100);
@@ -112,7 +136,7 @@ describe('parseALPHeader', () => {
     expect(hdr.excCount).toBe(0);
   });
 
-  it('handles small blobs gracefully', () => {
+  it("handles small blobs gracefully", () => {
     const hdr = parseALPHeader(new Uint8Array(3));
     expect(hdr.count).toBe(0);
     expect(hdr.bitWidth).toBe(0);
@@ -120,15 +144,15 @@ describe('parseALPHeader', () => {
     expect(hdr.excCount).toBe(0);
   });
 
-  it('handles empty blob', () => {
+  it("handles empty blob", () => {
     const hdr = parseALPHeader(new Uint8Array(0));
     expect(hdr.count).toBe(0);
     expect(hdr.exponent).toBe(0);
   });
 });
 
-describe('parseXORHeader', () => {
-  it('parses a valid 18-byte XOR header', () => {
+describe("parseXORHeader", () => {
+  it("parses a valid 18-byte XOR header", () => {
     const timestamps = [1000000000n, 1001000000n, 1002000000n];
     const values = [42.5, 42.7, 42.9];
     const encoded = encodeChunk(timestamps, values);
@@ -139,7 +163,7 @@ describe('parseXORHeader', () => {
     expect(hdr.firstVal).toBeCloseTo(42.5);
   });
 
-  it('handles small blobs', () => {
+  it("handles small blobs", () => {
     const hdr = parseXORHeader(new Uint8Array(5));
     expect(hdr.count).toBe(0);
     expect(hdr.firstTs).toBe(0n);
@@ -147,22 +171,28 @@ describe('parseXORHeader', () => {
   });
 });
 
-describe('buildALPBitMap', () => {
-  it('builds value entries for bit-packed offsets', () => {
+describe("buildALPBitMap", () => {
+  it("builds value entries for bit-packed offsets", () => {
     const offsets = [5, 10, 15, 20, 25];
     const blob = makeALPBlob({
-      count: 5, exponent: 3, bitWidth: 8, minInt: 1000n,
-      excCount: 0, offsets, excPositions: [], excValues: [],
+      count: 5,
+      exponent: 3,
+      bitWidth: 8,
+      minInt: 1000n,
+      excCount: 0,
+      offsets,
+      excPositions: [],
+      excValues: [],
     });
 
     const bitMap = buildALPBitMap(blob, null, 5);
-    const values = bitMap.filter(e => e.type === 'value');
+    const values = bitMap.filter((e) => e.type === "value");
 
     expect(values).toHaveLength(5);
     values.forEach((entry, i) => {
       expect(entry.sampleIndex).toBe(i);
-      expect(entry.type).toBe('value');
-      expect(entry.encoding).toBe('alp-bitpacked');
+      expect(entry.type).toBe("value");
+      expect(entry.encoding).toBe("alp-bitpacked");
       expect(entry.offset).toBe(offsets[i]);
       expect(entry.bitWidth).toBe(8);
       expect(entry.isException).toBe(false);
@@ -171,50 +201,66 @@ describe('buildALPBitMap', () => {
     });
   });
 
-  it('marks exceptions correctly', () => {
+  it("marks exceptions correctly", () => {
     const blob = makeALPBlob({
-      count: 3, exponent: 2, bitWidth: 4, minInt: 0n,
-      excCount: 1, offsets: [1, 2, 3],
-      excPositions: [1], excValues: [99.99],
+      count: 3,
+      exponent: 2,
+      bitWidth: 4,
+      minInt: 0n,
+      excCount: 1,
+      offsets: [1, 2, 3],
+      excPositions: [1],
+      excValues: [99.99],
     });
 
     const bitMap = buildALPBitMap(blob, null, 3);
-    const values = bitMap.filter(e => e.type === 'value');
+    const values = bitMap.filter((e) => e.type === "value");
 
     expect(values[0].isException).toBe(false);
     expect(values[1].isException).toBe(true);
-    expect(values[1].encoding).toBe('alp-exception');
+    expect(values[1].encoding).toBe("alp-exception");
     expect(values[1].decoded).toBeCloseTo(99.99);
     expect(values[2].isException).toBe(false);
   });
 
-  it('includes timestamp entries when tsBlob provided', () => {
+  it("includes timestamp entries when tsBlob provided", () => {
     const blob = makeALPBlob({
-      count: 3, exponent: 3, bitWidth: 8, minInt: 0n,
-      excCount: 0, offsets: [1, 2, 3], excPositions: [], excValues: [],
+      count: 3,
+      exponent: 3,
+      bitWidth: 8,
+      minInt: 0n,
+      excCount: 0,
+      offsets: [1, 2, 3],
+      excPositions: [],
+      excValues: [],
     });
     const tsBlob = makeTimestampBlob([1000000000, 1001000000, 1002000000]);
 
     const bitMap = buildALPBitMap(blob, tsBlob, 3);
-    const tsEntries = bitMap.filter(e => e.type === 'timestamp');
+    const tsEntries = bitMap.filter((e) => e.type === "timestamp");
 
     expect(tsEntries).toHaveLength(3);
-    expect(tsEntries[0].encoding).toBe('raw');
+    expect(tsEntries[0].encoding).toBe("raw");
     expect(tsEntries[0].decoded).toBe(1000000000n);
     // Subsequent timestamps use delta-of-delta encoding
     expect(tsEntries[1].sampleIndex).toBe(1);
     expect(tsEntries[2].sampleIndex).toBe(2);
   });
 
-  it('bit positions are non-overlapping and contiguous for values', () => {
+  it("bit positions are non-overlapping and contiguous for values", () => {
     const blob = makeALPBlob({
-      count: 10, exponent: 2, bitWidth: 5, minInt: 0n,
-      excCount: 0, offsets: Array.from({ length: 10 }, (_, i) => i),
-      excPositions: [], excValues: [],
+      count: 10,
+      exponent: 2,
+      bitWidth: 5,
+      minInt: 0n,
+      excCount: 0,
+      offsets: Array.from({ length: 10 }, (_, i) => i),
+      excPositions: [],
+      excValues: [],
     });
 
     const bitMap = buildALPBitMap(blob, null, 10);
-    const values = bitMap.filter(e => e.type === 'value');
+    const values = bitMap.filter((e) => e.type === "value");
 
     for (let i = 1; i < values.length; i++) {
       expect(values[i].startBit).toBe(values[i - 1].endBit);
@@ -222,16 +268,16 @@ describe('buildALPBitMap', () => {
   });
 });
 
-describe('buildByteLookup', () => {
-  it('returns null for empty bitMap', () => {
+describe("buildByteLookup", () => {
+  it("returns null for empty bitMap", () => {
     expect(buildByteLookup(null, 100)).toBeNull();
     expect(buildByteLookup([], 100)).toBeNull();
   });
 
-  it('maps bytes to their dominant entry', () => {
+  it("maps bytes to their dominant entry", () => {
     const bitMap = [
-      { sampleIndex: 0, type: 'value', startBit: 0, endBit: 16 },  // 2 full bytes
-      { sampleIndex: 1, type: 'value', startBit: 16, endBit: 32 }, // 2 more bytes
+      { sampleIndex: 0, type: "value", startBit: 0, endBit: 16 }, // 2 full bytes
+      { sampleIndex: 1, type: "value", startBit: 16, endBit: 32 }, // 2 more bytes
     ];
 
     const lookup = buildByteLookup(bitMap, 4);
@@ -241,12 +287,12 @@ describe('buildByteLookup', () => {
     expect(lookup[3]).toBe(bitMap[1]);
   });
 
-  it('handles sub-byte entries (assigns byte to majority owner)', () => {
+  it("handles sub-byte entries (assigns byte to majority owner)", () => {
     // Entry A owns bits 0-5 (6 bits) of byte 0
     // Entry B owns bits 6-12 (7 bits) spanning byte 0 (2 bits) and byte 1 (5 bits)
     const bitMap = [
-      { sampleIndex: 0, type: 'value', startBit: 0, endBit: 6 },
-      { sampleIndex: 1, type: 'value', startBit: 6, endBit: 13 },
+      { sampleIndex: 0, type: "value", startBit: 0, endBit: 6 },
+      { sampleIndex: 1, type: "value", startBit: 6, endBit: 13 },
     ];
 
     const lookup = buildByteLookup(bitMap, 2);
@@ -256,10 +302,8 @@ describe('buildByteLookup', () => {
     expect(lookup[1]).toBe(bitMap[1]);
   });
 
-  it('handles blobOffset for timestamp entries', () => {
-    const bitMap = [
-      { sampleIndex: 0, type: 'timestamp', startBit: 0, endBit: 16, blobOffset: 10 },
-    ];
+  it("handles blobOffset for timestamp entries", () => {
+    const bitMap = [{ sampleIndex: 0, type: "timestamp", startBit: 0, endBit: 16, blobOffset: 10 }];
 
     const lookup = buildByteLookup(bitMap, 20);
     // Bits 0-15 at blobOffset 10 → global bits 80-95 → bytes 10-11
@@ -270,22 +314,22 @@ describe('buildByteLookup', () => {
   });
 });
 
-describe('entryByteRange', () => {
-  it('computes byte range for a value entry', () => {
+describe("entryByteRange", () => {
+  it("computes byte range for a value entry", () => {
     const entry = { startBit: 0, endBit: 24 };
     const range = entryByteRange(entry, 100);
     expect(range.startByte).toBe(0);
     expect(range.endByte).toBe(3);
   });
 
-  it('handles partial-byte entries', () => {
+  it("handles partial-byte entries", () => {
     const entry = { startBit: 3, endBit: 13 };
     const range = entryByteRange(entry, 100);
     expect(range.startByte).toBe(0);
     expect(range.endByte).toBe(2); // ceil(13/8) = 2
   });
 
-  it('handles blobOffset', () => {
+  it("handles blobOffset", () => {
     const entry = { startBit: 0, endBit: 16, blobOffset: 5 };
     const range = entryByteRange(entry, 20);
     // Global bits: 40-55 → bytes 5-6
@@ -293,15 +337,15 @@ describe('entryByteRange', () => {
     expect(range.endByte).toBe(7);
   });
 
-  it('clamps to totalBytes', () => {
+  it("clamps to totalBytes", () => {
     const entry = { startBit: 0, endBit: 200 };
     const range = entryByteRange(entry, 10);
     expect(range.endByte).toBe(10);
   });
 });
 
-describe('buildByteRegionMap', () => {
-  it('maps bytes to region indices', () => {
+describe("buildByteRegionMap", () => {
+  it("maps bytes to region indices", () => {
     const regions = [
       { start: 0, end: 14 },
       { start: 14, end: 100 },
@@ -314,7 +358,7 @@ describe('buildByteRegionMap', () => {
     expect(map[99]).toBe(1);
   });
 
-  it('handles overlapping regions (last wins)', () => {
+  it("handles overlapping regions (last wins)", () => {
     const regions = [
       { start: 0, end: 20 },
       { start: 10, end: 30 },
@@ -325,171 +369,203 @@ describe('buildByteRegionMap', () => {
   });
 });
 
-describe('renderHexRowHTML', () => {
-  it('renders a hex row with correct offset and values', () => {
+describe("renderHexRowHTML", () => {
+  it("renders a hex row with correct offset and values", () => {
     const bytes = new Uint8Array([0x48, 0x65, 0x6c, 0x6c]); // "Hell"
     const byteRegion = new Uint8Array([0, 0, 0, 0]);
-    const regions = [{ cls: 'header' }];
+    const regions = [{ cls: "header" }];
 
-    const html = renderHexRowHTML(0, 4, bytes, byteRegion, regions, 'hex', null);
+    const html = renderHexRowHTML(0, 4, bytes, byteRegion, regions, "hex", null);
 
-    expect(html).toContain('0x0000');
-    expect(html).toContain('48');
-    expect(html).toContain('65');
-    expect(html).toContain('6C');
-    expect(html).toContain('6C');
-    expect(html).toContain('region-header');
-    expect(html).toContain('Hell'); // ASCII column
+    expect(html).toContain("0x0000");
+    expect(html).toContain("48");
+    expect(html).toContain("65");
+    expect(html).toContain("6C");
+    expect(html).toContain("6C");
+    expect(html).toContain("region-header");
+    expect(html).toContain("Hell"); // ASCII column
   });
 
-  it('renders decimal mode with smaller font', () => {
+  it("renders decimal mode with smaller font", () => {
     const bytes = new Uint8Array([255, 0, 128]);
     const byteRegion = new Uint8Array([0, 0, 0]);
-    const regions = [{ cls: 'values' }];
+    const regions = [{ cls: "values" }];
 
-    const html = renderHexRowHTML(0, 3, bytes, byteRegion, regions, 'decimal', null);
+    const html = renderHexRowHTML(0, 3, bytes, byteRegion, regions, "decimal", null);
 
-    expect(html).toContain('255');
-    expect(html).toContain('  0');
-    expect(html).toContain('128');
-    expect(html).toContain('font-size:8px');
+    expect(html).toContain("255");
+    expect(html).toContain("  0");
+    expect(html).toContain("128");
+    expect(html).toContain("font-size:8px");
   });
 
-  it('adds sample mapping classes when byteLookup provided', () => {
+  it("adds sample mapping classes when byteLookup provided", () => {
     const bytes = new Uint8Array([10, 20, 30, 40]);
     const byteRegion = new Uint8Array([0, 0, 0, 0]);
-    const regions = [{ cls: 'values' }];
-    const entryA = { sampleIndex: 0, type: 'value' };
-    const entryB = { sampleIndex: 1, type: 'timestamp' };
+    const regions = [{ cls: "values" }];
+    const entryA = { sampleIndex: 0, type: "value" };
+    const entryB = { sampleIndex: 1, type: "timestamp" };
     const byteLookup = [entryA, entryA, entryB, entryB];
 
-    const html = renderHexRowHTML(0, 4, bytes, byteRegion, regions, 'hex', byteLookup);
+    const html = renderHexRowHTML(0, 4, bytes, byteRegion, regions, "hex", byteLookup);
 
-    expect(html).toContain('hex-mapped');
-    expect(html).toContain('hex-sample-even');
-    expect(html).toContain('hex-sample-odd');
-    expect(html).toContain('hex-val');
-    expect(html).toContain('hex-ts');
-    expect(html).toContain('hex-boundary');
+    expect(html).toContain("hex-mapped");
+    expect(html).toContain("hex-sample-even");
+    expect(html).toContain("hex-sample-odd");
+    expect(html).toContain("hex-val");
+    expect(html).toContain("hex-ts");
+    expect(html).toContain("hex-boundary");
   });
 
-  it('handles non-printable ASCII correctly', () => {
-    const bytes = new Uint8Array([0x00, 0x1F, 0x7F, 0x41]); // control chars + 'A'
+  it("handles non-printable ASCII correctly", () => {
+    const bytes = new Uint8Array([0x00, 0x1f, 0x7f, 0x41]); // control chars + 'A'
     const byteRegion = new Uint8Array([0, 0, 0, 0]);
-    const regions = [{ cls: 'header' }];
+    const regions = [{ cls: "header" }];
 
-    const html = renderHexRowHTML(0, 4, bytes, byteRegion, regions, 'hex', null);
-    expect(html).toContain('\u00b7\u00b7\u00b7A'); // dots for non-printable + 'A'
+    const html = renderHexRowHTML(0, 4, bytes, byteRegion, regions, "hex", null);
+    expect(html).toContain("\u00b7\u00b7\u00b7A"); // dots for non-printable + 'A'
   });
 
-  it('pads rows correctly for offset > 0', () => {
+  it("pads rows correctly for offset > 0", () => {
     const bytes = new Uint8Array(64);
     const byteRegion = new Uint8Array(64);
-    const regions = [{ cls: 'values' }];
+    const regions = [{ cls: "values" }];
 
-    const html = renderHexRowHTML(1, 32, bytes, byteRegion, regions, 'hex', null);
-    expect(html).toContain('0x0020'); // row 1 * 32 = 32 = 0x20
+    const html = renderHexRowHTML(1, 32, bytes, byteRegion, regions, "hex", null);
+    expect(html).toContain("0x0020"); // row 1 * 32 = 32 = 0x20
   });
 
-  it('HTML-escapes <, >, & in ASCII column', () => {
+  it("HTML-escapes <, >, & in ASCII column", () => {
     // bytes 0x3C = '<', 0x3E = '>', 0x26 = '&'
-    const bytes = new Uint8Array([0x41, 0x3C, 0x3E, 0x26]);
+    const bytes = new Uint8Array([0x41, 0x3c, 0x3e, 0x26]);
     const byteRegion = [0, 0, 0, 0];
-    const regions = [{ name: 'test', cls: 'test' }];
-    const html = renderHexRowHTML(0, 4, bytes, byteRegion, regions, 'hex', null);
+    const regions = [{ name: "test", cls: "test" }];
+    const html = renderHexRowHTML(0, 4, bytes, byteRegion, regions, "hex", null);
     // ASCII column must use HTML entities, not raw characters
-    expect(html).toContain('&lt;');
-    expect(html).toContain('&gt;');
-    expect(html).toContain('&amp;');
+    expect(html).toContain("&lt;");
+    expect(html).toContain("&gt;");
+    expect(html).toContain("&amp;");
     // The ASCII div should contain escaped versions: A&lt;&gt;&amp;
-    expect(html).toContain('A&lt;&gt;&amp;');
+    expect(html).toContain("A&lt;&gt;&amp;");
   });
 });
 
-describe('encodingDescription', () => {
-  it('describes raw encoding', () => {
-    expect(encodingDescription({ encoding: 'raw' })).toContain('Raw');
+describe("encodingDescription", () => {
+  it("describes raw encoding", () => {
+    expect(encodingDescription({ encoding: "raw" })).toContain("Raw");
   });
 
-  it('describes dod-zero', () => {
-    const desc = encodingDescription({ encoding: 'dod-zero' });
-    expect(desc).toContain('Δ²');
-    expect(desc).toContain('1 bit');
+  it("describes dod-zero", () => {
+    const desc = encodingDescription({ encoding: "dod-zero" });
+    expect(desc).toContain("Δ²");
+    expect(desc).toContain("1 bit");
   });
 
-  it('describes all dod encodings', () => {
-    expect(encodingDescription({ encoding: 'dod-7bit' })).toContain('7-bit');
-    expect(encodingDescription({ encoding: 'dod-9bit' })).toContain('9-bit');
-    expect(encodingDescription({ encoding: 'dod-12bit' })).toContain('12-bit');
-    expect(encodingDescription({ encoding: 'dod-64bit' })).toContain('64-bit');
+  it("describes all dod encodings", () => {
+    expect(encodingDescription({ encoding: "dod-7bit" })).toContain("7-bit");
+    expect(encodingDescription({ encoding: "dod-9bit" })).toContain("9-bit");
+    expect(encodingDescription({ encoding: "dod-12bit" })).toContain("12-bit");
+    expect(encodingDescription({ encoding: "dod-64bit" })).toContain("64-bit");
   });
 
-  it('describes xor encodings', () => {
-    expect(encodingDescription({ encoding: 'xor-zero' })).toContain('XOR = 0');
-    expect(encodingDescription({ encoding: 'xor-reuse', meaningful: 12 })).toContain('12 meaningful');
-    expect(encodingDescription({ encoding: 'xor-new', leading: 5, meaningful: 20 })).toContain('leading(5)');
+  it("describes xor encodings", () => {
+    expect(encodingDescription({ encoding: "xor-zero" })).toContain("XOR = 0");
+    expect(encodingDescription({ encoding: "xor-reuse", meaningful: 12 })).toContain(
+      "12 meaningful"
+    );
+    expect(encodingDescription({ encoding: "xor-new", leading: 5, meaningful: 20 })).toContain(
+      "leading(5)"
+    );
   });
 
-  it('describes alp encodings', () => {
-    expect(encodingDescription({ encoding: 'alp-bitpacked', offset: 42, bitWidth: 11 })).toContain('42');
-    expect(encodingDescription({ encoding: 'alp-exception' })).toContain('exception');
+  it("describes alp encodings", () => {
+    expect(encodingDescription({ encoding: "alp-bitpacked", offset: 42, bitWidth: 11 })).toContain(
+      "42"
+    );
+    expect(encodingDescription({ encoding: "alp-exception" })).toContain("exception");
   });
 
-  it('returns empty string for unknown encoding', () => {
-    expect(encodingDescription({ encoding: 'unknown' })).toBe('');
+  it("returns empty string for unknown encoding", () => {
+    expect(encodingDescription({ encoding: "unknown" })).toBe("");
   });
 });
 
-describe('buildALPInsightHtml', () => {
-  it('produces HTML with ALP pipeline steps', () => {
+describe("buildALPInsightHtml", () => {
+  it("produces HTML with ALP pipeline steps", () => {
     const html = buildALPInsightHtml({
-      count: 100, exponent: 3, bitWidth: 11, minInt: 42000n,
-      excCount: 0, bitpackedBytes: 138, valBlobLen: 152,
-      tsLen: 200, amortizedTsLen: 40, sharedCount: 5,
-      tsCount: 100, firstTs: 1000000000n,
+      count: 100,
+      exponent: 3,
+      bitWidth: 11,
+      minInt: 42000n,
+      excCount: 0,
+      bitpackedBytes: 138,
+      valBlobLen: 152,
+      tsLen: 200,
+      amortizedTsLen: 40,
+      sharedCount: 5,
+      tsCount: 100,
+      firstTs: 1000000000n,
     });
 
-    expect(html).toContain('ALP');
-    expect(html).toContain('Decimal Scaling');
-    expect(html).toContain('Frame of Reference');
-    expect(html).toContain('Bit-Packing');
-    expect(html).toContain('0 exceptions');
-    expect(html).toContain('Delta-of-Delta');
+    expect(html).toContain("ALP");
+    expect(html).toContain("Decimal Scaling");
+    expect(html).toContain("Frame of Reference");
+    expect(html).toContain("Bit-Packing");
+    expect(html).toContain("0 exceptions");
+    expect(html).toContain("Delta-of-Delta");
   });
 
-  it('shows exceptions when present', () => {
+  it("shows exceptions when present", () => {
     const html = buildALPInsightHtml({
-      count: 100, exponent: 3, bitWidth: 11, minInt: 0n,
-      excCount: 5, bitpackedBytes: 138, valBlobLen: 200,
-      tsLen: 0, amortizedTsLen: 0, sharedCount: 1, tsCount: 0, firstTs: 0n,
+      count: 100,
+      exponent: 3,
+      bitWidth: 11,
+      minInt: 0n,
+      excCount: 5,
+      bitpackedBytes: 138,
+      valBlobLen: 200,
+      tsLen: 0,
+      amortizedTsLen: 0,
+      sharedCount: 1,
+      tsCount: 0,
+      firstTs: 0n,
     });
 
-    expect(html).toContain('5 exceptions');
-    expect(html).toContain('5.0%');
+    expect(html).toContain("5 exceptions");
+    expect(html).toContain("5.0%");
   });
 });
 
-describe('buildXORInsightHtml', () => {
-  it('produces HTML with XOR pipeline steps', () => {
+describe("buildXORInsightHtml", () => {
+  it("produces HTML with XOR pipeline steps", () => {
     const html = buildXORInsightHtml({
-      count: 100, firstTs: 1000000000n, firstVal: 42.5, totalBytes: 500,
+      count: 100,
+      firstTs: 1000000000n,
+      firstVal: 42.5,
+      totalBytes: 500,
     });
 
-    expect(html).toContain('XOR-Delta');
-    expect(html).toContain('Gorilla');
-    expect(html).toContain('Delta-of-Delta');
-    expect(html).toContain('XOR of IEEE-754');
-    expect(html).toContain('bits/sample');
+    expect(html).toContain("XOR-Delta");
+    expect(html).toContain("Gorilla");
+    expect(html).toContain("Delta-of-Delta");
+    expect(html).toContain("XOR of IEEE-754");
+    expect(html).toContain("bits/sample");
   });
 });
 
-describe('end-to-end: ALP encode → bitMap → byteLookup', () => {
-  it('round-trips: every value byte is mapped to a sample', () => {
+describe("end-to-end: ALP encode → bitMap → byteLookup", () => {
+  it("round-trips: every value byte is mapped to a sample", () => {
     const count = 20;
     const offsets = Array.from({ length: count }, (_, i) => i * 3);
     const blob = makeALPBlob({
-      count, exponent: 2, bitWidth: 8, minInt: 100n,
-      excCount: 0, offsets, excPositions: [], excValues: [],
+      count,
+      exponent: 2,
+      bitWidth: 8,
+      minInt: 100n,
+      excCount: 0,
+      offsets,
+      excPositions: [],
+      excValues: [],
     });
 
     const bitMap = buildALPBitMap(blob, null, count);
@@ -501,18 +577,24 @@ describe('end-to-end: ALP encode → bitMap → byteLookup', () => {
     }
 
     // Value bytes (14+) should all be mapped
-    const bpBytes = Math.ceil(count * 8 / 8);
+    const bpBytes = Math.ceil((count * 8) / 8);
     for (let i = 14; i < 14 + bpBytes; i++) {
       expect(lookup[i]).toBeDefined();
-      expect(lookup[i].type).toBe('value');
+      expect(lookup[i].type).toBe("value");
     }
   });
 
-  it('with timestamps: all bytes are accounted for', () => {
+  it("with timestamps: all bytes are accounted for", () => {
     const count = 5;
     const blob = makeALPBlob({
-      count, exponent: 3, bitWidth: 4, minInt: 0n,
-      excCount: 0, offsets: [1, 2, 3, 4, 5], excPositions: [], excValues: [],
+      count,
+      exponent: 3,
+      bitWidth: 4,
+      minInt: 0n,
+      excCount: 0,
+      offsets: [1, 2, 3, 4, 5],
+      excPositions: [],
+      excValues: [],
     });
     const tsBlob = makeTimestampBlob([1000, 2000, 3000, 4000, 5000]);
     const totalLen = blob.byteLength + tsBlob.byteLength;
@@ -530,8 +612,8 @@ describe('end-to-end: ALP encode → bitMap → byteLookup', () => {
     expect(mapped).toBeGreaterThan(0);
 
     // Check that we have both types
-    const types = new Set(lookup.filter(Boolean).map(e => e.type));
-    expect(types.has('value')).toBe(true);
-    expect(types.has('timestamp')).toBe(true);
+    const types = new Set(lookup.filter(Boolean).map((e) => e.type));
+    expect(types.has("value")).toBe(true);
+    expect(types.has("timestamp")).toBe(true);
   });
 });

--- a/site/tsdb-engine/test/codec.test.js
+++ b/site/tsdb-engine/test/codec.test.js
@@ -1,296 +1,296 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from "vitest";
 import {
-  BitWriter,
   BitReader,
-  encodeChunk,
+  BitWriter,
+  bitsToFloat,
   decodeChunk,
   decodeChunkAnnotated,
+  encodeChunk,
   floatToBits,
-  bitsToFloat,
-} from '../js/codec.js'
+} from "../js/codec.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function makeTimestamps(base, count, stepNs) {
-  const ts = new BigInt64Array(count)
-  for (let i = 0; i < count; i++) ts[i] = base + BigInt(i) * stepNs
-  return ts
+  const ts = new BigInt64Array(count);
+  for (let i = 0; i < count; i++) ts[i] = base + BigInt(i) * stepNs;
+  return ts;
 }
 
 function makeValues(count, fn) {
-  const vals = new Float64Array(count)
-  for (let i = 0; i < count; i++) vals[i] = fn(i)
-  return vals
+  const vals = new Float64Array(count);
+  for (let i = 0; i < count; i++) vals[i] = fn(i);
+  return vals;
 }
 
 // ── BitWriter / BitReader ────────────────────────────────────────────
 
-describe('BitWriter / BitReader', () => {
-  it('round-trips a single bit (0)', () => {
-    const w = new BitWriter(1)
-    w.writeBit(0)
-    const r = new BitReader(w.finish())
-    expect(r.readBit()).toBe(0)
-  })
+describe("BitWriter / BitReader", () => {
+  it("round-trips a single bit (0)", () => {
+    const w = new BitWriter(1);
+    w.writeBit(0);
+    const r = new BitReader(w.finish());
+    expect(r.readBit()).toBe(0);
+  });
 
-  it('round-trips a single bit (1)', () => {
-    const w = new BitWriter(1)
-    w.writeBit(1)
-    const r = new BitReader(w.finish())
-    expect(r.readBit()).toBe(1)
-  })
+  it("round-trips a single bit (1)", () => {
+    const w = new BitWriter(1);
+    w.writeBit(1);
+    const r = new BitReader(w.finish());
+    expect(r.readBit()).toBe(1);
+  });
 
-  it('round-trips 7-bit pattern', () => {
-    const w = new BitWriter(4)
-    w.writeBitsNum(0b1010110, 7)
-    const r = new BitReader(w.finish())
-    expect(r.readBitsNum(7)).toBe(0b1010110)
-  })
+  it("round-trips 7-bit pattern", () => {
+    const w = new BitWriter(4);
+    w.writeBitsNum(0b1010110, 7);
+    const r = new BitReader(w.finish());
+    expect(r.readBitsNum(7)).toBe(0b1010110);
+  });
 
-  it('round-trips a 64-bit BigInt', () => {
-    const val = 0xDEADBEEFCAFEBABEn
-    const w = new BitWriter(16)
-    w.writeBits(val, 64)
-    const r = new BitReader(w.finish())
-    expect(r.readBits(64)).toBe(val)
-  })
+  it("round-trips a 64-bit BigInt", () => {
+    const val = 0xdeadbeefcafebaben;
+    const w = new BitWriter(16);
+    w.writeBits(val, 64);
+    const r = new BitReader(w.finish());
+    expect(r.readBits(64)).toBe(val);
+  });
 
-  it('round-trips mixed bit widths', () => {
-    const w = new BitWriter(16)
-    w.writeBit(1)
-    w.writeBitsNum(42, 8)
-    w.writeBits(123456789n, 40)
-    w.writeBit(0)
+  it("round-trips mixed bit widths", () => {
+    const w = new BitWriter(16);
+    w.writeBit(1);
+    w.writeBitsNum(42, 8);
+    w.writeBits(123456789n, 40);
+    w.writeBit(0);
 
-    const r = new BitReader(w.finish())
-    expect(r.readBit()).toBe(1)
-    expect(r.readBitsNum(8)).toBe(42)
-    expect(r.readBits(40)).toBe(123456789n)
-    expect(r.readBit()).toBe(0)
-  })
+    const r = new BitReader(w.finish());
+    expect(r.readBit()).toBe(1);
+    expect(r.readBitsNum(8)).toBe(42);
+    expect(r.readBits(40)).toBe(123456789n);
+    expect(r.readBit()).toBe(0);
+  });
 
-  it('totalBits tracks position correctly', () => {
-    const w = new BitWriter(4)
-    expect(w.totalBits).toBe(0)
-    w.writeBit(1)
-    expect(w.totalBits).toBe(1)
-    w.writeBitsNum(0xFF, 8)
-    expect(w.totalBits).toBe(9)
-  })
+  it("totalBits tracks position correctly", () => {
+    const w = new BitWriter(4);
+    expect(w.totalBits).toBe(0);
+    w.writeBit(1);
+    expect(w.totalBits).toBe(1);
+    w.writeBitsNum(0xff, 8);
+    expect(w.totalBits).toBe(9);
+  });
 
-  it('grows buffer when writing beyond initial capacity', () => {
-    const w = new BitWriter(1) // only 1 byte = 8 bits
-    for (let i = 0; i < 64; i++) w.writeBit(i % 2)
-    const bytes = w.finish()
-    expect(bytes.length).toBe(8) // 64 bits = 8 bytes
+  it("grows buffer when writing beyond initial capacity", () => {
+    const w = new BitWriter(1); // only 1 byte = 8 bits
+    for (let i = 0; i < 64; i++) w.writeBit(i % 2);
+    const bytes = w.finish();
+    expect(bytes.length).toBe(8); // 64 bits = 8 bytes
 
-    const r = new BitReader(bytes)
+    const r = new BitReader(bytes);
     for (let i = 0; i < 64; i++) {
-      expect(r.readBit()).toBe(i % 2)
+      expect(r.readBit()).toBe(i % 2);
     }
-  })
+  });
 
-  it('finish returns empty array when nothing written', () => {
-    const w = new BitWriter(4)
-    const bytes = w.finish()
-    expect(bytes.length).toBe(0)
-  })
+  it("finish returns empty array when nothing written", () => {
+    const w = new BitWriter(4);
+    const bytes = w.finish();
+    expect(bytes.length).toBe(0);
+  });
 
-  it('finish includes partial byte', () => {
-    const w = new BitWriter(4)
-    w.writeBit(1)
-    const bytes = w.finish()
-    expect(bytes.length).toBe(1)
-  })
-})
+  it("finish includes partial byte", () => {
+    const w = new BitWriter(4);
+    w.writeBit(1);
+    const bytes = w.finish();
+    expect(bytes.length).toBe(1);
+  });
+});
 
-describe('BitReader EOF', () => {
-  it('reading past the buffer returns NaN-ish values (no throw)', () => {
-    const r = new BitReader(new Uint8Array([0b10000000]))
-    expect(r.readBit()).toBe(1) // valid
+describe("BitReader EOF", () => {
+  it("reading past the buffer returns NaN-ish values (no throw)", () => {
+    const r = new BitReader(new Uint8Array([0b10000000]));
+    expect(r.readBit()).toBe(1); // valid
     // Reading past end doesn't throw, it returns garbage from undefined bytes
-    const bit = r.readBit()
-    expect(typeof bit).toBe('number')
-  })
-})
+    const bit = r.readBit();
+    expect(typeof bit).toBe("number");
+  });
+});
 
 // ── encodeChunk / decodeChunk ────────────────────────────────────────
 
-describe('encodeChunk / decodeChunk', () => {
-  it('round-trips regular timestamps and values', () => {
-    const baseTs = 1_700_000_000_000_000_000n
-    const ts = makeTimestamps(baseTs, 10, 1_000_000_000n) // 1 second apart
-    const vals = makeValues(10, i => 42.5 + i * 0.1)
+describe("encodeChunk / decodeChunk", () => {
+  it("round-trips regular timestamps and values", () => {
+    const baseTs = 1_700_000_000_000_000_000n;
+    const ts = makeTimestamps(baseTs, 10, 1_000_000_000n); // 1 second apart
+    const vals = makeValues(10, (i) => 42.5 + i * 0.1);
 
-    const encoded = encodeChunk(ts, vals)
-    expect(encoded).toBeInstanceOf(Uint8Array)
-    expect(encoded.length).toBeGreaterThan(0)
+    const encoded = encodeChunk(ts, vals);
+    expect(encoded).toBeInstanceOf(Uint8Array);
+    expect(encoded.length).toBeGreaterThan(0);
 
-    const decoded = decodeChunk(encoded)
-    expect(decoded.timestamps.length).toBe(10)
-    expect(decoded.values.length).toBe(10)
+    const decoded = decodeChunk(encoded);
+    expect(decoded.timestamps.length).toBe(10);
+    expect(decoded.values.length).toBe(10);
 
     for (let i = 0; i < 10; i++) {
-      expect(decoded.timestamps[i]).toBe(ts[i])
-      expect(decoded.values[i]).toBeCloseTo(vals[i], 10)
+      expect(decoded.timestamps[i]).toBe(ts[i]);
+      expect(decoded.values[i]).toBeCloseTo(vals[i], 10);
     }
-  })
+  });
 
-  it('round-trips all-same values (zero XOR deltas)', () => {
-    const ts = makeTimestamps(1000n, 5, 100n)
-    const vals = new Float64Array([7.5, 7.5, 7.5, 7.5, 7.5])
+  it("round-trips all-same values (zero XOR deltas)", () => {
+    const ts = makeTimestamps(1000n, 5, 100n);
+    const vals = new Float64Array([7.5, 7.5, 7.5, 7.5, 7.5]);
 
-    const decoded = decodeChunk(encodeChunk(ts, vals))
+    const decoded = decodeChunk(encodeChunk(ts, vals));
     for (let i = 0; i < 5; i++) {
-      expect(decoded.timestamps[i]).toBe(ts[i])
-      expect(decoded.values[i]).toBe(7.5)
+      expect(decoded.timestamps[i]).toBe(ts[i]);
+      expect(decoded.values[i]).toBe(7.5);
     }
-  })
+  });
 
-  it('round-trips monotonically increasing timestamps with constant delta', () => {
-    const ts = makeTimestamps(0n, 20, 1000n) // constant delta = 1000
-    const vals = makeValues(20, i => i * 10.0)
+  it("round-trips monotonically increasing timestamps with constant delta", () => {
+    const ts = makeTimestamps(0n, 20, 1000n); // constant delta = 1000
+    const vals = makeValues(20, (i) => i * 10.0);
 
-    const decoded = decodeChunk(encodeChunk(ts, vals))
+    const decoded = decodeChunk(encodeChunk(ts, vals));
     for (let i = 0; i < 20; i++) {
-      expect(decoded.timestamps[i]).toBe(ts[i])
-      expect(decoded.values[i]).toBeCloseTo(vals[i], 10)
+      expect(decoded.timestamps[i]).toBe(ts[i]);
+      expect(decoded.values[i]).toBeCloseTo(vals[i], 10);
     }
-  })
+  });
 
-  it('round-trips with large timestamp gaps', () => {
+  it("round-trips with large timestamp gaps", () => {
     const ts = new BigInt64Array([
       1_000_000_000_000n,
       1_000_000_000_000n + 1_000_000_000n,
       1_000_000_000_000n + 100_000_000_000n, // big jump
       1_000_000_000_000n + 100_000_000_001n,
-    ])
-    const vals = new Float64Array([1.0, 2.0, 3.0, 4.0])
+    ]);
+    const vals = new Float64Array([1.0, 2.0, 3.0, 4.0]);
 
-    const decoded = decodeChunk(encodeChunk(ts, vals))
+    const decoded = decodeChunk(encodeChunk(ts, vals));
     for (let i = 0; i < 4; i++) {
-      expect(decoded.timestamps[i]).toBe(ts[i])
-      expect(decoded.values[i]).toBeCloseTo(vals[i], 10)
+      expect(decoded.timestamps[i]).toBe(ts[i]);
+      expect(decoded.values[i]).toBeCloseTo(vals[i], 10);
     }
-  })
+  });
 
-  it('round-trips diverse value patterns', () => {
-    const ts = makeTimestamps(0n, 6, 1000n)
-    const vals = new Float64Array([0, -1.5, 1e10, 1e-10, Math.PI, -0])
+  it("round-trips diverse value patterns", () => {
+    const ts = makeTimestamps(0n, 6, 1000n);
+    const vals = new Float64Array([0, -1.5, 1e10, 1e-10, Math.PI, -0]);
 
-    const decoded = decodeChunk(encodeChunk(ts, vals))
+    const decoded = decodeChunk(encodeChunk(ts, vals));
     for (let i = 0; i < 6; i++) {
-      expect(decoded.timestamps[i]).toBe(ts[i])
-      expect(decoded.values[i]).toBeCloseTo(vals[i], 10)
+      expect(decoded.timestamps[i]).toBe(ts[i]);
+      expect(decoded.values[i]).toBeCloseTo(vals[i], 10);
     }
-  })
+  });
 
-  it('handles empty input', () => {
-    const encoded = encodeChunk(new BigInt64Array(0), new Float64Array(0))
-    expect(encoded.length).toBe(0)
+  it("handles empty input", () => {
+    const encoded = encodeChunk(new BigInt64Array(0), new Float64Array(0));
+    expect(encoded.length).toBe(0);
 
-    const decoded = decodeChunk(encoded)
-    expect(decoded.timestamps.length).toBe(0)
-    expect(decoded.values.length).toBe(0)
-  })
+    const decoded = decodeChunk(encoded);
+    expect(decoded.timestamps.length).toBe(0);
+    expect(decoded.values.length).toBe(0);
+  });
 
-  it('handles single sample', () => {
-    const ts = new BigInt64Array([1_000_000_000_000_000_000n])
-    const vals = new Float64Array([42.0])
+  it("handles single sample", () => {
+    const ts = new BigInt64Array([1_000_000_000_000_000_000n]);
+    const vals = new Float64Array([42.0]);
 
-    const decoded = decodeChunk(encodeChunk(ts, vals))
-    expect(decoded.timestamps.length).toBe(1)
-    expect(decoded.timestamps[0]).toBe(1_000_000_000_000_000_000n)
-    expect(decoded.values[0]).toBe(42.0)
-  })
+    const decoded = decodeChunk(encodeChunk(ts, vals));
+    expect(decoded.timestamps.length).toBe(1);
+    expect(decoded.timestamps[0]).toBe(1_000_000_000_000_000_000n);
+    expect(decoded.values[0]).toBe(42.0);
+  });
 
-  it('handles larger chunk (100 samples)', () => {
-    const ts = makeTimestamps(1_000_000_000n, 100, 15_000_000_000n) // 15s apart
-    const vals = makeValues(100, i => Math.sin(i * 0.1) * 100)
+  it("handles larger chunk (100 samples)", () => {
+    const ts = makeTimestamps(1_000_000_000n, 100, 15_000_000_000n); // 15s apart
+    const vals = makeValues(100, (i) => Math.sin(i * 0.1) * 100);
 
-    const decoded = decodeChunk(encodeChunk(ts, vals))
-    expect(decoded.timestamps.length).toBe(100)
+    const decoded = decodeChunk(encodeChunk(ts, vals));
+    expect(decoded.timestamps.length).toBe(100);
     for (let i = 0; i < 100; i++) {
-      expect(decoded.timestamps[i]).toBe(ts[i])
-      expect(decoded.values[i]).toBeCloseTo(vals[i], 10)
+      expect(decoded.timestamps[i]).toBe(ts[i]);
+      expect(decoded.values[i]).toBeCloseTo(vals[i], 10);
     }
-  })
-})
+  });
+});
 
 // ── decodeChunkAnnotated ─────────────────────────────────────────────
 
-describe('decodeChunkAnnotated', () => {
-  it('returns correct structure with bitMap', () => {
-    const ts = makeTimestamps(1000n, 3, 100n)
-    const vals = new Float64Array([1.0, 2.0, 3.0])
-    const encoded = encodeChunk(ts, vals)
+describe("decodeChunkAnnotated", () => {
+  it("returns correct structure with bitMap", () => {
+    const ts = makeTimestamps(1000n, 3, 100n);
+    const vals = new Float64Array([1.0, 2.0, 3.0]);
+    const encoded = encodeChunk(ts, vals);
 
-    const result = decodeChunkAnnotated(encoded)
-    expect(result.timestamps).toBeInstanceOf(BigInt64Array)
-    expect(result.values).toBeInstanceOf(Float64Array)
-    expect(Array.isArray(result.bitMap)).toBe(true)
-    expect(result.bitMap.length).toBe(3)
-  })
+    const result = decodeChunkAnnotated(encoded);
+    expect(result.timestamps).toBeInstanceOf(BigInt64Array);
+    expect(result.values).toBeInstanceOf(Float64Array);
+    expect(Array.isArray(result.bitMap)).toBe(true);
+    expect(result.bitMap.length).toBe(3);
+  });
 
-  it('sample 0 uses raw encoding', () => {
-    const ts = new BigInt64Array([5000n])
-    const vals = new Float64Array([99.9])
-    const encoded = encodeChunk(ts, vals)
+  it("sample 0 uses raw encoding", () => {
+    const ts = new BigInt64Array([5000n]);
+    const vals = new Float64Array([99.9]);
+    const encoded = encodeChunk(ts, vals);
 
-    const { bitMap } = decodeChunkAnnotated(encoded)
-    expect(bitMap[0].sampleIndex).toBe(0)
-    expect(bitMap[0].timestamp.encoding).toBe('raw')
-    expect(bitMap[0].timestamp.bits).toBe(64)
-    expect(bitMap[0].value.encoding).toBe('raw')
-    expect(bitMap[0].value.bits).toBe(64)
-    expect(bitMap[0].timestamp.decoded).toBe(5000n)
-    expect(bitMap[0].value.decoded).toBeCloseTo(99.9, 10)
-  })
+    const { bitMap } = decodeChunkAnnotated(encoded);
+    expect(bitMap[0].sampleIndex).toBe(0);
+    expect(bitMap[0].timestamp.encoding).toBe("raw");
+    expect(bitMap[0].timestamp.bits).toBe(64);
+    expect(bitMap[0].value.encoding).toBe("raw");
+    expect(bitMap[0].value.bits).toBe(64);
+    expect(bitMap[0].timestamp.decoded).toBe(5000n);
+    expect(bitMap[0].value.decoded).toBeCloseTo(99.9, 10);
+  });
 
-  it('subsequent samples have encoding annotations', () => {
-    const ts = makeTimestamps(1000n, 4, 100n) // constant delta → dod=0
-    const vals = new Float64Array([1.0, 1.0, 2.0, 2.0])
-    const encoded = encodeChunk(ts, vals)
+  it("subsequent samples have encoding annotations", () => {
+    const ts = makeTimestamps(1000n, 4, 100n); // constant delta → dod=0
+    const vals = new Float64Array([1.0, 1.0, 2.0, 2.0]);
+    const encoded = encodeChunk(ts, vals);
 
-    const { bitMap } = decodeChunkAnnotated(encoded)
+    const { bitMap } = decodeChunkAnnotated(encoded);
     // Sample 1 should have dod and delta
-    expect(bitMap[1].timestamp).toHaveProperty('dod')
-    expect(bitMap[1].timestamp).toHaveProperty('delta')
+    expect(bitMap[1].timestamp).toHaveProperty("dod");
+    expect(bitMap[1].timestamp).toHaveProperty("delta");
     // Constant delta → dod-zero for sample 2 onwards
-    expect(bitMap[2].timestamp.encoding).toBe('dod-zero')
+    expect(bitMap[2].timestamp.encoding).toBe("dod-zero");
     // Same value → xor-zero
-    expect(bitMap[1].value.encoding).toBe('xor-zero')
-    expect(bitMap[1].value.bits).toBe(1)
-  })
+    expect(bitMap[1].value.encoding).toBe("xor-zero");
+    expect(bitMap[1].value.bits).toBe(1);
+  });
 
-  it('annotated decode matches plain decode', () => {
-    const ts = makeTimestamps(0n, 10, 500n)
-    const vals = makeValues(10, i => i * 1.5)
-    const encoded = encodeChunk(ts, vals)
+  it("annotated decode matches plain decode", () => {
+    const ts = makeTimestamps(0n, 10, 500n);
+    const vals = makeValues(10, (i) => i * 1.5);
+    const encoded = encodeChunk(ts, vals);
 
-    const plain = decodeChunk(encoded)
-    const annotated = decodeChunkAnnotated(encoded)
+    const plain = decodeChunk(encoded);
+    const annotated = decodeChunkAnnotated(encoded);
 
     for (let i = 0; i < 10; i++) {
-      expect(annotated.timestamps[i]).toBe(plain.timestamps[i])
-      expect(annotated.values[i]).toBeCloseTo(plain.values[i], 10)
+      expect(annotated.timestamps[i]).toBe(plain.timestamps[i]);
+      expect(annotated.values[i]).toBeCloseTo(plain.values[i], 10);
     }
-  })
+  });
 
-  it('handles empty input', () => {
-    const result = decodeChunkAnnotated(new Uint8Array(0))
-    expect(result.timestamps.length).toBe(0)
-    expect(result.values.length).toBe(0)
-    expect(result.bitMap.length).toBe(0)
-  })
-})
+  it("handles empty input", () => {
+    const result = decodeChunkAnnotated(new Uint8Array(0));
+    expect(result.timestamps.length).toBe(0);
+    expect(result.values.length).toBe(0);
+    expect(result.bitMap.length).toBe(0);
+  });
+});
 
 // ── floatToBits / bitsToFloat ────────────────────────────────────────
 
-describe('floatToBits / bitsToFloat', () => {
-  it('round-trips common values', () => {
+describe("floatToBits / bitsToFloat", () => {
+  it("round-trips common values", () => {
     for (const v of [0, 1.0, -1.0, 42.5, Math.PI, 1e100, Number.MIN_VALUE]) {
-      expect(bitsToFloat(floatToBits(v))).toBe(v)
+      expect(bitsToFloat(floatToBits(v))).toBe(v);
     }
-  })
-})
+  });
+});

--- a/site/tsdb-engine/test/query.test.js
+++ b/site/tsdb-engine/test/query.test.js
@@ -1,330 +1,386 @@
-import { describe, it, expect } from 'vitest'
-import { ScanEngine } from '../js/query.js'
-import { FlatStore } from '../js/stores.js'
+import { describe, expect, it } from "vitest";
+import { ScanEngine } from "../js/query.js";
+import { FlatStore } from "../js/stores.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function buildStore(seriesData) {
-  const store = new FlatStore()
+  const store = new FlatStore();
   for (const { labels, timestamps, values } of seriesData) {
-    const id = store.getOrCreateSeries(labels)
-    store.appendBatch(id, new BigInt64Array(timestamps), new Float64Array(values))
+    const id = store.getOrCreateSeries(labels);
+    store.appendBatch(id, new BigInt64Array(timestamps), new Float64Array(values));
   }
-  return store
+  return store;
 }
 
-const SEC = 1_000_000_000n // 1 second in nanoseconds
+const SEC = 1_000_000_000n; // 1 second in nanoseconds
 
 function makeLabels(name, extra = {}) {
-  const m = new Map([['__name__', name]])
-  for (const [k, v] of Object.entries(extra)) m.set(k, v)
-  return m
+  const m = new Map([["__name__", name]]);
+  for (const [k, v] of Object.entries(extra)) m.set(k, v);
+  return m;
 }
 
 // ── Aggregation tests ────────────────────────────────────────────────
 
-describe('ScanEngine', () => {
-  const engine = new ScanEngine()
+describe("ScanEngine", () => {
+  const engine = new ScanEngine();
 
-  describe('no aggregation', () => {
-    it('returns raw series data', () => {
-      const store = buildStore([
-        { labels: makeLabels('cpu', { host: 'a' }), timestamps: [1n * SEC, 2n * SEC], values: [10, 20] },
-      ])
-      const result = engine.query(store, {
-        metric: 'cpu',
-        start: 0n,
-        end: 10n * SEC,
-      })
-      expect(result.series.length).toBe(1)
-      expect(result.series[0].timestamps.length).toBe(2)
-      expect(result.series[0].values[0]).toBeCloseTo(10)
-      expect(result.series[0].values[1]).toBeCloseTo(20)
-      expect(result.scannedSeries).toBe(1)
-      expect(result.scannedSamples).toBe(2)
-    })
-  })
-
-  describe('sum aggregation', () => {
-    it('sums values across series', () => {
-      const store = buildStore([
-        { labels: makeLabels('cpu', { host: 'a' }), timestamps: [1n * SEC, 2n * SEC], values: [10, 20] },
-        { labels: makeLabels('cpu', { host: 'b' }), timestamps: [1n * SEC, 2n * SEC], values: [5, 15] },
-      ])
-      const result = engine.query(store, {
-        metric: 'cpu',
-        start: 0n,
-        end: 10n * SEC,
-        agg: 'sum',
-        groupBy: [],
-      })
-      expect(result.series.length).toBe(1)
-      expect(result.series[0].values[0]).toBeCloseTo(15) // 10 + 5
-      expect(result.series[0].values[1]).toBeCloseTo(35) // 20 + 15
-    })
-  })
-
-  describe('avg aggregation', () => {
-    it('averages values across series', () => {
-      const store = buildStore([
-        { labels: makeLabels('cpu', { host: 'a' }), timestamps: [1n * SEC, 2n * SEC], values: [10, 20] },
-        { labels: makeLabels('cpu', { host: 'b' }), timestamps: [1n * SEC, 2n * SEC], values: [30, 40] },
-      ])
-      const result = engine.query(store, {
-        metric: 'cpu',
-        start: 0n,
-        end: 10n * SEC,
-        agg: 'avg',
-        groupBy: [],
-      })
-      expect(result.series[0].values[0]).toBeCloseTo(20) // (10+30)/2
-      expect(result.series[0].values[1]).toBeCloseTo(30) // (20+40)/2
-    })
-  })
-
-  describe('min aggregation', () => {
-    it('finds minimum across series', () => {
-      const store = buildStore([
-        { labels: makeLabels('cpu', { host: 'a' }), timestamps: [1n * SEC, 2n * SEC], values: [10, 40] },
-        { labels: makeLabels('cpu', { host: 'b' }), timestamps: [1n * SEC, 2n * SEC], values: [5, 50] },
-      ])
-      const result = engine.query(store, {
-        metric: 'cpu',
-        start: 0n,
-        end: 10n * SEC,
-        agg: 'min',
-        groupBy: [],
-      })
-      expect(result.series[0].values[0]).toBeCloseTo(5)
-      expect(result.series[0].values[1]).toBeCloseTo(40)
-    })
-  })
-
-  describe('max aggregation', () => {
-    it('finds maximum across series', () => {
-      const store = buildStore([
-        { labels: makeLabels('cpu', { host: 'a' }), timestamps: [1n * SEC, 2n * SEC], values: [10, 40] },
-        { labels: makeLabels('cpu', { host: 'b' }), timestamps: [1n * SEC, 2n * SEC], values: [5, 50] },
-      ])
-      const result = engine.query(store, {
-        metric: 'cpu',
-        start: 0n,
-        end: 10n * SEC,
-        agg: 'max',
-        groupBy: [],
-      })
-      expect(result.series[0].values[0]).toBeCloseTo(10)
-      expect(result.series[0].values[1]).toBeCloseTo(50)
-    })
-  })
-
-  describe('count aggregation', () => {
-    it('counts contributions across series', () => {
-      const store = buildStore([
-        { labels: makeLabels('cpu', { host: 'a' }), timestamps: [1n * SEC, 2n * SEC], values: [10, 20] },
-        { labels: makeLabels('cpu', { host: 'b' }), timestamps: [1n * SEC, 2n * SEC], values: [5, 15] },
-      ])
-      const result = engine.query(store, {
-        metric: 'cpu',
-        start: 0n,
-        end: 10n * SEC,
-        agg: 'count',
-        groupBy: [],
-      })
-      expect(result.series[0].values[0]).toBeCloseTo(2) // 2 series contribute
-      expect(result.series[0].values[1]).toBeCloseTo(2)
-    })
-  })
-
-  describe('rate aggregation', () => {
-    it('calculates per-second rate', () => {
+  describe("no aggregation", () => {
+    it("returns raw series data", () => {
       const store = buildStore([
         {
-          labels: makeLabels('requests', { host: 'a' }),
+          labels: makeLabels("cpu", { host: "a" }),
+          timestamps: [1n * SEC, 2n * SEC],
+          values: [10, 20],
+        },
+      ]);
+      const result = engine.query(store, {
+        metric: "cpu",
+        start: 0n,
+        end: 10n * SEC,
+      });
+      expect(result.series.length).toBe(1);
+      expect(result.series[0].timestamps.length).toBe(2);
+      expect(result.series[0].values[0]).toBeCloseTo(10);
+      expect(result.series[0].values[1]).toBeCloseTo(20);
+      expect(result.scannedSeries).toBe(1);
+      expect(result.scannedSamples).toBe(2);
+    });
+  });
+
+  describe("sum aggregation", () => {
+    it("sums values across series", () => {
+      const store = buildStore([
+        {
+          labels: makeLabels("cpu", { host: "a" }),
+          timestamps: [1n * SEC, 2n * SEC],
+          values: [10, 20],
+        },
+        {
+          labels: makeLabels("cpu", { host: "b" }),
+          timestamps: [1n * SEC, 2n * SEC],
+          values: [5, 15],
+        },
+      ]);
+      const result = engine.query(store, {
+        metric: "cpu",
+        start: 0n,
+        end: 10n * SEC,
+        agg: "sum",
+        groupBy: [],
+      });
+      expect(result.series.length).toBe(1);
+      expect(result.series[0].values[0]).toBeCloseTo(15); // 10 + 5
+      expect(result.series[0].values[1]).toBeCloseTo(35); // 20 + 15
+    });
+  });
+
+  describe("avg aggregation", () => {
+    it("averages values across series", () => {
+      const store = buildStore([
+        {
+          labels: makeLabels("cpu", { host: "a" }),
+          timestamps: [1n * SEC, 2n * SEC],
+          values: [10, 20],
+        },
+        {
+          labels: makeLabels("cpu", { host: "b" }),
+          timestamps: [1n * SEC, 2n * SEC],
+          values: [30, 40],
+        },
+      ]);
+      const result = engine.query(store, {
+        metric: "cpu",
+        start: 0n,
+        end: 10n * SEC,
+        agg: "avg",
+        groupBy: [],
+      });
+      expect(result.series[0].values[0]).toBeCloseTo(20); // (10+30)/2
+      expect(result.series[0].values[1]).toBeCloseTo(30); // (20+40)/2
+    });
+  });
+
+  describe("min aggregation", () => {
+    it("finds minimum across series", () => {
+      const store = buildStore([
+        {
+          labels: makeLabels("cpu", { host: "a" }),
+          timestamps: [1n * SEC, 2n * SEC],
+          values: [10, 40],
+        },
+        {
+          labels: makeLabels("cpu", { host: "b" }),
+          timestamps: [1n * SEC, 2n * SEC],
+          values: [5, 50],
+        },
+      ]);
+      const result = engine.query(store, {
+        metric: "cpu",
+        start: 0n,
+        end: 10n * SEC,
+        agg: "min",
+        groupBy: [],
+      });
+      expect(result.series[0].values[0]).toBeCloseTo(5);
+      expect(result.series[0].values[1]).toBeCloseTo(40);
+    });
+  });
+
+  describe("max aggregation", () => {
+    it("finds maximum across series", () => {
+      const store = buildStore([
+        {
+          labels: makeLabels("cpu", { host: "a" }),
+          timestamps: [1n * SEC, 2n * SEC],
+          values: [10, 40],
+        },
+        {
+          labels: makeLabels("cpu", { host: "b" }),
+          timestamps: [1n * SEC, 2n * SEC],
+          values: [5, 50],
+        },
+      ]);
+      const result = engine.query(store, {
+        metric: "cpu",
+        start: 0n,
+        end: 10n * SEC,
+        agg: "max",
+        groupBy: [],
+      });
+      expect(result.series[0].values[0]).toBeCloseTo(10);
+      expect(result.series[0].values[1]).toBeCloseTo(50);
+    });
+  });
+
+  describe("count aggregation", () => {
+    it("counts contributions across series", () => {
+      const store = buildStore([
+        {
+          labels: makeLabels("cpu", { host: "a" }),
+          timestamps: [1n * SEC, 2n * SEC],
+          values: [10, 20],
+        },
+        {
+          labels: makeLabels("cpu", { host: "b" }),
+          timestamps: [1n * SEC, 2n * SEC],
+          values: [5, 15],
+        },
+      ]);
+      const result = engine.query(store, {
+        metric: "cpu",
+        start: 0n,
+        end: 10n * SEC,
+        agg: "count",
+        groupBy: [],
+      });
+      expect(result.series[0].values[0]).toBeCloseTo(2); // 2 series contribute
+      expect(result.series[0].values[1]).toBeCloseTo(2);
+    });
+  });
+
+  describe("rate aggregation", () => {
+    it("calculates per-second rate", () => {
+      const store = buildStore([
+        {
+          labels: makeLabels("requests", { host: "a" }),
           timestamps: [0n, 1n * SEC, 2n * SEC, 3n * SEC],
           values: [0, 100, 250, 500],
         },
-      ])
+      ]);
       const result = engine.query(store, {
-        metric: 'requests',
+        metric: "requests",
         start: 0n,
         end: 10n * SEC,
-        agg: 'rate',
+        agg: "rate",
         groupBy: [],
-      })
+      });
       // rate[0] = 0 (first point has no previous)
-      expect(result.series[0].values[0]).toBeCloseTo(0)
+      expect(result.series[0].values[0]).toBeCloseTo(0);
       // rate[1] = (100-0) / 1s = 100/s
-      expect(result.series[0].values[1]).toBeCloseTo(100)
+      expect(result.series[0].values[1]).toBeCloseTo(100);
       // rate[2] = (250-100) / 1s = 150/s
-      expect(result.series[0].values[2]).toBeCloseTo(150)
+      expect(result.series[0].values[2]).toBeCloseTo(150);
       // rate[3] = (500-250) / 1s = 250/s
-      expect(result.series[0].values[3]).toBeCloseTo(250)
-    })
+      expect(result.series[0].values[3]).toBeCloseTo(250);
+    });
 
-    it('handles varying time gaps in rate', () => {
+    it("handles varying time gaps in rate", () => {
       const store = buildStore([
         {
-          labels: makeLabels('bytes'),
+          labels: makeLabels("bytes"),
           timestamps: [0n, 2n * SEC, 5n * SEC], // 2s gap, then 3s gap
           values: [0, 200, 500],
         },
-      ])
+      ]);
       const result = engine.query(store, {
-        metric: 'bytes',
+        metric: "bytes",
         start: 0n,
         end: 10n * SEC,
-        agg: 'rate',
+        agg: "rate",
         groupBy: [],
-      })
+      });
       // rate[1] = 200/2s = 100/s
-      expect(result.series[0].values[1]).toBeCloseTo(100)
+      expect(result.series[0].values[1]).toBeCloseTo(100);
       // rate[2] = 300/3s = 100/s
-      expect(result.series[0].values[2]).toBeCloseTo(100)
-    })
-  })
+      expect(result.series[0].values[2]).toBeCloseTo(100);
+    });
+  });
 
-  describe('step-based downsampling', () => {
-    it('buckets data into step intervals', () => {
+  describe("step-based downsampling", () => {
+    it("buckets data into step intervals", () => {
       const store = buildStore([
         {
-          labels: makeLabels('cpu', { host: 'a' }),
+          labels: makeLabels("cpu", { host: "a" }),
           timestamps: [0n, 1n * SEC, 2n * SEC, 3n * SEC, 4n * SEC, 5n * SEC],
           values: [10, 20, 30, 40, 50, 60],
         },
-      ])
+      ]);
       const result = engine.query(store, {
-        metric: 'cpu',
+        metric: "cpu",
         start: 0n,
         end: 10n * SEC,
-        agg: 'sum',
+        agg: "sum",
         step: 2n * SEC, // 2-second buckets
         groupBy: [],
-      })
+      });
       // Buckets: [0,2s) [2s,4s) [4s,6s)
       // bucket 0: ts 0, 1 → values 10, 20 → sum 30
       // bucket 1: ts 2, 3 → values 30, 40 → sum 70
       // bucket 2: ts 4, 5 → values 50, 60 → sum 110
-      expect(result.series[0].timestamps.length).toBe(3)
-      expect(result.series[0].values[0]).toBeCloseTo(30)
-      expect(result.series[0].values[1]).toBeCloseTo(70)
-      expect(result.series[0].values[2]).toBeCloseTo(110)
-    })
+      expect(result.series[0].timestamps.length).toBe(3);
+      expect(result.series[0].values[0]).toBeCloseTo(30);
+      expect(result.series[0].values[1]).toBeCloseTo(70);
+      expect(result.series[0].values[2]).toBeCloseTo(110);
+    });
 
-    it('output timestamps align to step boundaries', () => {
+    it("output timestamps align to step boundaries", () => {
       const store = buildStore([
         {
-          labels: makeLabels('cpu'),
+          labels: makeLabels("cpu"),
           timestamps: [0n, 3n * SEC, 6n * SEC, 9n * SEC],
           values: [1, 2, 3, 4],
         },
-      ])
+      ]);
       const result = engine.query(store, {
-        metric: 'cpu',
+        metric: "cpu",
         start: 0n,
         end: 20n * SEC,
-        agg: 'sum',
+        agg: "sum",
         step: 3n * SEC,
         groupBy: [],
-      })
+      });
       // Check timestamps are evenly spaced at step intervals
       for (let i = 1; i < result.series[0].timestamps.length; i++) {
-        const diff = result.series[0].timestamps[i] - result.series[0].timestamps[i - 1]
-        expect(diff).toBe(3n * SEC)
+        const diff = result.series[0].timestamps[i] - result.series[0].timestamps[i - 1];
+        expect(diff).toBe(3n * SEC);
       }
-    })
+    });
 
-    it('avg downsampling computes correct averages', () => {
+    it("avg downsampling computes correct averages", () => {
       const store = buildStore([
         {
-          labels: makeLabels('cpu'),
+          labels: makeLabels("cpu"),
           timestamps: [0n, 1n * SEC, 2n * SEC, 3n * SEC],
           values: [10, 20, 30, 40],
         },
-      ])
+      ]);
       const result = engine.query(store, {
-        metric: 'cpu',
+        metric: "cpu",
         start: 0n,
         end: 10n * SEC,
-        agg: 'avg',
+        agg: "avg",
         step: 2n * SEC,
         groupBy: [],
-      })
+      });
       // bucket 0: (10+20)/2 = 15
       // bucket 1: (30+40)/2 = 35
-      expect(result.series[0].values[0]).toBeCloseTo(15)
-      expect(result.series[0].values[1]).toBeCloseTo(35)
-    })
-  })
+      expect(result.series[0].values[0]).toBeCloseTo(15);
+      expect(result.series[0].values[1]).toBeCloseTo(35);
+    });
+  });
 
-  describe('empty query result', () => {
-    it('returns empty series for non-existent metric', () => {
+  describe("empty query result", () => {
+    it("returns empty series for non-existent metric", () => {
       const store = buildStore([
-        { labels: makeLabels('cpu'), timestamps: [1n * SEC], values: [42] },
-      ])
+        { labels: makeLabels("cpu"), timestamps: [1n * SEC], values: [42] },
+      ]);
       const result = engine.query(store, {
-        metric: 'nonexistent',
+        metric: "nonexistent",
         start: 0n,
         end: 10n * SEC,
-      })
-      expect(result.series.length).toBe(0)
-      expect(result.scannedSeries).toBe(0)
-      expect(result.scannedSamples).toBe(0)
-    })
+      });
+      expect(result.series.length).toBe(0);
+      expect(result.scannedSeries).toBe(0);
+      expect(result.scannedSamples).toBe(0);
+    });
 
-    it('returns empty series for non-existent metric with aggregation', () => {
+    it("returns empty series for non-existent metric with aggregation", () => {
       const store = buildStore([
-        { labels: makeLabels('cpu'), timestamps: [1n * SEC], values: [42] },
-      ])
+        { labels: makeLabels("cpu"), timestamps: [1n * SEC], values: [42] },
+      ]);
       const result = engine.query(store, {
-        metric: 'nonexistent',
+        metric: "nonexistent",
         start: 0n,
         end: 10n * SEC,
-        agg: 'sum',
+        agg: "sum",
         groupBy: [],
-      })
-      expect(result.series.length).toBe(0)
-    })
-  })
+      });
+      expect(result.series.length).toBe(0);
+    });
+  });
 
-  describe('label matchers', () => {
-    it('filters by additional label matcher', () => {
+  describe("label matchers", () => {
+    it("filters by additional label matcher", () => {
       const store = buildStore([
-        { labels: makeLabels('cpu', { host: 'a' }), timestamps: [1n * SEC], values: [10] },
-        { labels: makeLabels('cpu', { host: 'b' }), timestamps: [1n * SEC], values: [20] },
-      ])
+        { labels: makeLabels("cpu", { host: "a" }), timestamps: [1n * SEC], values: [10] },
+        { labels: makeLabels("cpu", { host: "b" }), timestamps: [1n * SEC], values: [20] },
+      ]);
       const result = engine.query(store, {
-        metric: 'cpu',
+        metric: "cpu",
         start: 0n,
         end: 10n * SEC,
-        matchers: [{ label: 'host', value: 'a' }],
-      })
-      expect(result.series.length).toBe(1)
-      expect(result.series[0].values[0]).toBeCloseTo(10)
-      expect(result.scannedSeries).toBe(1)
-    })
-  })
+        matchers: [{ label: "host", value: "a" }],
+      });
+      expect(result.series.length).toBe(1);
+      expect(result.series[0].values[0]).toBeCloseTo(10);
+      expect(result.scannedSeries).toBe(1);
+    });
+  });
 
-  describe('groupBy', () => {
-    it('groups aggregation by label', () => {
+  describe("groupBy", () => {
+    it("groups aggregation by label", () => {
       const store = buildStore([
-        { labels: makeLabels('cpu', { host: 'a', dc: 'us' }), timestamps: [1n * SEC], values: [10] },
-        { labels: makeLabels('cpu', { host: 'b', dc: 'us' }), timestamps: [1n * SEC], values: [20] },
-        { labels: makeLabels('cpu', { host: 'c', dc: 'eu' }), timestamps: [1n * SEC], values: [30] },
-      ])
+        {
+          labels: makeLabels("cpu", { host: "a", dc: "us" }),
+          timestamps: [1n * SEC],
+          values: [10],
+        },
+        {
+          labels: makeLabels("cpu", { host: "b", dc: "us" }),
+          timestamps: [1n * SEC],
+          values: [20],
+        },
+        {
+          labels: makeLabels("cpu", { host: "c", dc: "eu" }),
+          timestamps: [1n * SEC],
+          values: [30],
+        },
+      ]);
       const result = engine.query(store, {
-        metric: 'cpu',
+        metric: "cpu",
         start: 0n,
         end: 10n * SEC,
-        agg: 'sum',
-        groupBy: ['dc'],
-      })
-      expect(result.series.length).toBe(2)
+        agg: "sum",
+        groupBy: ["dc"],
+      });
+      expect(result.series.length).toBe(2);
       // Find each group
-      const us = result.series.find(s => s.labels.get('dc') === 'us')
-      const eu = result.series.find(s => s.labels.get('dc') === 'eu')
-      expect(us.values[0]).toBeCloseTo(30) // 10+20
-      expect(eu.values[0]).toBeCloseTo(30)
-    })
-  })
-})
+      const us = result.series.find((s) => s.labels.get("dc") === "us");
+      const eu = result.series.find((s) => s.labels.get("dc") === "eu");
+      expect(us.values[0]).toBeCloseTo(30); // 10+20
+      expect(eu.values[0]).toBeCloseTo(30);
+    });
+  });
+});

--- a/site/tsdb-engine/test/stores.test.js
+++ b/site/tsdb-engine/test/stores.test.js
@@ -1,255 +1,294 @@
-import { describe, it, expect } from 'vitest'
-import { FlatStore, ChunkedStore } from '../js/stores.js'
+import { describe, expect, it } from "vitest";
+import { ChunkedStore, FlatStore } from "../js/stores.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function pushSample(store, labels, ts, val) {
-  const id = store.getOrCreateSeries(labels)
-  store.appendBatch(id, new BigInt64Array([ts]), new Float64Array([val]))
-  return id
+  const id = store.getOrCreateSeries(labels);
+  store.appendBatch(id, new BigInt64Array([ts]), new Float64Array([val]));
+  return id;
 }
 
 function pushSamples(store, labels, timestamps, values) {
-  const id = store.getOrCreateSeries(labels)
-  store.appendBatch(id, new BigInt64Array(timestamps), new Float64Array(values))
-  return id
+  const id = store.getOrCreateSeries(labels);
+  store.appendBatch(id, new BigInt64Array(timestamps), new Float64Array(values));
+  return id;
 }
 
-const CPU_LABELS = new Map([['__name__', 'cpu'], ['host', 'a']])
-const MEM_LABELS = new Map([['__name__', 'mem'], ['host', 'a']])
-const CPU_LABELS_B = new Map([['__name__', 'cpu'], ['host', 'b']])
+const CPU_LABELS = new Map([
+  ["__name__", "cpu"],
+  ["host", "a"],
+]);
+const MEM_LABELS = new Map([
+  ["__name__", "mem"],
+  ["host", "a"],
+]);
+const CPU_LABELS_B = new Map([
+  ["__name__", "cpu"],
+  ["host", "b"],
+]);
 
 // ── FlatStore ────────────────────────────────────────────────────────
 
-describe('FlatStore', () => {
-  it('creates store with correct name', () => {
-    const store = new FlatStore()
-    expect(store.name).toBe('FlatStore')
-  })
+describe("FlatStore", () => {
+  it("creates store with correct name", () => {
+    const store = new FlatStore();
+    expect(store.name).toBe("FlatStore");
+  });
 
-  it('pushes and reads back data', () => {
-    const store = new FlatStore()
-    pushSample(store, CPU_LABELS, 1000n, 42.5)
-    pushSample(store, CPU_LABELS, 2000n, 43.0)
+  it("pushes and reads back data", () => {
+    const store = new FlatStore();
+    pushSample(store, CPU_LABELS, 1000n, 42.5);
+    pushSample(store, CPU_LABELS, 2000n, 43.0);
 
-    const ids = store.matchLabel('__name__', 'cpu')
-    expect(ids.length).toBe(1)
-    const data = store.read(ids[0], 0n, 10000n)
-    expect(data.timestamps.length).toBe(2)
-    expect(data.timestamps[0]).toBe(1000n)
-    expect(data.timestamps[1]).toBe(2000n)
-    expect(data.values[0]).toBeCloseTo(42.5)
-    expect(data.values[1]).toBeCloseTo(43.0)
-  })
+    const ids = store.matchLabel("__name__", "cpu");
+    expect(ids.length).toBe(1);
+    const data = store.read(ids[0], 0n, 10000n);
+    expect(data.timestamps.length).toBe(2);
+    expect(data.timestamps[0]).toBe(1000n);
+    expect(data.timestamps[1]).toBe(2000n);
+    expect(data.values[0]).toBeCloseTo(42.5);
+    expect(data.values[1]).toBeCloseTo(43.0);
+  });
 
-  it('matches labels correctly', () => {
-    const store = new FlatStore()
-    pushSample(store, CPU_LABELS, 1000n, 1.0)
-    pushSample(store, MEM_LABELS, 1000n, 2.0)
-    pushSample(store, CPU_LABELS_B, 1000n, 3.0)
+  it("matches labels correctly", () => {
+    const store = new FlatStore();
+    pushSample(store, CPU_LABELS, 1000n, 1.0);
+    pushSample(store, MEM_LABELS, 1000n, 2.0);
+    pushSample(store, CPU_LABELS_B, 1000n, 3.0);
 
-    const cpuIds = store.matchLabel('__name__', 'cpu')
-    expect(cpuIds.length).toBe(2)
-    const memIds = store.matchLabel('__name__', 'mem')
-    expect(memIds.length).toBe(1)
-    const hostAIds = store.matchLabel('host', 'a')
-    expect(hostAIds.length).toBe(2)
-    const noMatch = store.matchLabel('__name__', 'disk')
-    expect(noMatch.length).toBe(0)
-  })
+    const cpuIds = store.matchLabel("__name__", "cpu");
+    expect(cpuIds.length).toBe(2);
+    const memIds = store.matchLabel("__name__", "mem");
+    expect(memIds.length).toBe(1);
+    const hostAIds = store.matchLabel("host", "a");
+    expect(hostAIds.length).toBe(2);
+    const noMatch = store.matchLabel("__name__", "disk");
+    expect(noMatch.length).toBe(0);
+  });
 
-  it('queries time range subset', () => {
-    const store = new FlatStore()
-    const ts = [1000n, 2000n, 3000n, 4000n, 5000n]
-    const vals = [10, 20, 30, 40, 50]
-    pushSamples(store, CPU_LABELS, ts, vals)
+  it("queries time range subset", () => {
+    const store = new FlatStore();
+    const ts = [1000n, 2000n, 3000n, 4000n, 5000n];
+    const vals = [10, 20, 30, 40, 50];
+    pushSamples(store, CPU_LABELS, ts, vals);
 
-    const ids = store.matchLabel('__name__', 'cpu')
-    const data = store.read(ids[0], 2000n, 4000n)
-    expect(data.timestamps.length).toBe(3)
-    expect(data.timestamps[0]).toBe(2000n)
-    expect(data.timestamps[2]).toBe(4000n)
-    expect(data.values[0]).toBeCloseTo(20)
-    expect(data.values[2]).toBeCloseTo(40)
-  })
+    const ids = store.matchLabel("__name__", "cpu");
+    const data = store.read(ids[0], 2000n, 4000n);
+    expect(data.timestamps.length).toBe(3);
+    expect(data.timestamps[0]).toBe(2000n);
+    expect(data.timestamps[2]).toBe(4000n);
+    expect(data.values[0]).toBeCloseTo(20);
+    expect(data.values[2]).toBeCloseTo(40);
+  });
 
-  it('returns empty result for out-of-range query', () => {
-    const store = new FlatStore()
-    pushSample(store, CPU_LABELS, 1000n, 42.5)
+  it("returns empty result for out-of-range query", () => {
+    const store = new FlatStore();
+    pushSample(store, CPU_LABELS, 1000n, 42.5);
 
-    const ids = store.matchLabel('__name__', 'cpu')
-    const data = store.read(ids[0], 5000n, 9000n)
-    expect(data.timestamps.length).toBe(0)
-    expect(data.values.length).toBe(0)
-  })
+    const ids = store.matchLabel("__name__", "cpu");
+    const data = store.read(ids[0], 5000n, 9000n);
+    expect(data.timestamps.length).toBe(0);
+    expect(data.values.length).toBe(0);
+  });
 
-  it('deduplicates series with same labels', () => {
-    const store = new FlatStore()
-    const id1 = store.getOrCreateSeries(CPU_LABELS)
-    const id2 = store.getOrCreateSeries(new Map([['__name__', 'cpu'], ['host', 'a']]))
-    expect(id1).toBe(id2)
-    expect(store.seriesCount).toBe(1)
-  })
+  it("deduplicates series with same labels", () => {
+    const store = new FlatStore();
+    const id1 = store.getOrCreateSeries(CPU_LABELS);
+    const id2 = store.getOrCreateSeries(
+      new Map([
+        ["__name__", "cpu"],
+        ["host", "a"],
+      ])
+    );
+    expect(id1).toBe(id2);
+    expect(store.seriesCount).toBe(1);
+  });
 
-  it('deduplicates regardless of label insertion order', () => {
-    const store = new FlatStore()
-    const id1 = store.getOrCreateSeries(new Map([['host', 'a'], ['__name__', 'cpu']]))
-    const id2 = store.getOrCreateSeries(new Map([['__name__', 'cpu'], ['host', 'a']]))
-    expect(id1).toBe(id2)
-    expect(store.seriesCount).toBe(1)
-  })
+  it("deduplicates regardless of label insertion order", () => {
+    const store = new FlatStore();
+    const id1 = store.getOrCreateSeries(
+      new Map([
+        ["host", "a"],
+        ["__name__", "cpu"],
+      ])
+    );
+    const id2 = store.getOrCreateSeries(
+      new Map([
+        ["__name__", "cpu"],
+        ["host", "a"],
+      ])
+    );
+    expect(id1).toBe(id2);
+    expect(store.seriesCount).toBe(1);
+  });
 
-  it('tracks sample and series counts', () => {
-    const store = new FlatStore()
-    pushSamples(store, CPU_LABELS, [1000n, 2000n], [1, 2])
-    pushSample(store, MEM_LABELS, 1000n, 3.0)
-    expect(store.seriesCount).toBe(2)
-    expect(store.sampleCount).toBe(3)
-  })
+  it("tracks sample and series counts", () => {
+    const store = new FlatStore();
+    pushSamples(store, CPU_LABELS, [1000n, 2000n], [1, 2]);
+    pushSample(store, MEM_LABELS, 1000n, 3.0);
+    expect(store.seriesCount).toBe(2);
+    expect(store.sampleCount).toBe(3);
+  });
 
-  it('reports memoryBytes > 0 after data is added', () => {
-    const store = new FlatStore()
-    pushSample(store, CPU_LABELS, 1000n, 42.5)
-    expect(store.memoryBytes()).toBeGreaterThan(0)
-  })
+  it("reports memoryBytes > 0 after data is added", () => {
+    const store = new FlatStore();
+    pushSample(store, CPU_LABELS, 1000n, 42.5);
+    expect(store.memoryBytes()).toBeGreaterThan(0);
+  });
 
-  it('returns labels for a series', () => {
-    const store = new FlatStore()
-    const id = pushSample(store, CPU_LABELS, 1000n, 42.5)
-    const labels = store.labels(id)
-    expect(labels.get('__name__')).toBe('cpu')
-    expect(labels.get('host')).toBe('a')
-  })
-})
+  it("returns labels for a series", () => {
+    const store = new FlatStore();
+    const id = pushSample(store, CPU_LABELS, 1000n, 42.5);
+    const labels = store.labels(id);
+    expect(labels.get("__name__")).toBe("cpu");
+    expect(labels.get("host")).toBe("a");
+  });
+});
 
 // ── ChunkedStore ─────────────────────────────────────────────────────
 
-describe('ChunkedStore', () => {
-  it('creates store with correct name', () => {
-    const store = new ChunkedStore()
-    expect(store.name).toBe('ChunkedStore')
-  })
+describe("ChunkedStore", () => {
+  it("creates store with correct name", () => {
+    const store = new ChunkedStore();
+    expect(store.name).toBe("ChunkedStore");
+  });
 
-  it('pushes and reads back data', () => {
-    const store = new ChunkedStore()
-    pushSample(store, CPU_LABELS, 1000n, 42.5)
-    pushSample(store, CPU_LABELS, 2000n, 43.0)
+  it("pushes and reads back data", () => {
+    const store = new ChunkedStore();
+    pushSample(store, CPU_LABELS, 1000n, 42.5);
+    pushSample(store, CPU_LABELS, 2000n, 43.0);
 
-    const ids = store.matchLabel('__name__', 'cpu')
-    const data = store.read(ids[0], 0n, 10000n)
-    expect(data.timestamps.length).toBe(2)
-    expect(data.timestamps[0]).toBe(1000n)
-    expect(data.values[0]).toBeCloseTo(42.5)
-  })
+    const ids = store.matchLabel("__name__", "cpu");
+    const data = store.read(ids[0], 0n, 10000n);
+    expect(data.timestamps.length).toBe(2);
+    expect(data.timestamps[0]).toBe(1000n);
+    expect(data.values[0]).toBeCloseTo(42.5);
+  });
 
-  it('queries time range subset', () => {
-    const store = new ChunkedStore()
-    const ts = [1000n, 2000n, 3000n, 4000n, 5000n]
-    const vals = [10, 20, 30, 40, 50]
-    pushSamples(store, CPU_LABELS, ts, vals)
+  it("queries time range subset", () => {
+    const store = new ChunkedStore();
+    const ts = [1000n, 2000n, 3000n, 4000n, 5000n];
+    const vals = [10, 20, 30, 40, 50];
+    pushSamples(store, CPU_LABELS, ts, vals);
 
-    const ids = store.matchLabel('__name__', 'cpu')
-    const data = store.read(ids[0], 2000n, 4000n)
-    expect(data.timestamps.length).toBe(3)
-    expect(data.values[1]).toBeCloseTo(30)
-  })
+    const ids = store.matchLabel("__name__", "cpu");
+    const data = store.read(ids[0], 2000n, 4000n);
+    expect(data.timestamps.length).toBe(3);
+    expect(data.values[1]).toBeCloseTo(30);
+  });
 
-  it('freezes chunks when exceeding chunkSize', () => {
-    const chunkSize = 10
-    const store = new ChunkedStore(chunkSize)
-    const baseTs = 1_000_000_000_000n
-    const ts = []
-    const vals = []
+  it("freezes chunks when exceeding chunkSize", () => {
+    const chunkSize = 10;
+    const store = new ChunkedStore(chunkSize);
+    const baseTs = 1_000_000_000_000n;
+    const ts = [];
+    const vals = [];
     for (let i = 0; i < 25; i++) {
-      ts.push(baseTs + BigInt(i) * 1000n)
-      vals.push(i * 1.0)
+      ts.push(baseTs + BigInt(i) * 1000n);
+      vals.push(i * 1.0);
     }
-    pushSamples(store, CPU_LABELS, ts, vals)
+    pushSamples(store, CPU_LABELS, ts, vals);
 
-    const ids = store.matchLabel('__name__', 'cpu')
-    const info = store.getChunkInfo(ids[0])
+    const ids = store.matchLabel("__name__", "cpu");
+    const info = store.getChunkInfo(ids[0]);
     // 25 samples / 10 chunkSize = 2 frozen chunks + 5 in hot
-    expect(info.frozen.length).toBe(2)
-    expect(info.hot.count).toBe(5)
-    expect(info.frozen[0].count).toBe(10)
-    expect(info.frozen[1].count).toBe(10)
-  })
+    expect(info.frozen.length).toBe(2);
+    expect(info.hot.count).toBe(5);
+    expect(info.frozen[0].count).toBe(10);
+    expect(info.frozen[1].count).toBe(10);
+  });
 
-  it('reads data spanning frozen and hot chunks', () => {
-    const chunkSize = 5
-    const store = new ChunkedStore(chunkSize)
-    const ts = []
-    const vals = []
+  it("reads data spanning frozen and hot chunks", () => {
+    const chunkSize = 5;
+    const store = new ChunkedStore(chunkSize);
+    const ts = [];
+    const vals = [];
     for (let i = 0; i < 12; i++) {
-      ts.push(BigInt(i + 1) * 1000n)
-      vals.push((i + 1) * 10.0)
+      ts.push(BigInt(i + 1) * 1000n);
+      vals.push((i + 1) * 10.0);
     }
-    pushSamples(store, CPU_LABELS, ts, vals)
+    pushSamples(store, CPU_LABELS, ts, vals);
 
-    const ids = store.matchLabel('__name__', 'cpu')
-    const data = store.read(ids[0], 0n, 100000n)
-    expect(data.timestamps.length).toBe(12)
+    const ids = store.matchLabel("__name__", "cpu");
+    const data = store.read(ids[0], 0n, 100000n);
+    expect(data.timestamps.length).toBe(12);
     // Verify ordering across chunks
     for (let i = 0; i < 12; i++) {
-      expect(data.timestamps[i]).toBe(BigInt(i + 1) * 1000n)
-      expect(data.values[i]).toBeCloseTo((i + 1) * 10.0)
+      expect(data.timestamps[i]).toBe(BigInt(i + 1) * 1000n);
+      expect(data.values[i]).toBeCloseTo((i + 1) * 10.0);
     }
-  })
+  });
 
-  it('tracks memoryBytes including compressed chunks', () => {
-    const chunkSize = 5
-    const store = new ChunkedStore(chunkSize)
-    const ts = []
-    const vals = []
+  it("tracks memoryBytes including compressed chunks", () => {
+    const chunkSize = 5;
+    const store = new ChunkedStore(chunkSize);
+    const ts = [];
+    const vals = [];
     for (let i = 0; i < 10; i++) {
-      ts.push(BigInt(i) * 1000n)
-      vals.push(i * 1.0)
+      ts.push(BigInt(i) * 1000n);
+      vals.push(i * 1.0);
     }
-    pushSamples(store, CPU_LABELS, ts, vals)
+    pushSamples(store, CPU_LABELS, ts, vals);
 
-    const bytes = store.memoryBytes()
-    expect(bytes).toBeGreaterThan(0)
-  })
+    const bytes = store.memoryBytes();
+    expect(bytes).toBeGreaterThan(0);
+  });
 
-  it('deduplicates series with same labels', () => {
-    const store = new ChunkedStore()
-    const id1 = store.getOrCreateSeries(CPU_LABELS)
-    const id2 = store.getOrCreateSeries(new Map([['__name__', 'cpu'], ['host', 'a']]))
-    expect(id1).toBe(id2)
-    expect(store.seriesCount).toBe(1)
-  })
+  it("deduplicates series with same labels", () => {
+    const store = new ChunkedStore();
+    const id1 = store.getOrCreateSeries(CPU_LABELS);
+    const id2 = store.getOrCreateSeries(
+      new Map([
+        ["__name__", "cpu"],
+        ["host", "a"],
+      ])
+    );
+    expect(id1).toBe(id2);
+    expect(store.seriesCount).toBe(1);
+  });
 
-  it('deduplicates regardless of label insertion order', () => {
-    const store = new ChunkedStore()
-    const id1 = store.getOrCreateSeries(new Map([['host', 'a'], ['__name__', 'cpu']]))
-    const id2 = store.getOrCreateSeries(new Map([['__name__', 'cpu'], ['host', 'a']]))
-    expect(id1).toBe(id2)
-  })
+  it("deduplicates regardless of label insertion order", () => {
+    const store = new ChunkedStore();
+    const id1 = store.getOrCreateSeries(
+      new Map([
+        ["host", "a"],
+        ["__name__", "cpu"],
+      ])
+    );
+    const id2 = store.getOrCreateSeries(
+      new Map([
+        ["__name__", "cpu"],
+        ["host", "a"],
+      ])
+    );
+    expect(id1).toBe(id2);
+  });
 
-  it('compression ratio improves with regular data', () => {
-    const chunkSize = 50
-    const store = new ChunkedStore(chunkSize)
-    const ts = []
-    const vals = []
+  it("compression ratio improves with regular data", () => {
+    const chunkSize = 50;
+    const store = new ChunkedStore(chunkSize);
+    const ts = [];
+    const vals = [];
     for (let i = 0; i < 50; i++) {
-      ts.push(BigInt(i) * 1_000_000_000n)
-      vals.push(42.5) // all same value → great compression
+      ts.push(BigInt(i) * 1_000_000_000n);
+      vals.push(42.5); // all same value → great compression
     }
-    pushSamples(store, CPU_LABELS, ts, vals)
+    pushSamples(store, CPU_LABELS, ts, vals);
 
-    const ids = store.matchLabel('__name__', 'cpu')
-    const info = store.getChunkInfo(ids[0])
-    expect(info.frozen.length).toBe(1)
-    const rawBytes = info.frozen[0].rawBytes
-    const compressedBytes = info.frozen[0].compressedBytes
-    expect(compressedBytes).toBeLessThan(rawBytes)
-  })
+    const ids = store.matchLabel("__name__", "cpu");
+    const info = store.getChunkInfo(ids[0]);
+    expect(info.frozen.length).toBe(1);
+    const rawBytes = info.frozen[0].rawBytes;
+    const compressedBytes = info.frozen[0].compressedBytes;
+    expect(compressedBytes).toBeLessThan(rawBytes);
+  });
 
-  it('returns empty result for out-of-range query', () => {
-    const store = new ChunkedStore()
-    pushSample(store, CPU_LABELS, 1000n, 42.5)
-    const ids = store.matchLabel('__name__', 'cpu')
-    const data = store.read(ids[0], 5000n, 9000n)
-    expect(data.timestamps.length).toBe(0)
-  })
-})
+  it("returns empty result for out-of-range query", () => {
+    const store = new ChunkedStore();
+    pushSample(store, CPU_LABELS, 1000n, 42.5);
+    const ids = store.matchLabel("__name__", "cpu");
+    const data = store.read(ids[0], 5000n, 9000n);
+    expect(data.timestamps.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Absorbs all remaining value from PR #94 onto current main, plus 2 validation fixes from the Playwright audit.

## What is new vs main

### fix(learn) — 2 validation fixes (from Playwright audit)
- **Delta-of-Delta**: Δ column header cleaned up (removed redundant "(delta)" text suffix)
- **XOR-Delta**: IEEE 754 field note added adjacent to the 64-bit grid (`1 sign · 11 exponent · 52 fraction`)

### fix(lint) — resolve all biome errors across monorepo (from PR #94)
- `biome.json`: exclude bench R&D scripts from linting
- `packages/o11ytsdb/src`: biome-ignore for intentional patterns (noNonNullAssertion, noAssignInExpressions, noDuplicateElseIf), fix formatting + import order
- `packages/o11ytsdb/test`: fix formatting, import order
- `site/tsdb-engine`: fix useTemplate, useParseIntRadix, noUnusedVariables; add `type=button` to all buttons; reduced-motion guard for reveal pulse animation
- `research/gorilla-bench.mjs`: useTemplate, biome-ignore for bit-width dispatch

### fix(chart) — from PR #94
- `isMonitorMetric` and `defaultMetricLabel` now handle aggregated `_monitor/` prefix

### fix(package-lock) — from PR #94
- Update `@benchkit` package versions

## Relationship to PR #94
PR #94 (`fix/learn-nav-and-shared-fixes`) had learn breadcrumb/nav fixes that were already superseded by PRs #93 and #96. This PR cherry-picks all 4 commits from #94 onto current main, keeping main's newer learn files where conflicts arose.

Closes #94