### PR TITLE
fix(lint): fix biome import ordering in packages/views/test

### DIFF
--- a/packages/views/test/index.test.ts
+++ b/packages/views/test/index.test.ts
@@ -11,6 +11,7 @@ import {
   createTelemetryStore,
   mergeTimeSeriesFrames,
 } from "../src/index.js";
+
 describe("@otlpkit/views", () => {
   it("builds time-series frames", () => {
     const frame = buildTimeSeriesFrame(metricsDocument, {
@@ -921,5 +922,4 @@ describe("@otlpkit/views", () => {
       "4000000000",
     ]);
   });
-
 });


### PR DESCRIPTION
Adds missing blank line separator after import group and before describe() block as required by biome organizeImports. This file was introduced in the big merge but has a minor biome formatting issue that blocks CI on all PRs.