### PR TITLE
fix(site): add missing TSDB Engine nav link to benchkit and octo11y pages

### DIFF
--- a/site/benchkit/index.html
+++ b/site/benchkit/index.html
@@ -21,6 +21,7 @@
         <a class="brand" href="/o11ykit/">o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
+          <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/" aria-current="page">Benchkit</a>
           <a href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">Playground</a>

--- a/site/octo11y/index.html
+++ b/site/octo11y/index.html
@@ -21,6 +21,7 @@
         <a class="brand" href="/o11ykit/">o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
+          <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
           <a href="/o11ykit/octo11y/" aria-current="page">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
           <a href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">Playground</a>


### PR DESCRIPTION
## Summary

Site audit revealed the benchkit and octo11y pages are missing the "TSDB Engine" nav link that appears on all other pages.

## Changes

- `site/benchkit/index.html` — added TSDB Engine link between OtlpKit and Octo11y
- `site/octo11y/index.html` — added TSDB Engine link between OtlpKit and Octo11y

## Audit results

| Page | Status |
|------|--------|
| `/o11ykit/` | ✅ Clean |
| `/o11ykit/tsdb-engine/` | ✅ Fixed separately (wrong base href, pushed to main) |
| `/o11ykit/benchkit/` | 🔧 Fixed here |
| `/o11ykit/octo11y/` | 🔧 Fixed here |
| `/o11ykit/otlpkit-docs/` | ✅ Clean |
| `/o11ykit/tsdb-engine/learn/*` | ✅ Clean (no top nav, relative links only) |