### PR TITLE
chore(deps-dev): bump @biomejs/biome from 2.4.11 to 2.4.12

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "files": {
     "includes": [
       "**",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",
-        "@biomejs/biome": "^2.4.11",
+        "@biomejs/biome": "^2.4.12",
         "@changesets/cli": "^2.31.0",
         "@playwright/test": "^1.54.2",
         "@types/node": "^25.6.0",
@@ -600,9 +600,9 @@
       "link": true
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.11.tgz",
-      "integrity": "sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.12.tgz",
+      "integrity": "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -616,20 +616,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.4.11",
-        "@biomejs/cli-darwin-x64": "2.4.11",
-        "@biomejs/cli-linux-arm64": "2.4.11",
-        "@biomejs/cli-linux-arm64-musl": "2.4.11",
-        "@biomejs/cli-linux-x64": "2.4.11",
-        "@biomejs/cli-linux-x64-musl": "2.4.11",
-        "@biomejs/cli-win32-arm64": "2.4.11",
-        "@biomejs/cli-win32-x64": "2.4.11"
+        "@biomejs/cli-darwin-arm64": "2.4.12",
+        "@biomejs/cli-darwin-x64": "2.4.12",
+        "@biomejs/cli-linux-arm64": "2.4.12",
+        "@biomejs/cli-linux-arm64-musl": "2.4.12",
+        "@biomejs/cli-linux-x64": "2.4.12",
+        "@biomejs/cli-linux-x64-musl": "2.4.12",
+        "@biomejs/cli-win32-arm64": "2.4.12",
+        "@biomejs/cli-win32-x64": "2.4.12"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.11.tgz",
-      "integrity": "sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.12.tgz",
+      "integrity": "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==",
       "cpu": [
         "arm64"
       ],
@@ -644,9 +644,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.11.tgz",
-      "integrity": "sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.12.tgz",
+      "integrity": "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==",
       "cpu": [
         "x64"
       ],
@@ -661,9 +661,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.11.tgz",
-      "integrity": "sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.12.tgz",
+      "integrity": "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==",
       "cpu": [
         "arm64"
       ],
@@ -678,9 +678,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.11.tgz",
-      "integrity": "sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.12.tgz",
+      "integrity": "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==",
       "cpu": [
         "arm64"
       ],
@@ -695,9 +695,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.11.tgz",
-      "integrity": "sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.12.tgz",
+      "integrity": "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==",
       "cpu": [
         "x64"
       ],
@@ -712,9 +712,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.11.tgz",
-      "integrity": "sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.12.tgz",
+      "integrity": "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==",
       "cpu": [
         "x64"
       ],
@@ -729,9 +729,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.11.tgz",
-      "integrity": "sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.12.tgz",
+      "integrity": "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==",
       "cpu": [
         "arm64"
       ],
@@ -746,9 +746,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.11.tgz",
-      "integrity": "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.12.tgz",
+      "integrity": "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -55,12 +55,12 @@
     "release:publish": "changeset publish"
   },
   "devDependencies": {
-    "@types/node": "^25.6.0",
-    "@vercel/ncc": "^0.38.4",
     "@arethetypeswrong/cli": "^0.18.2",
-    "@biomejs/biome": "^2.4.11",
+    "@biomejs/biome": "^2.4.12",
     "@changesets/cli": "^2.31.0",
     "@playwright/test": "^1.54.2",
+    "@types/node": "^25.6.0",
+    "@vercel/ncc": "^0.38.4",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.4",
     "publint": "^0.3.18",

--- a/packages/views/test/index.test.ts
+++ b/packages/views/test/index.test.ts
@@ -11,6 +11,7 @@ import {
   createTelemetryStore,
   mergeTimeSeriesFrames,
 } from "../src/index.js";
+
 describe("@otlpkit/views", () => {
   it("builds time-series frames", () => {
     const frame = buildTimeSeriesFrame(metricsDocument, {
@@ -921,5 +922,4 @@ describe("@otlpkit/views", () => {
       "4000000000",
     ]);
   });
-
 });


### PR DESCRIPTION
Replaces #90 which had merge conflicts after multiple PRs landed on main.\n\nBumps `@biomejs/biome` from 2.4.11 to 2.4.12.