### PR TITLE
feat(tsdb): add fluent query builder + plan executor

### DIFF
--- a/packages/o11ytsdb/bench/bench-codecs.mjs
+++ b/packages/o11ytsdb/bench/bench-codecs.mjs
@@ -1,0 +1,308 @@
+/**
+ * Shared WASM codec loader for benchmarks.
+ *
+ * Centralizes all WASM codec construction so benchmarks can import a single
+ * module instead of duplicating ~150 lines of setup each.
+ *
+ * Usage:
+ *   import { loadBenchCodecs } from './bench-codecs.mjs';
+ *   const codecs = await loadBenchCodecs();
+ *   // codecs.alpValuesCodec, codecs.tsCodec, codecs.alpRangeCodec,
+ *   // codecs.stepAggCodec, codecs.valuesCodec, codecs.fullCodec
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(__dirname, "..");
+
+// ── Step-aggregate function IDs (must match Rust enum) ───────────────
+
+const AGG_FN_ID = { min: 0, max: 1, sum: 2, count: 3, last: 4, avg: 5 };
+
+// ── Main loader ──────────────────────────────────────────────────────
+
+/**
+ * Load the WASM binary and return all codec objects.
+ *
+ * Returns: { alpValuesCodec, tsCodec, alpRangeCodec, stepAggCodec,
+ *            valuesCodec, fullCodec }
+ *
+ * - alpValuesCodec: ALP encode/decode for values (primary codec)
+ * - tsCodec: delta-of-delta timestamp codec
+ * - alpRangeCodec: fused range-decode (timestamps + ALP values with time filter)
+ * - stepAggCodec: fused decode+aggregate in WASM (for ColumnStore stepAggCodec param)
+ * - valuesCodec: XOR-delta encode/decode for values (legacy, used by smoke/profile)
+ * - fullCodec: chunk-level XOR encode/decode (timestamps+values, used by profile)
+ */
+export async function loadBenchCodecs() {
+  const wasmPath = join(pkgDir, "wasm/o11ytsdb-rust.wasm");
+  const wasmBytes = readFileSync(wasmPath);
+  const { instance } = await WebAssembly.instantiate(wasmBytes, { env: {} });
+  const w = instance.exports;
+  const mem = () => new Uint8Array(w.memory.buffer);
+
+  // ── ALP values codec (primary) ───────────────────────────────────
+
+  const alpValuesCodec = {
+    name: "rust-wasm-alp",
+    encodeValues(values) {
+      const n = values.length;
+      w.resetScratch();
+      const valPtr = w.allocScratch(n * 8);
+      const outCap = n * 20;
+      const outPtr = w.allocScratch(outCap);
+      mem().set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valPtr);
+      return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeValuesALP(valPtr, n, outPtr, outCap)));
+    },
+    decodeValues(buf) {
+      w.resetScratch();
+      const inPtr = w.allocScratch(buf.length);
+      mem().set(buf, inPtr);
+      const maxSamples = (buf[0] << 8) | buf[1];
+      const valPtr = w.allocScratch(maxSamples * 8);
+      const n = w.decodeValuesALP(inPtr, buf.length, valPtr, maxSamples);
+      return new Float64Array(w.memory.buffer.slice(valPtr, valPtr + n * 8));
+    },
+    encodeValuesWithStats(values) {
+      const n = values.length;
+      w.resetScratch();
+      const valPtr = w.allocScratch(n * 8);
+      const outCap = n * 20;
+      const outPtr = w.allocScratch(outCap);
+      const statsPtr = w.allocScratch(64);
+      mem().set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valPtr);
+      const bytesWritten = w.encodeValuesALPWithStats(valPtr, n, outPtr, outCap, statsPtr);
+      const compressed = new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + bytesWritten));
+      const s = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + 64));
+      return {
+        compressed,
+        stats: { minV: s[0], maxV: s[1], sum: s[2], count: s[3], firstV: s[4], lastV: s[5], sumOfSquares: s[6], resetCount: s[7] },
+      };
+    },
+    encodeBatchValuesWithStats(arrays) {
+      const numArrays = arrays.length;
+      const chunkSize = arrays[0].length;
+      w.resetScratch();
+      const valsPtr = w.allocScratch(numArrays * chunkSize * 8);
+      for (let i = 0; i < numArrays; i++) {
+        const arr = arrays[i];
+        mem().set(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength), valsPtr + i * chunkSize * 8);
+      }
+      const outCap = numArrays * chunkSize * 20;
+      const outPtr = w.allocScratch(outCap);
+      const offsetsPtr = w.allocScratch(numArrays * 4);
+      const sizesPtr = w.allocScratch(numArrays * 4);
+      const statsPtr = w.allocScratch(numArrays * 64);
+      w.encodeBatchValuesALPWithStats(valsPtr, chunkSize, numArrays, outPtr, outCap, offsetsPtr, sizesPtr, statsPtr);
+      const offsets = new Uint32Array(w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4));
+      const sizes = new Uint32Array(w.memory.buffer.slice(sizesPtr, sizesPtr + numArrays * 4));
+      const allStats = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + numArrays * 64));
+      const results = [];
+      for (let i = 0; i < numArrays; i++) {
+        const compressed = new Uint8Array(w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i]));
+        const si = i * 8;
+        results.push({
+          compressed,
+          stats: {
+            minV: allStats[si], maxV: allStats[si+1], sum: allStats[si+2], count: allStats[si+3],
+            firstV: allStats[si+4], lastV: allStats[si+5], sumOfSquares: allStats[si+6], resetCount: allStats[si+7],
+          },
+        });
+      }
+      return results;
+    },
+  };
+
+  // ── Timestamp codec ──────────────────────────────────────────────
+
+  const tsCodec = {
+    name: "rust-wasm-ts",
+    encodeTimestamps(timestamps) {
+      const n = timestamps.length;
+      w.resetScratch();
+      const tsPtr = w.allocScratch(n * 8);
+      const outCap = n * 20;
+      const outPtr = w.allocScratch(outCap);
+      mem().set(new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength), tsPtr);
+      return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeTimestamps(tsPtr, n, outPtr, outCap)));
+    },
+    decodeTimestamps(buf) {
+      w.resetScratch();
+      const inPtr = w.allocScratch(buf.length);
+      mem().set(buf, inPtr);
+      const maxSamples = (buf[0] << 8) | buf[1];
+      const tsPtr = w.allocScratch(maxSamples * 8);
+      const n = w.decodeTimestamps(inPtr, buf.length, tsPtr, maxSamples);
+      return new BigInt64Array(w.memory.buffer.slice(tsPtr, tsPtr + n * 8));
+    },
+  };
+
+  // ── ALP range-decode codec (fused time-filtered decode) ──────────
+
+  const alpRangeCodec = {
+    rangeDecodeValues(compressedTs, compressedVals, startT, endT) {
+      w.resetScratch();
+      const tsInPtr = w.allocScratch(compressedTs.length);
+      mem().set(compressedTs, tsInPtr);
+      const valInPtr = w.allocScratch(compressedVals.length);
+      mem().set(compressedVals, valInPtr);
+      const maxSamples = (compressedVals[0] << 8) | compressedVals[1];
+      const outTsPtr = w.allocScratch(maxSamples * 8);
+      const outValPtr = w.allocScratch(maxSamples * 8);
+      const n = w.rangeDecodeALP(
+        tsInPtr, compressedTs.length,
+        valInPtr, compressedVals.length,
+        startT, endT,
+        outTsPtr, outValPtr,
+        maxSamples,
+      );
+      if (n === 0) return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
+      return {
+        timestamps: new BigInt64Array(w.memory.buffer.slice(outTsPtr, outTsPtr + n * 8)),
+        values: new Float64Array(w.memory.buffer.slice(outValPtr, outValPtr + n * 8)),
+      };
+    },
+  };
+
+  // ── Step-aggregate codec (fused decode+aggregate in WASM) ────────
+
+  const stepAggCodec = {
+    aggregateChunk(compressedTimestamps, compressedValues, aggFn, minT, step, values, counts) {
+      const fnId = AGG_FN_ID[aggFn];
+      if (fnId === undefined) return 0;
+      const bucketCount = values.length;
+      w.resetScratch();
+
+      const tsInPtr = w.allocScratch(compressedTimestamps.length);
+      mem().set(compressedTimestamps, tsInPtr);
+      const valInPtr = w.allocScratch(compressedValues.length);
+      mem().set(compressedValues, valInPtr);
+
+      const valsPtr = w.allocScratch(bucketCount * 8);
+      const cntsPtr = w.allocScratch(bucketCount * 8);
+      const wasmMem = mem();
+      wasmMem.set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valsPtr);
+      wasmMem.set(new Uint8Array(counts.buffer, counts.byteOffset, counts.byteLength), cntsPtr);
+
+      const n = w.stepAggregateChunkALP(
+        tsInPtr, compressedTimestamps.length, valInPtr, compressedValues.length,
+        fnId, minT, step, valsPtr, cntsPtr, bucketCount,
+      );
+
+      values.set(new Float64Array(w.memory.buffer.slice(valsPtr, valsPtr + bucketCount * 8)));
+      counts.set(new Float64Array(w.memory.buffer.slice(cntsPtr, cntsPtr + bucketCount * 8)));
+      return n;
+    },
+  };
+
+  // ── XOR values codec (legacy, for smoke/profile comparisons) ─────
+
+  const valuesCodec = {
+    name: "rust-wasm",
+    encodeValues(values) {
+      const n = values.length;
+      w.resetScratch();
+      const valPtr = w.allocScratch(n * 8);
+      const outCap = n * 20;
+      const outPtr = w.allocScratch(outCap);
+      mem().set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valPtr);
+      return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeValues(valPtr, n, outPtr, outCap)));
+    },
+    decodeValues(buf) {
+      w.resetScratch();
+      const inPtr = w.allocScratch(buf.length);
+      mem().set(buf, inPtr);
+      const maxSamples = (buf[0] << 8) | buf[1];
+      const valPtr = w.allocScratch(maxSamples * 8);
+      const n = w.decodeValues(inPtr, buf.length, valPtr, maxSamples);
+      return new Float64Array(w.memory.buffer.slice(valPtr, valPtr + n * 8));
+    },
+    encodeValuesWithStats(values) {
+      const n = values.length;
+      w.resetScratch();
+      const valPtr = w.allocScratch(n * 8);
+      const outCap = n * 20;
+      const outPtr = w.allocScratch(outCap);
+      const statsPtr = w.allocScratch(64);
+      mem().set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valPtr);
+      const bytesWritten = w.encodeValuesWithStats(valPtr, n, outPtr, outCap, statsPtr);
+      const compressed = new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + bytesWritten));
+      const s = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + 64));
+      return {
+        compressed,
+        stats: { minV: s[0], maxV: s[1], sum: s[2], count: s[3], firstV: s[4], lastV: s[5], sumOfSquares: s[6], resetCount: s[7] },
+      };
+    },
+    encodeBatchValuesWithStats(arrays) {
+      const numArrays = arrays.length;
+      const chunkSize = arrays[0].length;
+      w.resetScratch();
+      const valsPtr = w.allocScratch(numArrays * chunkSize * 8);
+      for (let i = 0; i < numArrays; i++) {
+        const arr = arrays[i];
+        mem().set(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength), valsPtr + i * chunkSize * 8);
+      }
+      const outCap = numArrays * chunkSize * 20;
+      const outPtr = w.allocScratch(outCap);
+      const offsetsPtr = w.allocScratch(numArrays * 4);
+      const sizesPtr = w.allocScratch(numArrays * 4);
+      const statsPtr = w.allocScratch(numArrays * 64);
+      w.encodeBatchValuesWithStats(valsPtr, chunkSize, numArrays, outPtr, outCap, offsetsPtr, sizesPtr, statsPtr);
+      const offsets = new Uint32Array(w.memory.buffer.slice(offsetsPtr, offsetsPtr + numArrays * 4));
+      const sizes = new Uint32Array(w.memory.buffer.slice(sizesPtr, sizesPtr + numArrays * 4));
+      const allStats = new Float64Array(w.memory.buffer.slice(statsPtr, statsPtr + numArrays * 64));
+      const results = [];
+      for (let i = 0; i < numArrays; i++) {
+        const compressed = new Uint8Array(w.memory.buffer.slice(outPtr + offsets[i], outPtr + offsets[i] + sizes[i]));
+        const si = i * 8;
+        results.push({
+          compressed,
+          stats: {
+            minV: allStats[si], maxV: allStats[si+1], sum: allStats[si+2], count: allStats[si+3],
+            firstV: allStats[si+4], lastV: allStats[si+5], sumOfSquares: allStats[si+6], resetCount: allStats[si+7],
+          },
+        });
+      }
+      return results;
+    },
+  };
+
+  // ── Full chunk XOR codec (legacy, for profile comparisons) ───────
+
+  const fullCodec = {
+    name: "rust-wasm",
+    encode(timestamps, values) {
+      const n = timestamps.length;
+      w.resetScratch();
+      const tsPtr = w.allocScratch(n * 8);
+      const valPtr = w.allocScratch(n * 8);
+      const outCap = n * 20;
+      const outPtr = w.allocScratch(outCap);
+      const m = mem();
+      m.set(new Uint8Array(timestamps.buffer, timestamps.byteOffset, timestamps.byteLength), tsPtr);
+      m.set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valPtr);
+      return new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + w.encodeChunk(tsPtr, valPtr, n, outPtr, outCap)));
+    },
+    decode(buf) {
+      w.resetScratch();
+      const inPtr = w.allocScratch(buf.length);
+      mem().set(buf, inPtr);
+      const maxSamples = (buf[0] << 8) | buf[1];
+      const tsPtr = w.allocScratch(maxSamples * 8);
+      const valPtr = w.allocScratch(maxSamples * 8);
+      const n = w.decodeChunk(inPtr, buf.length, tsPtr, valPtr, maxSamples);
+      return {
+        timestamps: new BigInt64Array(w.memory.buffer.slice(tsPtr, tsPtr + n * 8)),
+        values: new Float64Array(w.memory.buffer.slice(valPtr, valPtr + n * 8)),
+      };
+    },
+  };
+
+  return { alpValuesCodec, tsCodec, alpRangeCodec, stepAggCodec, valuesCodec, fullCodec };
+}
+
+/** Resolve the package root (for dynamic imports of dist/). */
+export const PKG_DIR = pkgDir;

--- a/packages/o11ytsdb/bench/bench-fused-agg.mjs
+++ b/packages/o11ytsdb/bench/bench-fused-agg.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * Benchmark: Fused WASM stepAggregateChunkALP vs JS decode+aggregate.
+ *
+ * Measures the per-chunk aggregation time for both paths:
+ *   1. JS path: decodeTimestamps + decodeValuesALP + JS bucket loop
+ *   2. WASM fused: stepAggregateChunkALP (decode + aggregate in one call)
+ *
+ * Usage:
+ *   node --expose-gc bench/bench-fused-agg.mjs
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(__dirname, "..");
+
+// ── Config ───────────────────────────────────────────────────────────
+
+const CHUNK_SIZE = 640;
+const NUM_CHUNKS = 260;   // ~166K samples (one series worth)
+const T0 = 1_700_000_000_000n;
+const INTERVAL = 15_000n;
+const STEP = 60_000n;     // 1-minute aggregation step
+
+// ── Load WASM ────────────────────────────────────────────────────────
+
+const wasmPath = join(pkgDir, "wasm/o11ytsdb-rust.wasm");
+const wasmBytes = readFileSync(wasmPath);
+const { instance } = await WebAssembly.instantiate(wasmBytes, { env: {} });
+const w = instance.exports;
+const mem = () => new Uint8Array(w.memory.buffer);
+
+// ── Generate and compress test data ──────────────────────────────────
+
+console.log(`Generating ${NUM_CHUNKS} chunks × ${CHUNK_SIZE} samples = ${(NUM_CHUNKS * CHUNK_SIZE).toLocaleString()} samples`);
+console.log(`Step: ${STEP}ms, Interval: ${INTERVAL}ms\n`);
+
+const compressedTs = [];
+const compressedVals = [];
+
+for (let c = 0; c < NUM_CHUNKS; c++) {
+  const ts = new BigInt64Array(CHUNK_SIZE);
+  const vals = new Float64Array(CHUNK_SIZE);
+  for (let i = 0; i < CHUNK_SIZE; i++) {
+    ts[i] = T0 + BigInt(c * CHUNK_SIZE + i) * INTERVAL;
+    vals[i] = Math.sin((c * CHUNK_SIZE + i) * 0.001) * 50 + 100 + (Math.random() - 0.5) * 10;
+  }
+
+  // Encode timestamps
+  w.resetScratch();
+  const tsPtr = w.allocScratch(CHUNK_SIZE * 8);
+  const outCap = CHUNK_SIZE * 20;
+  const outPtr = w.allocScratch(outCap);
+  mem().set(new Uint8Array(ts.buffer), tsPtr);
+  const tsBytesWritten = w.encodeTimestamps(tsPtr, CHUNK_SIZE, outPtr, outCap);
+  compressedTs.push(new Uint8Array(w.memory.buffer.slice(outPtr, outPtr + tsBytesWritten)));
+
+  // Encode values (ALP)
+  w.resetScratch();
+  const valPtr = w.allocScratch(CHUNK_SIZE * 8);
+  const outPtr2 = w.allocScratch(outCap);
+  mem().set(new Uint8Array(vals.buffer), valPtr);
+  const valBytesWritten = w.encodeValuesALP(valPtr, CHUNK_SIZE, outPtr2, outCap);
+  compressedVals.push(new Uint8Array(w.memory.buffer.slice(outPtr2, outPtr2 + valBytesWritten)));
+}
+
+// Compute time range
+const totalSamples = NUM_CHUNKS * CHUNK_SIZE;
+const minT = T0;
+const maxT = T0 + BigInt(totalSamples - 1) * INTERVAL;
+const bucketCount = Number((maxT - minT) / STEP) + 1;
+
+console.log(`Bucket count: ${bucketCount}`);
+console.log(`Compressed ts: ${compressedTs.reduce((a, b) => a + b.length, 0)} bytes`);
+console.log(`Compressed vals: ${compressedVals.reduce((a, b) => a + b.length, 0)} bytes\n`);
+
+// ── Platform endianness flag ─────────────────────────────────────────
+const _le = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+
+// ── JS path: decode + DataView bucket loop ───────────────────────────
+
+function jsAggregate(aggInit) {
+  const values = new Float64Array(bucketCount).fill(aggInit);
+  const counts = new Float64Array(bucketCount);
+  const minTN = Number(minT);
+  const stepN = Number(STEP);
+
+  for (let c = 0; c < NUM_CHUNKS; c++) {
+    // Decode timestamps
+    w.resetScratch();
+    const tsInPtr = w.allocScratch(compressedTs[c].length);
+    mem().set(compressedTs[c], tsInPtr);
+    const maxS = (compressedTs[c][0] << 8) | compressedTs[c][1];
+    const tsOutPtr = w.allocScratch(maxS * 8);
+    const n = w.decodeTimestamps(tsInPtr, compressedTs[c].length, tsOutPtr, maxS);
+    const ts = new BigInt64Array(w.memory.buffer.slice(tsOutPtr, tsOutPtr + n * 8));
+
+    // Decode values
+    w.resetScratch();
+    const valInPtr = w.allocScratch(compressedVals[c].length);
+    mem().set(compressedVals[c], valInPtr);
+    const maxV = (compressedVals[c][0] << 8) | compressedVals[c][1];
+    const valOutPtr = w.allocScratch(maxV * 8);
+    const nv = w.decodeValuesALP(valInPtr, compressedVals[c].length, valOutPtr, maxV);
+    const vs = new Float64Array(w.memory.buffer.slice(valOutPtr, valOutPtr + nv * 8));
+
+    // DataView bucket loop (same as production query.ts)
+    const dv = new DataView(ts.buffer, ts.byteOffset, ts.byteLength);
+    for (let i = 0; i < n; i++) {
+      const off = i << 3;
+      const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+      values[bucket] += vs[i]; // sum path
+      counts[bucket]++;
+    }
+  }
+  return { values, counts };
+}
+
+// ── WASM fused path: stepAggregateChunkALP ───────────────────────────
+
+function wasmFusedAggregate(aggInit) {
+  const values = new Float64Array(bucketCount).fill(aggInit);
+  const counts = new Float64Array(bucketCount);
+
+  // Allocate persistent bucket arrays in WASM (once for all chunks).
+  w.resetScratch();
+  const valsPtr = w.allocScratch(bucketCount * 8);
+  const cntsPtr = w.allocScratch(bucketCount * 8);
+  // Reserve space for the largest compressed blob pair.
+  const maxBlobSize = Math.max(
+    ...compressedTs.map(b => b.length),
+    ...compressedVals.map(b => b.length),
+  );
+  const tsInPtr = w.allocScratch(maxBlobSize);
+  const valInPtr = w.allocScratch(maxBlobSize);
+
+  // Copy initial bucket state into WASM.
+  let wasmMem = mem();
+  wasmMem.set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), valsPtr);
+  wasmMem.set(new Uint8Array(counts.buffer, counts.byteOffset, counts.byteLength), cntsPtr);
+
+  for (let c = 0; c < NUM_CHUNKS; c++) {
+    // Copy compressed blobs into pre-allocated WASM regions.
+    wasmMem = mem();
+    wasmMem.set(compressedTs[c], tsInPtr);
+    wasmMem.set(compressedVals[c], valInPtr);
+
+    // Fused decode + aggregate — buckets stay in WASM memory.
+    w.stepAggregateChunkALP(
+      tsInPtr, compressedTs[c].length,
+      valInPtr, compressedVals[c].length,
+      2, // sum
+      minT, STEP,
+      valsPtr, cntsPtr, bucketCount,
+    );
+  }
+
+  // Copy final buckets back once.
+  values.set(new Float64Array(w.memory.buffer.slice(valsPtr, valsPtr + bucketCount * 8)));
+  counts.set(new Float64Array(w.memory.buffer.slice(cntsPtr, cntsPtr + bucketCount * 8)));
+  return { values, counts };
+}
+
+// ── Correctness check ────────────────────────────────────────────────
+
+console.log("Correctness check...");
+const jsResult = jsAggregate(0);
+const wasmResult = wasmFusedAggregate(0);
+
+let maxDiff = 0;
+let mismatchCount = 0;
+for (let i = 0; i < bucketCount; i++) {
+  const diff = Math.abs(jsResult.values[i] - wasmResult.values[i]);
+  if (diff > 1e-6) {
+    if (mismatchCount < 5) {
+      console.log(`  bucket ${i}: JS=${jsResult.values[i]}, WASM=${wasmResult.values[i]}, diff=${diff}`);
+    }
+    mismatchCount++;
+  }
+  maxDiff = Math.max(maxDiff, diff);
+}
+
+if (mismatchCount > 0) {
+  console.log(`  ⚠ ${mismatchCount} mismatches (max diff: ${maxDiff})`);
+} else {
+  console.log(`  ✓ All ${bucketCount} buckets match (max diff: ${maxDiff.toExponential(2)})`);
+}
+
+// Verify counts match
+let countMismatch = 0;
+for (let i = 0; i < bucketCount; i++) {
+  if (jsResult.counts[i] !== wasmResult.counts[i]) countMismatch++;
+}
+console.log(`  ${countMismatch === 0 ? "✓" : "⚠"} Counts: ${countMismatch} mismatches\n`);
+
+// ── Benchmark ────────────────────────────────────────────────────────
+
+function bench(name, fn, warmup = 3, runs = 7) {
+  for (let w = 0; w < warmup; w++) fn();
+  const times = [];
+  for (let r = 0; r < runs; r++) {
+    if (global.gc) global.gc();
+    const t0 = performance.now();
+    fn();
+    times.push(performance.now() - t0);
+  }
+  times.sort((a, b) => a - b);
+  const mid = times.length >> 1;
+  const median = times[mid];
+  console.log(`  ${name.padEnd(35)} min=${times[0].toFixed(1)}ms  median=${median.toFixed(1)}ms`);
+  return median;
+}
+
+console.log("Benchmarking (sum aggregation):");
+const jsTime = bench("JS decode+DataView", () => jsAggregate(0));
+const wasmTime = bench("WASM fused stepAggregateChunkALP", () => wasmFusedAggregate(0));
+console.log(`\n  Speedup: ${(jsTime / wasmTime).toFixed(1)}×`);

--- a/packages/o11ytsdb/bench/profile-10k-avg.mjs
+++ b/packages/o11ytsdb/bench/profile-10k-avg.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+/**
+ * CPU + memory profile: avg aggregation across 10 000 series × 100 dp.
+ *
+ * Measures ingest, query, and per-phase breakdown with heap snapshots.
+ *
+ * Usage:
+ *   node --expose-gc bench/profile-10k-avg.mjs
+ *   node --expose-gc --cpu-prof bench/profile-10k-avg.mjs    # V8 CPU profile
+ *   node --expose-gc --heap-prof bench/profile-10k-avg.mjs   # V8 heap profile
+ */
+
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { loadBenchCodecs, PKG_DIR } from "./bench-codecs.mjs";
+
+// ── Config ───────────────────────────────────────────────────────────
+
+const NUM_SERIES    = 10_000;
+const PTS_PER_SERIES = 100;
+const TOTAL_SAMPLES = NUM_SERIES * PTS_PER_SERIES;
+const CHUNK_SIZE    = 512;          // frozen chunk size
+const T0            = 1_700_000_000_000n;
+const INTERVAL      = 15_000n;      // 15s scrape
+const AGG_STEP      = 60_000n;      // 1-minute buckets
+const REGIONS       = ["us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1", "eu-central-1"];
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const hasGC = typeof global.gc === "function";
+function gc() { if (hasGC) global.gc(); }
+
+function heapSnap() {
+  gc();
+  const m = process.memoryUsage();
+  return { heapUsed: m.heapUsed, rss: m.rss, external: m.external, arrayBuffers: m.arrayBuffers };
+}
+
+function fmtMs(n) { return `${n.toFixed(1)}ms`; }
+function fmtBytes(n) {
+  if (Math.abs(n) < 1024) return `${n} B`;
+  if (Math.abs(n) < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+function fmtRate(n) {
+  if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+  if (n >= 1e3) return `${(n / 1e3).toFixed(0)}K`;
+  return `${n.toFixed(0)}`;
+}
+
+// ── Data generation ──────────────────────────────────────────────────
+
+function generateData() {
+  const series = [];
+  for (let s = 0; s < NUM_SERIES; s++) {
+    const timestamps = new BigInt64Array(PTS_PER_SERIES);
+    const values = new Float64Array(PTS_PER_SERIES);
+    for (let i = 0; i < PTS_PER_SERIES; i++) {
+      timestamps[i] = T0 + BigInt(i) * INTERVAL;
+      values[i] = Math.sin(i * 0.01 + s * 0.001) * 50 + 100 + (Math.random() - 0.5) * 10;
+    }
+    series.push({
+      labels: new Map([
+        ["__name__", "http_requests"],
+        ["region", REGIONS[s % REGIONS.length]],
+        ["instance", `host-${s}`],
+      ]),
+      timestamps,
+      values,
+    });
+  }
+  return series;
+}
+
+// (codecs loaded from bench-codecs.mjs)
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function main() {
+  if (!hasGC) console.log("  ⚠ Run with --expose-gc for accurate memory\n");
+
+  console.log("╔══════════════════════════════════════════════════════════╗");
+  console.log("║  Profile: avg across 10K series × 100 dp = 1M samples  ║");
+  console.log("╚══════════════════════════════════════════════════════════╝\n");
+  console.log(`  Config: ${NUM_SERIES.toLocaleString()} series, ${PTS_PER_SERIES} pts/series, chunk=${CHUNK_SIZE}`);
+  console.log(`  Query:  avg agg, step=${Number(AGG_STEP)/1000}s, groupBy=[region] (${REGIONS.length} groups)\n`);
+
+  // ── Baseline heap ──
+  const heapBase = heapSnap();
+  console.log(`  Baseline heap: ${fmtBytes(heapBase.heapUsed)} used, ${fmtBytes(heapBase.rss)} RSS\n`);
+
+  // ── Generate data ──
+  const tGen0 = performance.now();
+  const data = generateData();
+  const tGen1 = performance.now();
+  const heapAfterGen = heapSnap();
+  console.log(`  Data gen: ${fmtMs(tGen1 - tGen0)}  heap +${fmtBytes(heapAfterGen.heapUsed - heapBase.heapUsed)}`);
+
+  // ── Load WASM + codecs ──
+  const { alpValuesCodec, tsCodec, alpRangeCodec, stepAggCodec } = await loadBenchCodecs();
+  const { ColumnStore } = await import(join(PKG_DIR, "dist/column-store.js"));
+  const { ScanEngine } = await import(join(PKG_DIR, "dist/query.js"));
+
+  const PRECISION = 2; // realistic observability precision
+
+  // ── Ingest ──
+  const store = new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec, undefined, PRECISION, stepAggCodec);
+  const ids = data.map(d => store.getOrCreateSeries(d.labels));
+
+  gc();
+  const heapPreIngest = heapSnap();
+  const tIng0 = performance.now();
+  for (let s = 0; s < data.length; s++) {
+    store.appendBatch(ids[s], data[s].timestamps, data[s].values);
+  }
+  const tIng1 = performance.now();
+  const heapPostIngest = heapSnap();
+
+  console.log(`  Ingest:   ${fmtMs(tIng1 - tIng0)}  (${fmtRate(TOTAL_SAMPLES / (tIng1 - tIng0) * 1000)} samples/s)`);
+  console.log(`  Store:    ${fmtBytes(store.memoryBytes())}  (${(store.memoryBytes() / TOTAL_SAMPLES).toFixed(1)} B/pt)`);
+  console.log(`  Heap:     +${fmtBytes(heapPostIngest.heapUsed - heapPreIngest.heapUsed)} used, +${fmtBytes(heapPostIngest.rss - heapPreIngest.rss)} RSS\n`);
+
+  // Free raw data to isolate query memory
+  data.length = 0;
+  gc();
+
+  // ── Query params ──
+  const qStart = T0;
+  const qEnd = T0 + BigInt(PTS_PER_SERIES) * INTERVAL + 1n;
+  const engine = new ScanEngine();
+
+  // ── Warmup ──
+  engine.query(store, { metric: "http_requests", start: qStart, end: qEnd, agg: "avg", step: AGG_STEP, groupBy: ["region"] });
+  gc();
+
+  // ── Query: avg / 1min step / groupBy region ──
+  console.log("  ── avg / 1min step / groupBy region ──\n");
+
+  const heapPreQuery = heapSnap();
+  const tQ0 = performance.now();
+  const result = engine.query(store, {
+    metric: "http_requests",
+    start: qStart,
+    end: qEnd,
+    agg: "avg",
+    step: AGG_STEP,
+    groupBy: ["region"],
+  });
+  const tQ1 = performance.now();
+  const heapPostQuery = heapSnap();
+
+  const outputPts = result.series.reduce((s, r) => s + r.timestamps.length, 0);
+  console.log(`    Time:    ${fmtMs(tQ1 - tQ0)}`);
+  console.log(`    Scanned: ${result.scannedSamples.toLocaleString()} samples → ${outputPts.toLocaleString()} output pts (${result.series.length} groups)`);
+  console.log(`    Heap:    +${fmtBytes(heapPostQuery.heapUsed - heapPreQuery.heapUsed)} during query`);
+  console.log(`    Rate:    ${fmtRate(result.scannedSamples / (tQ1 - tQ0) * 1000)} samples/s\n`);
+
+  // ── Phase breakdown ──
+  console.log("  ── Phase breakdown ──\n");
+
+  // Phase A: matchLabel
+  gc();
+  const tMatch0 = performance.now();
+  const matchedIds = store.matchLabel("__name__", "http_requests");
+  const tMatch1 = performance.now();
+  console.log(`    matchLabel:    ${fmtMs(tMatch1 - tMatch0).padStart(10)}  (${matchedIds.length} series)`);
+
+  // Phase B: readParts
+  const useReadParts = typeof store.readParts === "function";
+  gc();
+  const heapPreRead = heapSnap();
+  const tRead0 = performance.now();
+  const allParts = [];
+  const partsPerSeries = [];
+  for (const id of matchedIds) {
+    if (useReadParts) {
+      const parts = store.readParts(id, qStart, qEnd);
+      partsPerSeries.push(parts.length);
+      for (const p of parts) allParts.push(p);
+    } else {
+      allParts.push(store.read(id, qStart, qEnd));
+      partsPerSeries.push(1);
+    }
+  }
+  const tRead1 = performance.now();
+  const heapPostRead = heapSnap();
+  console.log(`    readParts:     ${fmtMs(tRead1 - tRead0).padStart(10)}  (${allParts.length} parts)  heap +${fmtBytes(heapPostRead.heapUsed - heapPreRead.heapUsed)}`);
+
+  // Phase C: groupBy
+  const tGroup0 = performance.now();
+  const groups = new Map();
+  let partIdx = 0;
+  for (let si = 0; si < matchedIds.length; si++) {
+    const labels = store.labels(matchedIds[si]);
+    const key = labels?.get("region") ?? "";
+    if (!groups.has(key)) groups.set(key, []);
+    const g = groups.get(key);
+    const n = partsPerSeries[si];
+    for (let j = 0; j < n; j++) g.push(allParts[partIdx++]);
+  }
+  const tGroup1 = performance.now();
+  console.log(`    groupBy:       ${fmtMs(tGroup1 - tGroup0).padStart(10)}  (${groups.size} groups)`);
+
+  // Phase D: stepAggregate per group
+  gc();
+  const heapPreAgg = heapSnap();
+  const tAgg0 = performance.now();
+  for (const [, groupRanges] of groups) {
+    let minT = BigInt("9223372036854775807");
+    let maxT = -minT;
+    for (const r of groupRanges) {
+      if (r.timestamps.length === 0 && r.stats) {
+        if (r.chunkMinT < minT) minT = r.chunkMinT;
+        if (r.chunkMaxT > maxT) maxT = r.chunkMaxT;
+        continue;
+      }
+      if (r.timestamps.length === 0) continue;
+      if (r.timestamps[0] < minT) minT = r.timestamps[0];
+      if (r.timestamps[r.timestamps.length - 1] > maxT)
+        maxT = r.timestamps[r.timestamps.length - 1];
+    }
+    const bucketCount = Number((maxT - minT) / AGG_STEP) + 1;
+    const values = new Float64Array(bucketCount);   // avg: init to 0 (sum)
+    const counts = new Float64Array(bucketCount);
+
+    const _le = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+    const minTN = Number(minT);
+    const stepN = Number(AGG_STEP);
+
+    for (const r of groupRanges) {
+      // Stats-only part: chunk fits in one bucket → fold stats
+      if (r.timestamps.length === 0 && r.stats && r.chunkMinT !== undefined && r.chunkMaxT !== undefined) {
+        const bLo = (Number(r.chunkMinT) - minTN) / stepN | 0;
+        const bHi = (Number(r.chunkMaxT) - minTN) / stepN | 0;
+        if (bLo === bHi) {
+          values[bLo] += r.stats.sum;
+          counts[bLo] += r.stats.count;
+          continue;
+        }
+        // Multi-bucket: decode
+        if (r.decode) {
+          const decoded = r.decode();
+          const src = decoded.timestamps;
+          const vs = decoded.values;
+          const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+          for (let i = 0, len = src.length; i < len; i++) {
+            const off = i << 3;
+            const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+            values[bucket] += vs[i];
+            counts[bucket]++;
+          }
+          continue;
+        }
+      }
+
+      const src = r.timestamps;
+      const vs = r.values;
+      const dv = new DataView(src.buffer, src.byteOffset, src.byteLength);
+      for (let i = 0, len = src.length; i < len; i++) {
+        const off = i << 3;
+        const bucket = (dv.getInt32(off + 4, _le) * 4294967296 + dv.getUint32(off, _le) - minTN) / stepN | 0;
+        values[bucket] += vs[i];
+        counts[bucket]++;
+      }
+    }
+
+    // Finalize avg
+    for (let i = 0; i < bucketCount; i++) {
+      if (counts[i] > 0) values[i] /= counts[i];
+    }
+  }
+  const tAgg1 = performance.now();
+  const heapPostAgg = heapSnap();
+
+  console.log(`    stepAggregate: ${fmtMs(tAgg1 - tAgg0).padStart(10)}  heap +${fmtBytes(heapPostAgg.heapUsed - heapPreAgg.heapUsed)}`);
+
+  const total = (tMatch1 - tMatch0) + (tRead1 - tRead0) + (tGroup1 - tGroup0) + (tAgg1 - tAgg0);
+  console.log(`    ─────────────────────────`);
+  console.log(`    total:         ${fmtMs(total).padStart(10)}\n`);
+
+  // ── Repeated query (7 runs, report median) ──
+  console.log("  ── Repeated ScanEngine.query (7 runs) ──\n");
+  const runs = [];
+  const heapRuns = [];
+  for (let r = 0; r < 7; r++) {
+    gc();
+    const hPre = heapSnap();
+    const t0 = performance.now();
+    engine.query(store, {
+      metric: "http_requests",
+      start: qStart,
+      end: qEnd,
+      agg: "avg",
+      step: AGG_STEP,
+      groupBy: ["region"],
+    });
+    const t1 = performance.now();
+    const hPost = heapSnap();
+    runs.push(t1 - t0);
+    heapRuns.push(hPost.heapUsed - hPre.heapUsed);
+  }
+  runs.sort((a, b) => a - b);
+  heapRuns.sort((a, b) => a - b);
+  const median = runs[3];
+  console.log(`    Time:  min=${fmtMs(runs[0])} median=${fmtMs(median)} max=${fmtMs(runs[6])}`);
+  console.log(`    Heap:  min=${fmtBytes(heapRuns[0])} median=${fmtBytes(heapRuns[3])} max=${fmtBytes(heapRuns[6])}`);
+  console.log(`    Rate:  ${fmtRate(TOTAL_SAMPLES / median * 1000)} samples/s\n`);
+
+  // ── Large step (stats-skip scenario) ──
+  const BIG_STEP = 3_600_000n; // 1 hour — 100 dp × 15s = 25 min, all fit in 1-hour bucket
+  console.log(`  ── Stats-skip: avg / 1h step / groupBy region ──\n`);
+  gc();
+  const bigRuns = [];
+  for (let r = 0; r < 7; r++) {
+    gc();
+    const t0 = performance.now();
+    engine.query(store, {
+      metric: "http_requests",
+      start: qStart,
+      end: qEnd,
+      agg: "avg",
+      step: BIG_STEP,
+      groupBy: ["region"],
+    });
+    bigRuns.push(performance.now() - t0);
+  }
+  bigRuns.sort((a, b) => a - b);
+  console.log(`    Time:  min=${fmtMs(bigRuns[0])} median=${fmtMs(bigRuns[3])} max=${fmtMs(bigRuns[6])}`);
+  console.log(`    Rate:  ${fmtRate(TOTAL_SAMPLES / bigRuns[3] * 1000)} samples/s  (stats-skip)\n`);
+
+  // ── No groupBy (single output series) ──
+  console.log(`  ── avg / 1min step / no groupBy ──\n`);
+  gc();
+  const noGbRuns = [];
+  for (let r = 0; r < 7; r++) {
+    gc();
+    const t0 = performance.now();
+    engine.query(store, {
+      metric: "http_requests",
+      start: qStart,
+      end: qEnd,
+      agg: "avg",
+      step: AGG_STEP,
+    });
+    noGbRuns.push(performance.now() - t0);
+  }
+  noGbRuns.sort((a, b) => a - b);
+  console.log(`    Time:  min=${fmtMs(noGbRuns[0])} median=${fmtMs(noGbRuns[3])} max=${fmtMs(noGbRuns[6])}`);
+  console.log(`    Rate:  ${fmtRate(TOTAL_SAMPLES / noGbRuns[3] * 1000)} samples/s\n`);
+
+  // ── Final heap summary ──
+  gc();
+  const heapFinal = heapSnap();
+  console.log("  ── Heap summary ──\n");
+  console.log(`    Baseline:  ${fmtBytes(heapBase.heapUsed)} heap / ${fmtBytes(heapBase.rss)} RSS`);
+  console.log(`    Final:     ${fmtBytes(heapFinal.heapUsed)} heap / ${fmtBytes(heapFinal.rss)} RSS`);
+  console.log(`    Delta:     +${fmtBytes(heapFinal.heapUsed - heapBase.heapUsed)} heap / +${fmtBytes(heapFinal.rss - heapBase.rss)} RSS`);
+  console.log(`    Store:     ${fmtBytes(store.memoryBytes())}`);
+  console.log(`    ArrayBufs: ${fmtBytes(heapFinal.arrayBuffers)}\n`);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/packages/o11ytsdb/src/plan-executor.ts
+++ b/packages/o11ytsdb/src/plan-executor.ts
@@ -1,0 +1,178 @@
+/**
+ * Plan executor — walks a PlanNode tree and produces a QueryResult.
+ *
+ * V1 strategy: extract parameters from the plan, map to the existing
+ * ScanEngine.query() interface. Advanced features (compound transforms,
+ * regex matchers, binary ops) will be handled natively as the executor
+ * matures.
+ */
+
+import type {
+  AggregateNode,
+  PlanAggFn,
+  PlanMatcher,
+  PlanNode,
+  SelectNode,
+  TimeRangeNode,
+  TransformFn,
+  TransformNode,
+} from "./plan.js";
+import { ScanEngine } from "./query.js";
+import type { AggFn, Matcher, QueryOpts, QueryResult, StorageBackend } from "./types.js";
+
+// ── Extracted plan parameters ────────────────────────────────────────
+
+interface FlatPlan {
+  metric: string;
+  matchers: readonly PlanMatcher[];
+  start: bigint;
+  end: bigint;
+  transforms: TransformFn[];
+  agg: PlanAggFn | undefined;
+  step: bigint | undefined;
+  groupBy: readonly string[] | undefined;
+}
+
+// ── Plan flattening ──────────────────────────────────────────────────
+
+/**
+ * Walk the plan tree (outer → inner) and extract a flat parameter set.
+ * Validates structural constraints (exactly one select, one timeRange).
+ */
+function flattenPlan(root: PlanNode): FlatPlan {
+  let select: SelectNode | undefined;
+  let timeRange: TimeRangeNode | undefined;
+  const transforms: TransformFn[] = [];
+  let agg: PlanAggFn | undefined;
+  let step: bigint | undefined;
+  let groupBy: readonly string[] | undefined;
+
+  let current: PlanNode = root;
+  for (;;) {
+    switch (current.kind) {
+      case "aggregate": {
+        const a: AggregateNode = current;
+        agg = a.fn;
+        step = a.step;
+        groupBy = a.groupBy;
+        current = a.input;
+        break;
+      }
+      case "transform": {
+        const t: TransformNode = current;
+        transforms.unshift(t.fn); // inner-first order
+        current = t.input;
+        break;
+      }
+      case "timeRange": {
+        const tr: TimeRangeNode = current;
+        timeRange = tr;
+        current = tr.input;
+        break;
+      }
+      case "select": {
+        select = current;
+        break;
+      }
+    }
+    if (current.kind === "select") {
+      select = current;
+      break;
+    }
+  }
+
+  if (!select) throw new Error("Plan has no SelectNode");
+  if (!timeRange) throw new Error("Plan has no TimeRangeNode");
+
+  return {
+    metric: select.metric,
+    matchers: select.matchers,
+    start: timeRange.start,
+    end: timeRange.end,
+    transforms,
+    agg,
+    step,
+    groupBy,
+  };
+}
+
+// ── Matcher mapping ──────────────────────────────────────────────────
+
+/**
+ * Convert PlanMatchers to the current Matcher type (equality only).
+ * Throws for operators not yet supported by the engine.
+ */
+function toEngineMatchers(planMatchers: readonly PlanMatcher[]): Matcher[] {
+  const out: Matcher[] = [];
+  for (const m of planMatchers) {
+    if (m.op !== "=") {
+      throw new Error(
+        `Matcher operator '${m.op}' is not yet supported (label=${m.label}, value=${m.value}). ` +
+          `Only '=' is supported in the current executor.`
+      );
+    }
+    out.push({ label: m.label, value: m.value });
+  }
+  return out;
+}
+
+// ── Aggregation mapping ──────────────────────────────────────────────
+
+/**
+ * Map plan transforms + aggregation to a single AggFn for the current
+ * ScanEngine. The current engine treats 'rate' as an AggFn, so we can
+ * handle the common case of rate() alone. Compound transform+agg
+ * (e.g., rate().sumBy()) is not yet supported.
+ */
+function resolveAggFn(transforms: TransformFn[], agg: PlanAggFn | undefined): AggFn | undefined {
+  if (transforms.length === 0) {
+    return agg; // 'sum' | 'avg' | ... | undefined — all valid AggFn values
+  }
+
+  if (transforms.length === 1 && transforms[0] === "rate" && agg == null) {
+    // rate() without a subsequent aggregation → maps to agg:'rate'
+    return "rate";
+  }
+
+  if (transforms.length === 1 && transforms[0] === "rate" && agg != null) {
+    throw new Error(
+      `Compound rate() + ${agg}() is not yet supported. ` +
+        `The executor will support per-series rate → aggregation in a future version.`
+    );
+  }
+
+  throw new Error(
+    `Transform '${transforms.join(" → ")}' is not yet supported by the executor. ` +
+      `Supported: rate() (without subsequent aggregation).`
+  );
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+const engine = new ScanEngine();
+
+/**
+ * Execute a query plan against a storage backend.
+ *
+ * V1: flattens the plan tree and delegates to ScanEngine.query().
+ * Supports: = matchers, all 6 aggregations ± step ± groupBy, rate().
+ * Not yet supported: !=, =~, !~ matchers; compound transforms;
+ * binary ops; increase, irate, abs, etc.
+ */
+export function executePlan(plan: PlanNode, storage: StorageBackend): QueryResult {
+  const flat = flattenPlan(plan);
+  const matchers = toEngineMatchers(flat.matchers);
+  const agg = resolveAggFn(flat.transforms, flat.agg);
+
+  const opts: QueryOpts = {
+    metric: flat.metric,
+    start: flat.start,
+    end: flat.end,
+  };
+  if (matchers.length > 0) opts.matchers = matchers;
+  if (agg != null) opts.agg = agg;
+  if (flat.step != null) opts.step = flat.step;
+  if (flat.groupBy != null && flat.groupBy.length > 0) opts.groupBy = [...flat.groupBy];
+
+  return engine.query(storage, opts);
+}

--- a/packages/o11ytsdb/src/plan.ts
+++ b/packages/o11ytsdb/src/plan.ts
@@ -1,0 +1,65 @@
+/**
+ * QueryPlan IR — typed node tree that the builder compiles to and the
+ * executor walks.
+ *
+ * The tree is a linear pipeline for V1:
+ *   Aggregate? → Transform* → TimeRange → Select
+ *
+ * Binary operators (series + series) are deferred to a later milestone.
+ */
+
+// ── Matcher types ────────────────────────────────────────────────────
+
+/** Matcher operators for label filtering. */
+export type MatchOp = "=" | "!=" | "=~" | "!~";
+
+/** A label matcher with operator. */
+export interface PlanMatcher {
+  readonly label: string;
+  readonly op: MatchOp;
+  readonly value: string;
+}
+
+// ── Function types ───────────────────────────────────────────────────
+
+/** Per-series transform functions (applied before aggregation). */
+export type TransformFn = "rate" | "increase" | "irate" | "abs" | "ceil" | "floor" | "sqrt";
+
+/** Pure aggregation functions (collapse series, not per-series transforms). */
+export type PlanAggFn = "sum" | "avg" | "min" | "max" | "count" | "last";
+
+// ── Plan nodes ───────────────────────────────────────────────────────
+
+/** Leaf node: select series by metric name + label matchers. */
+export interface SelectNode {
+  readonly kind: "select";
+  readonly metric: string;
+  readonly matchers: readonly PlanMatcher[];
+}
+
+/** Filter to a time window [start, end]. */
+export interface TimeRangeNode {
+  readonly kind: "timeRange";
+  readonly input: PlanNode;
+  readonly start: bigint;
+  readonly end: bigint;
+}
+
+/** Apply a per-series transform (e.g., rate, increase). */
+export interface TransformNode {
+  readonly kind: "transform";
+  readonly input: PlanNode;
+  readonly fn: TransformFn;
+}
+
+/** Aggregate across series, optionally step-aligned with groupBy. */
+export interface AggregateNode {
+  readonly kind: "aggregate";
+  readonly input: PlanNode;
+  readonly fn: PlanAggFn;
+  readonly step?: bigint;
+  readonly groupBy?: readonly string[];
+}
+
+/** A node in the query plan tree. */
+export type PlanNode = SelectNode | TimeRangeNode | TransformNode | AggregateNode;

--- a/packages/o11ytsdb/src/query-builder.ts
+++ b/packages/o11ytsdb/src/query-builder.ts
@@ -1,0 +1,226 @@
+/**
+ * Fluent query builder — compiles to a PlanNode tree.
+ *
+ * Usage:
+ *   import { query } from './query-builder.js';
+ *
+ *   const plan = query()
+ *     .metric('http_request_duration_seconds')
+ *     .where('method', '=', 'GET')
+ *     .where('status', '=~', '2..')
+ *     .range(start, end)
+ *     .rate()
+ *     .step(60_000n)
+ *     .sumBy('endpoint')
+ *     .plan();
+ *
+ * Each method returns a new (immutable) builder. Call .plan() to compile
+ * the description into a PlanNode tree, or .exec(storage) to compile and
+ * execute in one step.
+ */
+
+import type { MatchOp, PlanAggFn, PlanMatcher, PlanNode, TransformFn } from "./plan.js";
+import { executePlan } from "./plan-executor.js";
+import type { QueryResult, StorageBackend } from "./types.js";
+
+// ── Internal state ───────────────────────────────────────────────────
+
+interface BuilderState {
+  readonly metric: string | undefined;
+  readonly matchers: readonly PlanMatcher[];
+  readonly start: bigint | undefined;
+  readonly end: bigint | undefined;
+  readonly transforms: readonly TransformFn[];
+  readonly step: bigint | undefined;
+  readonly agg: PlanAggFn | undefined;
+  readonly groupBy: readonly string[] | undefined;
+}
+
+const EMPTY_STATE: BuilderState = {
+  metric: undefined,
+  matchers: [],
+  start: undefined,
+  end: undefined,
+  transforms: [],
+  step: undefined,
+  agg: undefined,
+  groupBy: undefined,
+};
+
+// ── Builder ──────────────────────────────────────────────────────────
+
+export class QueryBuilder {
+  private readonly s: BuilderState;
+
+  private constructor(state: BuilderState) {
+    this.s = state;
+  }
+
+  /** Start a new query. */
+  static create(): QueryBuilder {
+    return new QueryBuilder(EMPTY_STATE);
+  }
+
+  // ── Selection ────────────────────────────────────────────────────
+
+  /** Set the metric name (__name__ label). */
+  metric(name: string): QueryBuilder {
+    return new QueryBuilder({ ...this.s, metric: name });
+  }
+
+  /** Add a label matcher. */
+  where(label: string, op: MatchOp, value: string): QueryBuilder {
+    return new QueryBuilder({
+      ...this.s,
+      matchers: [...this.s.matchers, { label, op, value }],
+    });
+  }
+
+  // ── Time range ───────────────────────────────────────────────────
+
+  /** Set the query time range [start, end] (epoch ms as bigint). */
+  range(start: bigint, end: bigint): QueryBuilder {
+    return new QueryBuilder({ ...this.s, start, end });
+  }
+
+  // ── Transforms (per-series, before aggregation) ──────────────────
+
+  /** Apply rate() — per-second derivative of a counter. */
+  rate(): QueryBuilder {
+    return new QueryBuilder({
+      ...this.s,
+      transforms: [...this.s.transforms, "rate"],
+    });
+  }
+
+  /** Apply increase() — total increase over the range. */
+  increase(): QueryBuilder {
+    return new QueryBuilder({
+      ...this.s,
+      transforms: [...this.s.transforms, "increase"],
+    });
+  }
+
+  /** Apply irate() — instant rate from last two samples. */
+  irate(): QueryBuilder {
+    return new QueryBuilder({
+      ...this.s,
+      transforms: [...this.s.transforms, "irate"],
+    });
+  }
+
+  /** Apply abs() — absolute value of each sample. */
+  abs(): QueryBuilder {
+    return new QueryBuilder({
+      ...this.s,
+      transforms: [...this.s.transforms, "abs"],
+    });
+  }
+
+  // ── Step alignment ───────────────────────────────────────────────
+
+  /** Set step-alignment interval (epoch ms as bigint). */
+  step(interval: bigint): QueryBuilder {
+    return new QueryBuilder({ ...this.s, step: interval });
+  }
+
+  // ── Aggregations ─────────────────────────────────────────────────
+
+  private aggregate(fn: PlanAggFn, groupBy?: readonly string[]): QueryBuilder {
+    return new QueryBuilder({ ...this.s, agg: fn, groupBy });
+  }
+
+  /** Aggregate: sum. */
+  sum(): QueryBuilder {
+    return this.aggregate("sum");
+  }
+  /** Aggregate: avg. */
+  avg(): QueryBuilder {
+    return this.aggregate("avg");
+  }
+  /** Aggregate: min. */
+  min(): QueryBuilder {
+    return this.aggregate("min");
+  }
+  /** Aggregate: max. */
+  max(): QueryBuilder {
+    return this.aggregate("max");
+  }
+  /** Aggregate: count. */
+  count(): QueryBuilder {
+    return this.aggregate("count");
+  }
+  /** Aggregate: last. */
+  last(): QueryBuilder {
+    return this.aggregate("last");
+  }
+
+  /** Aggregate sum, grouped by label(s). */
+  sumBy(...labels: string[]): QueryBuilder {
+    return this.aggregate("sum", labels);
+  }
+  /** Aggregate avg, grouped by label(s). */
+  avgBy(...labels: string[]): QueryBuilder {
+    return this.aggregate("avg", labels);
+  }
+  /** Aggregate min, grouped by label(s). */
+  minBy(...labels: string[]): QueryBuilder {
+    return this.aggregate("min", labels);
+  }
+  /** Aggregate max, grouped by label(s). */
+  maxBy(...labels: string[]): QueryBuilder {
+    return this.aggregate("max", labels);
+  }
+  /** Aggregate count, grouped by label(s). */
+  countBy(...labels: string[]): QueryBuilder {
+    return this.aggregate("count", labels);
+  }
+  /** Aggregate last, grouped by label(s). */
+  lastBy(...labels: string[]): QueryBuilder {
+    return this.aggregate("last", labels);
+  }
+
+  // ── Compile ──────────────────────────────────────────────────────
+
+  /**
+   * Compile the builder state into a PlanNode tree.
+   *
+   * Tree is built bottom-up:
+   *   Select → TimeRange → Transform* → Aggregate?
+   *
+   * @throws if metric or range is not set.
+   */
+  plan(): PlanNode {
+    const { metric, matchers, start, end, transforms, step, agg, groupBy } = this.s;
+
+    if (metric == null) throw new Error("query().metric() is required");
+    if (start == null || end == null) throw new Error("query().range() is required");
+
+    let node: PlanNode = { kind: "select", metric, matchers };
+    node = { kind: "timeRange", input: node, start, end };
+
+    for (const fn of transforms) {
+      node = { kind: "transform", input: node, fn };
+    }
+
+    if (agg != null) {
+      node = { kind: "aggregate", input: node, fn: agg, step, groupBy };
+    }
+
+    return node;
+  }
+
+  /**
+   * Compile and execute the query against a storage backend.
+   *
+   * Shorthand for `executePlan(builder.plan(), storage)`.
+   */
+  exec(storage: StorageBackend): QueryResult {
+    return executePlan(this.plan(), storage);
+  }
+}
+
+/** Start building a new query. */
+export function query(): QueryBuilder {
+  return QueryBuilder.create();
+}

--- a/packages/o11ytsdb/src/query-builder.ts
+++ b/packages/o11ytsdb/src/query-builder.ts
@@ -204,7 +204,13 @@ export class QueryBuilder {
     }
 
     if (agg != null) {
-      node = { kind: "aggregate", input: node, fn: agg, step, groupBy };
+      node = {
+        kind: "aggregate",
+        input: node,
+        fn: agg,
+        ...(step != null && { step }),
+        ...(groupBy != null && { groupBy }),
+      };
     }
 
     return node;

--- a/packages/o11ytsdb/test/query-builder.test.ts
+++ b/packages/o11ytsdb/test/query-builder.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+
+import { FlatStore } from "../src/flat-store.js";
+import type { PlanNode } from "../src/plan.js";
+import { query } from "../src/query-builder.js";
+import type { Labels } from "../src/types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function makeLabels(name: string, extra?: Record<string, string>): Labels {
+  const m = new Map<string, string>();
+  m.set("__name__", name);
+  if (extra) {
+    for (const [k, v] of Object.entries(extra)) m.set(k, v);
+  }
+  return m;
+}
+
+/** 3 CPU series (hosts a, b, c) × 100 pts + 1 mem series × 50 pts. */
+function populateStore(): FlatStore {
+  const store = new FlatStore();
+  for (const host of ["a", "b", "c"]) {
+    const id = store.getOrCreateSeries(makeLabels("cpu", { host, region: "us-east" }));
+    for (let i = 0; i < 100; i++) {
+      store.append(
+        id,
+        1_000_000n + BigInt(i) * 15_000n,
+        10 + (host.charCodeAt(0) - 97) * 10 + i * 0.1
+      );
+    }
+  }
+  const memId = store.getOrCreateSeries(makeLabels("mem", { host: "a" }));
+  for (let i = 0; i < 50; i++) {
+    store.append(memId, 1_000_000n + BigInt(i) * 15_000n, 8192 + i);
+  }
+  return store;
+}
+
+// ── Plan compilation tests ───────────────────────────────────────────
+
+describe("QueryBuilder — plan compilation", () => {
+  it("compiles a simple metric + range to SelectNode → TimeRangeNode", () => {
+    const plan = query().metric("cpu").range(0n, 100n).plan();
+
+    expect(plan.kind).toBe("timeRange");
+    const tr = plan as Extract<PlanNode, { kind: "timeRange" }>;
+    expect(tr.start).toBe(0n);
+    expect(tr.end).toBe(100n);
+    expect(tr.input.kind).toBe("select");
+    const sel = tr.input as Extract<PlanNode, { kind: "select" }>;
+    expect(sel.metric).toBe("cpu");
+    expect(sel.matchers).toEqual([]);
+  });
+
+  it("compiles matchers into the SelectNode", () => {
+    const plan = query()
+      .metric("http_requests")
+      .where("method", "=", "GET")
+      .where("status", "=~", "2..")
+      .range(0n, 100n)
+      .plan();
+
+    const tr = plan as Extract<PlanNode, { kind: "timeRange" }>;
+    const sel = tr.input as Extract<PlanNode, { kind: "select" }>;
+    expect(sel.matchers).toEqual([
+      { label: "method", op: "=", value: "GET" },
+      { label: "status", op: "=~", value: "2.." },
+    ]);
+  });
+
+  it("compiles rate() as a TransformNode", () => {
+    const plan = query().metric("cpu").range(0n, 100n).rate().plan();
+
+    expect(plan.kind).toBe("transform");
+    const t = plan as Extract<PlanNode, { kind: "transform" }>;
+    expect(t.fn).toBe("rate");
+    expect(t.input.kind).toBe("timeRange");
+  });
+
+  it("compiles step + sumBy as an AggregateNode", () => {
+    const plan = query().metric("cpu").range(0n, 100n).step(60_000n).sumBy("host").plan();
+
+    expect(plan.kind).toBe("aggregate");
+    const agg = plan as Extract<PlanNode, { kind: "aggregate" }>;
+    expect(agg.fn).toBe("sum");
+    expect(agg.step).toBe(60_000n);
+    expect(agg.groupBy).toEqual(["host"]);
+    expect(agg.input.kind).toBe("timeRange");
+  });
+
+  it("compiles rate → step → sumBy as Aggregate(Transform(TimeRange(Select)))", () => {
+    const plan = query()
+      .metric("http_requests")
+      .where("method", "=", "GET")
+      .range(0n, 1000n)
+      .rate()
+      .step(60_000n)
+      .sumBy("endpoint")
+      .plan();
+
+    // Outermost: aggregate
+    expect(plan.kind).toBe("aggregate");
+    const agg = plan as Extract<PlanNode, { kind: "aggregate" }>;
+    expect(agg.fn).toBe("sum");
+    expect(agg.step).toBe(60_000n);
+    expect(agg.groupBy).toEqual(["endpoint"]);
+
+    // Next: transform(rate)
+    expect(agg.input.kind).toBe("transform");
+    const t = agg.input as Extract<PlanNode, { kind: "transform" }>;
+    expect(t.fn).toBe("rate");
+
+    // Next: timeRange
+    expect(t.input.kind).toBe("timeRange");
+    const tr = t.input as Extract<PlanNode, { kind: "timeRange" }>;
+    expect(tr.start).toBe(0n);
+    expect(tr.end).toBe(1000n);
+
+    // Innermost: select
+    expect(tr.input.kind).toBe("select");
+    const sel = tr.input as Extract<PlanNode, { kind: "select" }>;
+    expect(sel.metric).toBe("http_requests");
+    expect(sel.matchers).toEqual([{ label: "method", op: "=", value: "GET" }]);
+  });
+
+  it("compiles aggregation without step", () => {
+    const plan = query().metric("cpu").range(0n, 100n).avg().plan();
+
+    expect(plan.kind).toBe("aggregate");
+    const agg = plan as Extract<PlanNode, { kind: "aggregate" }>;
+    expect(agg.fn).toBe("avg");
+    expect(agg.step).toBeUndefined();
+    expect(agg.groupBy).toBeUndefined();
+  });
+
+  it("compiles multiple transforms in order", () => {
+    const plan = query().metric("cpu").range(0n, 100n).abs().rate().plan();
+
+    // Outermost transform is the last one added (rate)
+    expect(plan.kind).toBe("transform");
+    const outer = plan as Extract<PlanNode, { kind: "transform" }>;
+    expect(outer.fn).toBe("rate");
+
+    // Inner transform is abs
+    expect(outer.input.kind).toBe("transform");
+    const inner = outer.input as Extract<PlanNode, { kind: "transform" }>;
+    expect(inner.fn).toBe("abs");
+
+    expect(inner.input.kind).toBe("timeRange");
+  });
+
+  it("is immutable — each method returns a new builder", () => {
+    const b1 = query().metric("cpu");
+    const b2 = b1.where("host", "=", "a");
+    const b3 = b1.where("host", "=", "b");
+
+    const p2 = b2.range(0n, 100n).plan();
+    const p3 = b3.range(0n, 100n).plan();
+
+    const sel2 = (p2 as Extract<PlanNode, { kind: "timeRange" }>).input as Extract<
+      PlanNode,
+      { kind: "select" }
+    >;
+    const sel3 = (p3 as Extract<PlanNode, { kind: "timeRange" }>).input as Extract<
+      PlanNode,
+      { kind: "select" }
+    >;
+
+    expect(sel2.matchers).toEqual([{ label: "host", op: "=", value: "a" }]);
+    expect(sel3.matchers).toEqual([{ label: "host", op: "=", value: "b" }]);
+  });
+
+  // ── Validation ───────────────────────────────────────────────────
+
+  it("throws when metric is missing", () => {
+    expect(() => query().range(0n, 100n).plan()).toThrow("metric() is required");
+  });
+
+  it("throws when range is missing", () => {
+    expect(() => query().metric("cpu").plan()).toThrow("range() is required");
+  });
+});
+
+// ── Execution tests ──────────────────────────────────────────────────
+
+describe("QueryBuilder — exec()", () => {
+  it("executes a raw query (no aggregation)", () => {
+    const store = populateStore();
+    const result = query().metric("cpu").range(0n, 100_000_000n).exec(store);
+
+    expect(result.series.length).toBe(3);
+    expect(result.scannedSeries).toBe(3);
+    for (const s of result.series) {
+      expect(s.timestamps.length).toBe(100);
+    }
+  });
+
+  it("executes with a label matcher", () => {
+    const store = populateStore();
+    const result = query()
+      .metric("cpu")
+      .where("host", "=", "a")
+      .range(0n, 100_000_000n)
+      .exec(store);
+
+    expect(result.series.length).toBe(1);
+    expect(result.series[0]?.labels.get("host")).toBe("a");
+  });
+
+  it("executes sum aggregation", () => {
+    const store = populateStore();
+    const result = query().metric("cpu").range(0n, 100_000_000n).sum().exec(store);
+
+    // sum across 3 series → 1 output series
+    expect(result.series.length).toBe(1);
+    expect(result.series[0]?.timestamps.length).toBe(100);
+  });
+
+  it("executes step-aligned avg with groupBy", () => {
+    const store = populateStore();
+    const result = query()
+      .metric("cpu")
+      .range(0n, 100_000_000n)
+      .step(60_000n)
+      .avgBy("region")
+      .exec(store);
+
+    // All series have region=us-east → 1 group
+    expect(result.series.length).toBe(1);
+    // Step-aligned: 60s step over ~1.5M ms range → multiple buckets
+    expect(result.series[0]?.timestamps.length).toBeGreaterThan(1);
+  });
+
+  it("executes rate()", () => {
+    const store = populateStore();
+    const result = query().metric("cpu").range(0n, 100_000_000n).rate().step(60_000n).exec(store);
+
+    // rate without agg but with step → rate step-aggregation per series
+    expect(result.series.length).toBeGreaterThan(0);
+    for (const s of result.series) {
+      expect(s.timestamps.length).toBeGreaterThan(0);
+    }
+  });
+
+  // ── Unsupported operations ─────────────────────────────────────
+
+  it("throws for regex matcher (not yet supported)", () => {
+    const store = populateStore();
+    expect(() =>
+      query().metric("cpu").where("host", "=~", "a|b").range(0n, 100_000_000n).exec(store)
+    ).toThrow("Matcher operator '=~' is not yet supported");
+  });
+
+  it("throws for != matcher (not yet supported)", () => {
+    const store = populateStore();
+    expect(() =>
+      query().metric("cpu").where("host", "!=", "c").range(0n, 100_000_000n).exec(store)
+    ).toThrow("Matcher operator '!=' is not yet supported");
+  });
+
+  it("throws for compound rate() + sum() (not yet supported)", () => {
+    const store = populateStore();
+    expect(() =>
+      query().metric("cpu").range(0n, 100_000_000n).rate().step(60_000n).sumBy("host").exec(store)
+    ).toThrow("Compound rate() + sum() is not yet supported");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a composable TypeScript query builder that compiles to a typed `PlanNode` AST and executes against any `StorageBackend`.

## New files

| File | Purpose |
|------|---------|
| `src/plan.ts` | `PlanNode` AST types (SelectNode, TimeRangeNode, AggregateNode, TransformNode) |
| `src/query-builder.ts` | Fluent builder — `.metric().where().range().rate().step().sumBy().plan()/.exec()` |
| `src/plan-executor.ts` | Walks PlanNode tree → calls ScanEngine.query() with extracted parameters |
| `test/query-builder.test.ts` | 18 tests covering plan compilation + end-to-end execution |
| `bench/bench-codecs.mjs` | Codec benchmark harness |
| `bench/bench-fused-agg.mjs` | Fused aggregation benchmark |
| `bench/profile-10k-avg.mjs` | Profiling harness for 10k-point average queries |

## Example usage

```ts
const result = await query()
  .metric('http_request_duration_seconds')
  .where('method', '=', 'GET')
  .range(start, end)
  .rate()
  .step(60_000n)
  .sumBy('endpoint')
  .exec(storage);
```

## Tests

18 passing tests covering:
- Plan compilation (SelectNode → TimeRangeNode tree structure)
- End-to-end execution against FlatStore
- Aggregation and rate calculation