### PR TITLE
feat(site): redesign with light theme, better architecture, and pipeline diagrams

### DIFF
--- a/site/benchkit/index.html
+++ b/site/benchkit/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>o11ykit / benchkit</title>
+    <title>Benchkit — CI performance automation</title>
     <meta
       name="description"
-      content="Benchkit docs: monitor, parse-results, aggregate, and compare workflows for CI performance telemetry."
+      content="Benchkit: monitor host telemetry, parse benchmarks, compare against baselines, and gate regressions in CI."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -24,66 +24,104 @@
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/" aria-current="page">Benchkit</a>
-          <a href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">Playground</a>
+          <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>
         </nav>
       </header>
 
       <section class="hero panel">
-        <p class="eyebrow">Product docs: Benchkit</p>
-        <h1>Benchmark + monitor automation for CI performance control.</h1>
+        <p class="eyebrow">automation layer</p>
+        <h1>Catch regressions<br/>before they merge.</h1>
         <p class="lede">
-          Benchkit extends Octo11y for performance engineering teams: collect host/process telemetry,
-          parse benchmark results, aggregate historical runs, and compare candidates against recent
-          baselines to catch regressions early.
+          Monitor host telemetry during CI. Parse benchmark output from any major tool.
+          Compare against rolling baselines. Post regression summaries to PRs.
+          All as composable GitHub Actions.
         </p>
         <div class="hero-actions">
           <a class="cta cta-primary" href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">
-            Open End-to-End Playground
+            End-to-End Playground
           </a>
           <a class="cta" href="https://github.com/strawgate/o11ykit/tree/main/octo11y/actions" target="_blank" rel="noreferrer">
-            Browse Benchkit Actions
+            Browse Actions
           </a>
         </div>
       </section>
 
+      <!-- Regression example -->
       <section class="panel">
-        <h2>Who Should Use Benchkit</h2>
-        <div class="grid grid-2">
-          <article class="journey">
-            <h3>Performance Owners</h3>
-            <p>
-              Teams responsible for preventing latency and resource regressions before merge.
-            </p>
-          </article>
-          <article class="journey">
-            <h3>CI Platform Engineers</h3>
-            <p>
-              Teams building reusable workflows that need benchmark telemetry with minimal YAML.
-            </p>
-          </article>
+        <h2>What a Regression Gate Looks Like</h2>
+        <p class="section-intro">The <code>compare</code> action flags regressions beyond your threshold and posts a summary to the PR:</p>
+        <table class="regression-table">
+          <thead>
+            <tr>
+              <th>Benchmark</th>
+              <th>Baseline (avg 10 runs)</th>
+              <th>Current</th>
+              <th>Change</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="name-col">BenchmarkParse</td>
+              <td>142 ns/op</td>
+              <td>148 ns/op</td>
+              <td>+4.2%</td>
+              <td class="pass">✅ pass</td>
+            </tr>
+            <tr>
+              <td class="name-col">BenchmarkEncode</td>
+              <td>89 ns/op</td>
+              <td>87 ns/op</td>
+              <td>−2.2%</td>
+              <td class="pass">✅ pass</td>
+            </tr>
+            <tr>
+              <td class="name-col">BenchmarkQuery</td>
+              <td>1,204 ns/op</td>
+              <td>2,451 ns/op</td>
+              <td>+103.6%</td>
+              <td class="fail">❌ regression</td>
+            </tr>
+            <tr>
+              <td class="name-col">BenchmarkAlloc</td>
+              <td>48 B/op</td>
+              <td>112 B/op</td>
+              <td>+133.3%</td>
+              <td class="fail">❌ regression</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Pipeline -->
+      <section class="panel">
+        <h2>The Pipeline</h2>
+        <div class="pipeline">
+          <div class="pipeline-stage accent-bench">
+            <div class="stage-name">monitor</div>
+            <div class="stage-desc">Start OTel Collector, scrape host metrics, stash on exit</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-stage accent-bench">
+            <div class="stage-name">parse-results</div>
+            <div class="stage-desc">Normalize benchmark output to OTLP, stash to data branch</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-stage accent-bench">
+            <div class="stage-name">aggregate</div>
+            <div class="stage-desc">Rebuild indexes and time-series from all runs</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-stage accent-bench">
+            <div class="stage-name">compare</div>
+            <div class="stage-desc">Flag regressions, post PR comment, optionally fail the step</div>
+          </div>
         </div>
       </section>
 
-      <section class="panel">
-        <h2>Core Actions</h2>
-        <div class="grid grid-3">
-          <article class="feature-card benchkit">
-            <h3>monitor</h3>
-            <p>Runs OTel Collector during CI and stashes telemetry on post-job exit.</p>
-          </article>
-          <article class="feature-card benchkit">
-            <h3>parse-results</h3>
-            <p>Converts benchmark output from files or logs into OTLP metrics and stashes by default.</p>
-          </article>
-          <article class="feature-card benchkit">
-            <h3>compare</h3>
-            <p>Compares current run against recent baselines with markdown summaries + thresholds.</p>
-          </article>
-        </div>
-      </section>
-
+      <!-- YAML quickstart -->
       <section class="panel code-panel">
-        <h2>Quickstart Workflow</h2>
+        <h2>Quickstart</h2>
 <pre><code>name: benchkit-ci
 on: [pull_request]
 
@@ -124,31 +162,43 @@ jobs:
           github-token: ${{ github.token }}</code></pre>
       </section>
 
+      <!-- Supported formats -->
       <section class="panel">
-        <h2>Modes That Matter</h2>
-        <div class="grid grid-2">
-          <article class="journey">
-            <h3>Auto Mode</h3>
-            <p>
-              Parse directly from GitHub Actions logs for low-friction setups where benchmark output
-              already appears in step logs.
-            </p>
+        <h2>Supported Formats</h2>
+        <p class="section-intro">Auto-detected or explicitly specified — <code>parse-results</code> handles them all:</p>
+        <div class="format-strip">
+          <span class="format-tag">Go bench</span>
+          <span class="format-tag">Rust cargo bench</span>
+          <span class="format-tag">Hyperfine</span>
+          <span class="format-tag">pytest-benchmark</span>
+          <span class="format-tag">benchmark-action</span>
+          <span class="format-tag">OTLP JSON</span>
+        </div>
+      </section>
+
+      <!-- Monitor details -->
+      <section class="panel">
+        <h2>What Monitor Captures</h2>
+        <div class="grid grid-3">
+          <article class="card accent-bench">
+            <h4>Host Metrics</h4>
+            <p>CPU utilization, memory usage, system load — filtered to runner-descendant processes.</p>
           </article>
-          <article class="journey">
-            <h3>File Mode</h3>
-            <p>
-              Parse known result files when you need deterministic input control across custom
-              benchmark tooling.
-            </p>
+          <article class="card accent-bench">
+            <h4>Custom Metrics</h4>
+            <p>One-liner emission via <code>benchkit-emit</code> CLI. No SDK, no configuration, just a name and value.</p>
+          </article>
+          <article class="card accent-bench">
+            <h4>Telemetry Sidecar</h4>
+            <p>Full OTLP collector with gRPC + HTTP receivers. Gzipped NDJSON stashed alongside benchmarks.</p>
           </article>
         </div>
       </section>
 
       <footer class="site-footer">
         <p>
-          Benchkit builds on Octo11y data primitives. Read
-          <a href="/o11ykit/octo11y/">Octo11y docs</a>
-          for indexing and publishing details.
+          Benchkit builds on <a href="/o11ykit/octo11y/">Octo11y</a> data primitives.
+          Part of <a href="/o11ykit/">o11ykit</a>.
         </p>
       </footer>
     </main>

--- a/site/index.html
+++ b/site/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>o11ykit</title>
+    <title>o11ykit — Observability primitives that compose</title>
     <meta
       name="description"
-      content="o11ykit brings together OtlpKit, Octo11y, and Benchkit for app diagnostics, GitHub telemetry, and performance workflows."
+      content="Parse OTLP. Shape telemetry. Gate regressions. OtlpKit, Octo11y, Benchkit, and a browser-native TSDB — all from one monorepo."
     />
-    <meta name="theme-color" content="#0a1624" />
+    <meta name="theme-color" content="#f8fafb" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500&display=swap" />
@@ -29,133 +29,132 @@
         </nav>
       </header>
 
+      <!-- Hero -->
       <section class="hero panel">
-        <p class="eyebrow">o11ykit platform</p>
-        <h1>Three products, one telemetry narrative.</h1>
+        <p class="eyebrow">monorepo</p>
+        <h1>Observability primitives<br/>that compose.</h1>
         <p class="lede">
-          Start with raw OTLP from your app, layer in repository and workflow telemetry, then add
-          benchmark + monitor automation for performance decisions that are grounded in data.
+          Parse OTLP JSON in the browser. Pipeline telemetry through GitHub Actions.
+          Gate performance regressions in CI. Three layers, one dependency tree.
         </p>
         <div class="hero-actions">
-          <a class="cta cta-primary" href="/o11ykit/otlpkit-docs/">Start With OtlpKit</a>
+          <a class="cta cta-primary" href="/o11ykit/otlpkit-docs/">Get Started</a>
           <a class="cta" href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">
-            Open Live Playground
+            Live Playground
           </a>
         </div>
-        <div class="pill-row" aria-label="Who this is for">
-          <span class="pill">App engineers</span>
-          <span class="pill">Platform teams</span>
-          <span class="pill">OSS maintainers</span>
-          <span class="pill">Performance owners</span>
+      </section>
+
+      <!-- Data flow pipeline -->
+      <section class="panel">
+        <h2>How Data Flows</h2>
+        <div class="pipeline">
+          <div class="pipeline-stage">
+            <div class="stage-icon">📡</div>
+            <div class="stage-name">Your App</div>
+            <div class="stage-desc">Emits OTLP metrics, traces, and logs</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-stage accent-otlp">
+            <div class="stage-name">@otlpkit</div>
+            <div class="stage-desc">Parse, query, shape into frames, adapt to any chart library</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-stage accent-octo">
+            <div class="stage-name">@octo11y</div>
+            <div class="stage-desc">Pipeline to a GitHub data branch — indexes, series, views</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-stage accent-bench">
+            <div class="stage-name">@benchkit</div>
+            <div class="stage-desc">Monitor CI, compare baselines, gate regressions</div>
+          </div>
         </div>
       </section>
 
+      <!-- Three layers -->
       <section class="panel">
-        <h2>Choose Your Starting Product</h2>
+        <h2>The Stack</h2>
         <div class="grid grid-3">
-          <article class="product-card otlpkit">
-            <p class="card-label">Product 1</p>
-            <h3>OtlpKit</h3>
+          <article class="card accent-otlp">
+            <h3 class="otlpkit">OtlpKit</h3>
             <p>
-              For teams instrumenting apps with OpenTelemetry who need immediate browser-based
-              diagnostics from OTLP metrics, traces, and logs.
+              Parse OTLP JSON. Build time-series frames, trace waterfalls, event timelines.
+              Render with Chart.js, ECharts, Recharts, or uPlot. Incremental ingest with bounded memory.
             </p>
-            <ul class="checklist">
-              <li>Parse OTLP JSON in the client</li>
-              <li>Build frames for charts, tables, and waterfalls</li>
-              <li>Adapt data to Chart.js, ECharts, Recharts, or uPlot</li>
-            </ul>
-            <div class="actions">
-              <a href="/o11ykit/otlpkit-docs/">Open OtlpKit Docs</a>
-              <a href="/o11ykit/otlpkit/">Launch OtlpKit Demo</a>
-              <a href="https://www.npmjs.com/search?q=%40otlpkit" target="_blank" rel="noreferrer">View npm Packages</a>
+            <div class="card-links">
+              <a href="/o11ykit/otlpkit-docs/">Docs</a>
+              <a href="/o11ykit/otlpkit/">Demo</a>
+              <a href="https://www.npmjs.com/search?q=%40otlpkit" target="_blank" rel="noreferrer">npm</a>
             </div>
           </article>
 
-          <article class="product-card octo11y">
-            <p class="card-label">Product 2</p>
-            <h3>Octo11y</h3>
+          <article class="card accent-octo">
+            <h3 class="octo11y">Octo11y</h3>
             <p>
-              For maintainers and platform engineers who want GitHub run activity transformed into
-              durable metrics history and dashboard-ready artifacts.
+              GitHub Actions that extract benchmark data from logs or files, aggregate run history,
+              and publish indexes and series to a data branch — no backend, no server, just Git.
             </p>
-            <ul class="checklist">
-              <li>Extract benchmark data from files or run logs</li>
-              <li>Aggregate run history into indexes and series</li>
-              <li>Publish metrics views from a lightweight data branch</li>
-            </ul>
-            <div class="actions">
-              <a href="/o11ykit/octo11y/">Open Octo11y Docs</a>
-              <a href="/o11ykit/experiences/dashboard/#guide">Open Octo11y Experience</a>
-              <a href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">Explore Playground</a>
-              <a href="https://github.com/strawgate/o11ykit/tree/main/octo11y" target="_blank" rel="noreferrer">Browse Source</a>
+            <div class="card-links">
+              <a href="/o11ykit/octo11y/">Docs</a>
+              <a href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">Playground</a>
             </div>
           </article>
 
-          <article class="product-card benchkit">
-            <p class="card-label">Product 3</p>
-            <h3>Benchkit</h3>
+          <article class="card accent-bench">
+            <h3 class="benchkit">Benchkit</h3>
             <p>
-              For teams running performance-sensitive CI pipelines who need benchmark + host metrics,
-              regression checks, and trend reporting in one flow.
+              Capture host telemetry during CI. Parse Go, Rust, Hyperfine, or pytest-benchmark output.
+              Compare against rolling baselines. Post regression summaries to PRs.
             </p>
-            <ul class="checklist">
-              <li>Capture monitor telemetry during CI jobs</li>
-              <li>Convert benchmark output to metrics automatically</li>
-              <li>Compare candidate runs against recent baselines</li>
-            </ul>
-            <div class="actions">
-              <a href="/o11ykit/benchkit/">Open Benchkit Docs</a>
-              <a href="/o11ykit/experiences/dashboard/#benchstory">Open Benchkit Experience</a>
-              <a href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">Run End-to-End Examples</a>
-              <a href="https://github.com/strawgate/o11ykit/tree/main/octo11y/actions" target="_blank" rel="noreferrer">Browse Actions</a>
+            <div class="card-links">
+              <a href="/o11ykit/benchkit/">Docs</a>
+              <a href="https://github.com/strawgate/o11ykit/tree/main/octo11y/actions" target="_blank" rel="noreferrer">Actions</a>
             </div>
           </article>
         </div>
       </section>
 
-      <section class="panel">
-        <h2>How The Stack Fits Together</h2>
-        <div class="stack-flow">
-          <article class="stack-layer layer-otlp">
-            <h3>@otlpkit/*</h3>
-            <p>Data model + query + view shaping for OTLP metrics, traces, and logs.</p>
-          </article>
-          <article class="stack-layer layer-octo">
-            <h3>@octo11y/*</h3>
-            <p>GitHub actions and run artifact model for telemetry pipelines.</p>
-          </article>
-          <article class="stack-layer layer-bench">
-            <h3>@benchkit/*</h3>
-            <p>Performance workflows on top: monitor, parse-results, aggregate, compare.</p>
-          </article>
+      <!-- TSDB Engine callout -->
+      <section class="callout">
+        <h3>🔬 o11ytsdb — Browser-Native Time-Series Database</h3>
+        <p>
+          XOR-delta (Gorilla), ALP, and Delta-ALP compression in TypeScript, Zig→WASM, and Rust→WASM.
+          Three storage backends. A scan query engine. <strong>57× compression</strong> on constant gauges.
+          <strong>~4 KB WASM binary</strong>.
+        </p>
+        <div class="card-links">
+          <a href="/o11ykit/tsdb-engine/">Explore the Engine</a>
+          <a href="/o11ykit/tsdb-engine/learn/">Learn How It Works</a>
         </div>
       </section>
 
+      <!-- Try it strip -->
       <section class="panel">
-        <h2>Common Team Journeys</h2>
-        <div class="grid grid-2">
-          <article class="journey">
-            <h3>App Diagnostics Journey</h3>
-            <p>
-              Instrument your app with OpenTelemetry, expose recent OTLP payloads through an API,
-              and render a zero-backend diagnostics dashboard in the browser with OtlpKit.
-            </p>
-          </article>
-          <article class="journey">
-            <h3>CI Performance Journey</h3>
-            <p>
-              Capture monitor metrics in CI, parse benchmark output from logs or files, aggregate to
-              a data branch, and gate regressions with compare summaries and trend pages.
-            </p>
-          </article>
+        <h2>Try It</h2>
+        <div class="try-strip">
+          <a href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">
+            <span class="try-icon">🎯</span>
+            <span>Live Playground</span>
+          </a>
+          <a href="/o11ykit/tsdb-engine/#live-demo">
+            <span class="try-icon">🚀</span>
+            <span>TSDB Live Demo</span>
+          </a>
+          <a href="/o11ykit/tsdb-engine/learn/">
+            <span class="try-icon">📚</span>
+            <span>Learn Experiences</span>
+          </a>
+          <a href="/o11ykit/otlpkit/">
+            <span class="try-icon">📊</span>
+            <span>OtlpKit Demo</span>
+          </a>
         </div>
       </section>
 
       <footer class="site-footer">
         <p>
-          Opinionated layering:
-          <code>@benchkit/* -> @octo11y/* -> @otlpkit/*</code>
+          Dependency layering: <code>@benchkit/* → @octo11y/* → @otlpkit/*</code>
         </p>
       </footer>
     </main>

--- a/site/octo11y/index.html
+++ b/site/octo11y/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>o11ykit / octo11y</title>
+    <title>Octo11y — GitHub-native telemetry pipelines</title>
     <meta
       name="description"
-      content="Octo11y docs: GitHub-native telemetry pipelines for benchmark and repository metrics."
+      content="Octo11y: GitHub Actions that turn workflow output into structured OTLP metrics on a data branch."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -24,20 +24,21 @@
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
           <a href="/o11ykit/octo11y/" aria-current="page">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
-          <a href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">Playground</a>
+          <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>
         </nav>
       </header>
 
       <section class="hero panel">
-        <p class="eyebrow">Product docs: Octo11y</p>
-        <h1>Turn GitHub activity into telemetry you can graph.</h1>
+        <p class="eyebrow">pipeline layer</p>
+        <h1>GitHub activity →<br/>telemetry you can graph.</h1>
         <p class="lede">
-          Octo11y is for repository maintainers and platform teams that want to convert workflow
-          logs, benchmark outputs, and repo metadata into structured run history and published views.
+          GitHub Actions that extract benchmark data from logs or files, stash run artifacts to a
+          data branch, aggregate history into indexes and time-series, and serve it all through
+          GitHub's CDN. No backend. No server. Just Git.
         </p>
         <div class="hero-actions">
           <a class="cta cta-primary" href="https://strawgate.com/o11ykit-playground/" target="_blank" rel="noreferrer">
-            Open Live Playground
+            Live Playground
           </a>
           <a class="cta" href="https://github.com/strawgate/o11ykit/tree/main/octo11y" target="_blank" rel="noreferrer">
             Browse Source
@@ -45,46 +46,73 @@
         </div>
       </section>
 
+      <!-- Pipeline diagram -->
       <section class="panel">
-        <h2>Where Octo11y Fits</h2>
-        <div class="grid grid-2">
-          <article class="journey">
-            <h3>Who Uses It</h3>
-            <p>
-              OSS maintainers, CI owners, and developer productivity teams who want objective
-              trend data across pull requests and releases.
-            </p>
-          </article>
-          <article class="journey">
-            <h3>What You Get</h3>
-            <p>
-              A clean data branch with run artifacts, indexes, and per-metric series files that can
-              be consumed by dashboards, badges, and custom reports.
-            </p>
-          </article>
+        <h2>The Pipeline</h2>
+        <div class="pipeline">
+          <div class="pipeline-stage">
+            <div class="stage-icon">⚙️</div>
+            <div class="stage-name">Workflow Run</div>
+            <div class="stage-desc">CI produces benchmark output in logs or files</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-stage accent-octo">
+            <div class="stage-name">parse-results</div>
+            <div class="stage-desc">Detect format, normalize to OTLP JSON</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-stage accent-octo">
+            <div class="stage-name">stash</div>
+            <div class="stage-desc">Commit to data branch with collision-safe run IDs</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-stage accent-octo">
+            <div class="stage-name">aggregate</div>
+            <div class="stage-desc">Rebuild indexes, series, and per-run detail views</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-stage">
+            <div class="stage-icon">📊</div>
+            <div class="stage-name">Dashboard</div>
+            <div class="stage-desc">Client-side chart from GitHub raw CDN</div>
+          </div>
         </div>
       </section>
 
+      <!-- Actions -->
       <section class="panel">
-        <h2>Core Capabilities</h2>
+        <h2>Actions</h2>
         <div class="grid grid-3">
-          <article class="feature-card octo11y">
-            <h3>Parse Results</h3>
-            <p>Read benchmark outputs from files or workflow logs and convert to OTLP metrics.</p>
+          <article class="card accent-octo">
+            <h3>parse-results</h3>
+            <p>Reads benchmark output from files or workflow logs. Auto-detects Go, Rust, Hyperfine, pytest-benchmark, or OTLP format. Normalizes to OTLP JSON.</p>
           </article>
-          <article class="feature-card octo11y">
-            <h3>Aggregate History</h3>
-            <p>Produce run indexes, refs/PR views, and per-metric time-series artifacts.</p>
+          <article class="card accent-octo">
+            <h3>stash</h3>
+            <p>Glob-expands result files, merges monitor telemetry, commits to the data branch with retry logic (up to 5 attempts on conflict).</p>
           </article>
-          <article class="feature-card octo11y">
-            <h3>Repository Metrics</h3>
-            <p>Collect stars, forks, workflow health, and language distribution as telemetry.</p>
+          <article class="card accent-octo">
+            <h3>aggregate</h3>
+            <p>Reads all run artifacts. Builds <code>index.json</code>, per-metric series files, ref/PR views, and Shields.io badge endpoints.</p>
+          </article>
+          <article class="card accent-octo">
+            <h3>repo-stats</h3>
+            <p>Collects stars, forks, contributors, issues, PRs, releases, workflow success %, and language breakdown as OTLP metrics.</p>
+          </article>
+          <article class="card accent-octo">
+            <h3>ingest-ci-runs</h3>
+            <p>Discovers completed workflow runs for scheduled benchmark ingestion — daily nightly benchmarks, weekly rollups.</p>
+          </article>
+          <article class="card accent-octo">
+            <h3>emit-metric</h3>
+            <p>One-off lightweight metric emission without a full OTLP SDK. One CLI call to <code>benchkit-emit</code>.</p>
           </article>
         </div>
       </section>
 
+      <!-- YAML quickstart -->
       <section class="panel code-panel">
-        <h2>Quickstart Workflow</h2>
+        <h2>Quickstart</h2>
 <pre><code>name: benchmark-pipeline
 on: [workflow_dispatch]
 
@@ -109,19 +137,28 @@ jobs:
           github-token: ${{ github.token }}</code></pre>
       </section>
 
+      <!-- Data branch structure -->
       <section class="panel">
-        <h2>Typical Outcomes</h2>
-        <ul class="checklist wide">
-          <li>Trend charts for benchmark and repository metrics over time</li>
-          <li>Consistent metric history per branch, PR, and commit</li>
-          <li>Data artifacts that power public or internal pages</li>
-        </ul>
+        <h2>What You Get</h2>
+        <p class="section-intro">A clean data branch with structured artifacts, served through GitHub's CDN:</p>
+        <div class="data-tree">
+          <span class="tree-dir">bench-data/</span><br/>
+          ├── <span class="tree-dir">data/</span><br/>
+          │   ├── <span class="tree-file">index.json</span> — summary of all runs<br/>
+          │   ├── <span class="tree-dir">series/</span> — per-metric time-series files<br/>
+          │   ├── <span class="tree-dir">index/</span> — refs.json, prs.json for navigation<br/>
+          │   ├── <span class="tree-dir">views/runs/{id}/</span> — per-run detail views<br/>
+          │   ├── <span class="tree-dir">badges/</span> — Shields.io endpoint JSON<br/>
+          │   └── <span class="tree-dir">runs/{run-id}/</span> — immutable run artifacts<br/>
+          │       ├── <span class="tree-file">benchmark.otlp.json</span><br/>
+          │       └── <span class="tree-file">telemetry.otlp.jsonl.gz</span>
+        </div>
       </section>
 
       <footer class="site-footer">
         <p>
           Need performance-specific automation on top?
-          <a href="/o11ykit/benchkit/">Go to Benchkit docs</a>
+          <a href="/o11ykit/benchkit/">Benchkit docs →</a>
         </p>
       </footer>
     </main>

--- a/site/otlpkit-docs/index.html
+++ b/site/otlpkit-docs/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>o11ykit / otlpkit</title>
+    <title>OtlpKit — Parse, query, and render OTLP in the browser</title>
     <meta
       name="description"
-      content="OtlpKit docs: who it is for, what it does, and how to turn OTLP payloads into diagnostics dashboards."
+      content="OtlpKit: four npm packages that turn OTLP JSON into chart-ready frames for Chart.js, ECharts, Recharts, and uPlot."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -24,49 +24,103 @@
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
-          <a href="/o11ykit/otlpkit/">Live Demo</a>
+          <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>
         </nav>
       </header>
 
       <section class="hero panel">
-        <p class="eyebrow">Product docs: OtlpKit</p>
-        <h1>OTLP payloads into browser-native diagnostics.</h1>
+        <p class="eyebrow">foundation layer</p>
+        <h1>OTLP in. Charts out.</h1>
         <p class="lede">
-          OtlpKit is for app engineers, SREs, and platform teams who already emit OpenTelemetry and
-          want a lightweight way to explore metrics, traces, and logs without standing up a full
-          observability backend for every use case.
+          Four packages that parse OTLP JSON, filter and group records, build library-agnostic frames,
+          and project them into Chart.js, ECharts, Recharts, or uPlot configs. Zero backend required.
         </p>
         <div class="hero-actions">
-          <a class="cta cta-primary" href="/o11ykit/otlpkit/">Open OtlpKit Demo</a>
+          <a class="cta cta-primary" href="/o11ykit/otlpkit/">Open Live Demo</a>
           <a class="cta" href="https://www.npmjs.com/search?q=%40otlpkit" target="_blank" rel="noreferrer">
-            View @otlpkit Packages
+            npm Packages
           </a>
         </div>
       </section>
 
+      <!-- The pipeline -->
       <section class="panel">
-        <h2>What You Can Build</h2>
-        <div class="grid grid-3">
-          <article class="feature-card otlpkit">
-            <h3>Diagnostics Dashboards</h3>
-            <p>Render latency, throughput, and error trends directly in your app UI.</p>
-          </article>
-          <article class="feature-card otlpkit">
-            <h3>Trace Drilldowns</h3>
-            <p>Use trace waterfalls and event timelines for incident and regression analysis.</p>
-          </article>
-          <article class="feature-card otlpkit">
-            <h3>Log + Metric Correlation</h3>
-            <p>Display related logs and metrics from the same OTLP stream in one page.</p>
-          </article>
+        <h2>The Pipeline</h2>
+        <div class="pipeline">
+          <div class="pipeline-stage accent-otlp">
+            <div class="stage-name">@otlpkit/otlpjson</div>
+            <div class="stage-desc">Parse OTLP JSON, detect signals, normalize timestamps, flatten attributes</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-stage accent-otlp">
+            <div class="stage-name">@otlpkit/query</div>
+            <div class="stage-desc">Filter, group, bucket time-series, select latest values</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-stage accent-otlp">
+            <div class="stage-name">@otlpkit/views</div>
+            <div class="stage-desc">Build frames: time-series, latest values, histograms, trace waterfalls</div>
+          </div>
+          <div class="pipeline-arrow">→</div>
+          <div class="pipeline-stage accent-otlp">
+            <div class="stage-name">@otlpkit/adapters</div>
+            <div class="stage-desc">Project to Chart.js, ECharts, Recharts, or uPlot native configs</div>
+          </div>
         </div>
       </section>
 
+      <!-- Packages -->
+      <section class="panel">
+        <h2>Packages</h2>
+        <div class="grid grid-2">
+          <div class="pkg-card">
+            <div class="pkg-name">@otlpkit/otlpjson</div>
+            <div class="pkg-desc">Parse raw OTLP JSON documents. Signal detection (metrics, traces, logs), timestamp normalization, attribute flattening, typed iterators.</div>
+            <ul class="pkg-exports">
+              <li>parseOtlpJson()</li>
+              <li>collectMetricPoints()</li>
+              <li>collectSpans()</li>
+              <li>collectLogRecords()</li>
+            </ul>
+          </div>
+          <div class="pkg-card">
+            <div class="pkg-name">@otlpkit/query</div>
+            <div class="pkg-desc">Materialize signals into queryable record sets. Filter by attributes, group by labels, bucket into time windows with sum/avg/min/max/count/rate.</div>
+            <ul class="pkg-exports">
+              <li>filterRecords()</li>
+              <li>groupBy()</li>
+              <li>bucketTimeSeries()</li>
+              <li>selectLatestValues()</li>
+            </ul>
+          </div>
+          <div class="pkg-card">
+            <div class="pkg-name">@otlpkit/views</div>
+            <div class="pkg-desc">Build reusable, library-agnostic frame objects. Incremental ingest store with bounded memory. Frame merging and append operations for streaming updates.</div>
+            <ul class="pkg-exports">
+              <li>buildTimeSeriesFrame()</li>
+              <li>buildLatestValuesFrame()</li>
+              <li>createTelemetryStore()</li>
+              <li>appendTimeSeriesFrame()</li>
+            </ul>
+          </div>
+          <div class="pkg-card">
+            <div class="pkg-name">@otlpkit/adapters</div>
+            <div class="pkg-desc">Minimal translation layer to each chart library's native idioms. Row-based for Recharts, dataset/encode for ECharts, columnar for uPlot.</div>
+            <ul class="pkg-exports">
+              <li>toChartJsLineConfig()</li>
+              <li>toEChartsTimeSeriesOption()</li>
+              <li>toRechartsLineData()</li>
+              <li>toUPlotTimeSeriesModel()</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- Code example -->
       <section class="panel code-panel">
-        <h2>5-Minute Integration Sketch</h2>
-        <p>
-          Pull OTLP JSON from your API, shape it with <code>@otlpkit/views</code>, then feed your
-          charting library via an adapter.
+        <h2>Integration Example</h2>
+        <p class="section-intro">
+          Fetch OTLP from your API, build a frame, render a chart — three imports, five lines of glue.
         </p>
 <pre><code>import { buildTimeSeriesFrame, buildLatestValuesFrame } from "@otlpkit/views";
 import { toEChartsTimeSeriesOption } from "@otlpkit/adapters/echarts";
@@ -81,49 +135,25 @@ const latency = buildTimeSeriesFrame(metricsDoc, {
   title: "P95 latency by service",
 });
 
-const latest = buildLatestValuesFrame(metricsDoc, {
-  signal: "metrics",
-  metricName: "http.server.active_requests",
-  splitBy: "resource.service.name",
-  title: "Active requests now",
-});
-
 const option = toEChartsTimeSeriesOption(latency);</code></pre>
       </section>
 
+      <!-- Works with -->
       <section class="panel">
-        <h2>Who Should Use OtlpKit</h2>
-        <div class="grid grid-2">
-          <article class="journey">
-            <h3>Application Teams</h3>
-            <p>
-              You already instrument with OpenTelemetry and need embeddable diagnostics in internal
-              tools, admin pages, or incident UIs.
-            </p>
-          </article>
-          <article class="journey">
-            <h3>Platform / Runtime Teams</h3>
-            <p>
-              You need portable visualizations over raw telemetry in CI previews, staging clusters,
-              and edge deployments where heavyweight stacks are unnecessary.
-            </p>
-          </article>
+        <h2>Works With</h2>
+        <div class="format-strip">
+          <span class="format-tag">Chart.js</span>
+          <span class="format-tag">ECharts</span>
+          <span class="format-tag">Recharts</span>
+          <span class="format-tag">uPlot</span>
+          <span class="format-tag">Visx</span>
         </div>
-      </section>
-
-      <section class="panel">
-        <h2>Advanced Practice</h2>
-        <p>
-          If your runtime captures OTLP into a ring buffer (for example, a local processor in front
-          of your telemetry pipeline), OtlpKit can render that buffered data over a simple API for
-          instant diagnostics without waiting on external storage pipelines.
-        </p>
       </section>
 
       <footer class="site-footer">
         <p>
-          Continue the story with GitHub telemetry automation:
-          <a href="/o11ykit/octo11y/">Octo11y docs</a>
+          OtlpKit is the foundation layer of <a href="/o11ykit/">o11ykit</a>.
+          Build telemetry pipelines on top with <a href="/o11ykit/octo11y/">Octo11y</a>.
         </p>
       </footer>
     </main>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,198 +1,228 @@
+/* ─── o11ykit — Shared Site Styles ─────────────────────────────────── */
+
 :root {
   --ink: #0a1a2a;
-  --ink-soft: #304b62;
-  --surface: rgba(250, 253, 255, 0.86);
-  --surface-strong: rgba(255, 255, 255, 0.92);
-  --line: rgba(37, 79, 108, 0.2);
-  --shadow-lg: 0 22px 58px rgba(12, 39, 63, 0.16);
-  --shadow-sm: 0 10px 24px rgba(10, 36, 56, 0.1);
-  --otlp: #f26f2d;
+  --ink-soft: #3d5468;
+  --ink-muted: #6b8499;
+  --surface: rgba(255, 255, 255, 0.92);
+  --surface-strong: rgba(255, 255, 255, 0.96);
+  --line: rgba(37, 79, 108, 0.14);
+  --line-strong: rgba(37, 79, 108, 0.25);
+  --shadow-lg: 0 16px 48px rgba(12, 39, 63, 0.1);
+  --shadow-sm: 0 6px 20px rgba(10, 36, 56, 0.06);
+  --otlp: #e85d1a;
   --octo: #058d75;
   --bench: #1259e0;
+  --tsdb: #7c3aed;
+  --mono: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+  --sans: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
 }
 
-* {
-  box-sizing: border-box;
-}
+* { box-sizing: border-box; }
 
 body {
   margin: 0;
   min-height: 100vh;
   color: var(--ink);
-  font-family: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
-  background: linear-gradient(150deg, #eef6ff 0%, #fff7ee 38%, #edfff6 74%, #edf4ff 100%);
+  font-family: var(--sans);
+  background: #f8fafb;
 }
 
+/* ─── Ambient background glow ──────────────────────────────────────── */
 .ambient {
   position: fixed;
   inset: 0;
   z-index: 0;
   pointer-events: none;
   background:
-    radial-gradient(660px 500px at 8% -12%, rgba(242, 111, 45, 0.28), transparent 62%),
-    radial-gradient(700px 500px at 91% -8%, rgba(5, 141, 117, 0.25), transparent 60%),
-    radial-gradient(900px 700px at 52% 112%, rgba(18, 89, 224, 0.2), transparent 68%);
+    radial-gradient(600px 400px at 5% -8%, rgba(232, 93, 26, 0.1), transparent 55%),
+    radial-gradient(600px 400px at 95% -5%, rgba(5, 141, 117, 0.08), transparent 50%),
+    radial-gradient(800px 500px at 50% 110%, rgba(18, 89, 224, 0.06), transparent 60%);
 }
 
+/* ─── Page layout ──────────────────────────────────────────────────── */
 .page {
   position: relative;
   z-index: 1;
-  max-width: 1160px;
+  max-width: 1100px;
   margin: 0 auto;
-  padding: 28px 18px 56px;
+  padding: 24px 20px 48px;
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: 18px;
+  gap: 16px;
 }
 
+/* ─── Panel (shared card) ──────────────────────────────────────────── */
 .panel {
   background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 24px;
-  padding: 22px;
+  border-radius: 20px;
+  padding: 24px;
   box-shadow: var(--shadow-lg);
-  backdrop-filter: blur(8px);
   min-width: 0;
 }
 
+/* ─── Top bar ──────────────────────────────────────────────────────── */
 .topbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  padding-block: 14px;
+  gap: 14px;
+  padding-block: 12px;
 }
 
 .brand {
-  color: #0d2034;
+  color: var(--ink);
   text-decoration: none;
-  font-size: 19px;
+  font-size: 18px;
   font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.03em;
+  font-family: var(--mono);
 }
 
 .topnav {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 6px;
 }
 
 .topnav a {
   text-decoration: none;
-  color: #173149;
+  color: var(--ink-soft);
   font-size: 13px;
   font-weight: 600;
-  border-radius: 999px;
-  border: 1px solid rgba(53, 93, 121, 0.22);
-  background: rgba(255, 255, 255, 0.8);
-  padding: 7px 12px;
-  transition:
-    transform 120ms ease,
-    border-color 120ms ease;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: var(--surface-strong);
+  padding: 6px 11px;
+  transition: border-color 120ms ease, color 120ms ease;
 }
 
 .topnav a[aria-current="page"] {
-  border-color: rgba(21, 67, 97, 0.42);
-  background: rgba(255, 255, 255, 0.96);
+  color: var(--ink);
+  border-color: var(--line-strong);
+  background: white;
 }
 
 .topnav a:hover {
-  transform: translateY(-1px);
+  color: var(--ink);
+  border-color: var(--line-strong);
 }
 
+/* ─── Hero ─────────────────────────────────────────────────────────── */
 .hero h1 {
-  margin: 8px 0 12px;
-  font-size: clamp(34px, 5.7vw, 68px);
-  line-height: 0.98;
-  letter-spacing: -0.03em;
+  margin: 6px 0 10px;
+  font-size: clamp(32px, 5.5vw, 60px);
+  line-height: 1.0;
+  letter-spacing: -0.035em;
 }
 
 .eyebrow {
   margin: 0;
   text-transform: uppercase;
-  letter-spacing: 0.11em;
+  letter-spacing: 0.1em;
   font-size: 11px;
   font-weight: 700;
-  color: #4d687c;
+  color: var(--ink-muted);
+  font-family: var(--mono);
 }
 
-.lede,
-.hero p {
+.lede {
   margin: 0;
   color: var(--ink-soft);
-  max-width: 72ch;
+  max-width: 68ch;
   font-size: 17px;
-  line-height: 1.45;
+  line-height: 1.5;
 }
 
 .hero-actions {
-  margin-top: 18px;
+  margin-top: 16px;
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
 }
 
+/* ─── Buttons ──────────────────────────────────────────────────────── */
 .cta {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   text-decoration: none;
-  color: #112a3f;
+  color: var(--ink);
   font-size: 14px;
   font-weight: 600;
-  border-radius: 999px;
-  border: 1px solid rgba(36, 76, 104, 0.24);
-  background: rgba(255, 255, 255, 0.9);
-  padding: 11px 16px;
-  transition:
-    transform 130ms ease,
-    box-shadow 130ms ease;
+  border-radius: 10px;
+  border: 1px solid var(--line-strong);
+  background: white;
+  padding: 10px 16px;
+  transition: transform 120ms ease, box-shadow 120ms ease;
 }
 
 .cta:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 9px 18px rgba(22, 54, 76, 0.16);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(22, 54, 76, 0.1);
 }
 
 .cta-primary {
-  color: #f4fbff;
-  border-color: rgba(14, 55, 86, 0.72);
-  background: linear-gradient(130deg, #10314e, #0f5a89);
+  color: white;
+  border-color: transparent;
+  background: var(--ink);
 }
 
+.cta-primary:hover {
+  background: #132d44;
+}
+
+/* ─── Pill row ─────────────────────────────────────────────────────── */
 .pill-row {
-  margin-top: 16px;
+  margin-top: 14px;
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
 }
 
 .pill {
   font-size: 12px;
-  font-weight: 600;
-  color: #22435a;
-  border: 1px solid rgba(45, 82, 108, 0.24);
-  background: rgba(255, 255, 255, 0.72);
-  border-radius: 999px;
-  padding: 7px 11px;
+  font-weight: 500;
+  font-family: var(--mono);
+  color: var(--ink-soft);
+  border: 1px solid var(--line);
+  background: white;
+  border-radius: 6px;
+  padding: 5px 10px;
 }
 
+/* ─── Typography ───────────────────────────────────────────────────── */
 h2 {
   margin: 0 0 12px;
-  font-size: clamp(24px, 3.1vw, 38px);
-  letter-spacing: -0.02em;
+  font-size: clamp(22px, 3vw, 34px);
+  letter-spacing: -0.025em;
 }
 
 h3 {
   margin: 0;
-  font-size: 24px;
+  font-size: 20px;
   letter-spacing: -0.02em;
 }
 
+h4 {
+  margin: 0;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+
+.section-intro {
+  margin: 0 0 16px;
+  color: var(--ink-soft);
+  max-width: 68ch;
+  line-height: 1.5;
+}
+
+/* ─── Grid layouts ─────────────────────────────────────────────────── */
 .grid {
   display: grid;
-  gap: 14px;
+  gap: 12px;
 }
 
 .grid-2 {
@@ -200,55 +230,100 @@ h3 {
 }
 
 .grid-3 {
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
+.grid-4 {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+/* ─── Cards ────────────────────────────────────────────────────────── */
+.card {
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: var(--shadow-sm);
+  animation: rise-in 380ms ease both;
+}
+
+.card:nth-child(2) { animation-delay: 60ms; }
+.card:nth-child(3) { animation-delay: 120ms; }
+.card:nth-child(4) { animation-delay: 180ms; }
+
+.card p {
+  margin: 8px 0 0;
+  color: var(--ink-soft);
+  line-height: 1.45;
+  font-size: 14px;
+}
+
+/* Legacy card classes (compat with tsdb-engine) */
 .product-card,
 .feature-card,
 .journey,
 .stack-layer {
-  background: var(--surface-strong);
-  border: 1px solid rgba(43, 80, 106, 0.2);
-  border-radius: 18px;
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 14px;
   padding: 16px;
   box-shadow: var(--shadow-sm);
-  animation: rise-in 420ms ease both;
+  animation: rise-in 380ms ease both;
 }
 
 .product-card:nth-child(2),
 .feature-card:nth-child(2),
-.stack-layer:nth-child(2) {
-  animation-delay: 80ms;
-}
+.stack-layer:nth-child(2) { animation-delay: 60ms; }
 
 .product-card:nth-child(3),
 .feature-card:nth-child(3),
-.stack-layer:nth-child(3) {
-  animation-delay: 140ms;
-}
+.stack-layer:nth-child(3) { animation-delay: 120ms; }
 
 .product-card p,
 .feature-card p,
 .journey p,
 .stack-layer p {
-  margin: 10px 0 0;
+  margin: 8px 0 0;
   color: var(--ink-soft);
-  line-height: 1.42;
+  line-height: 1.45;
+  font-size: 14px;
 }
 
-.card-label {
-  margin: 0;
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: #577084;
+/* ─── Per-product accent colors ────────────────────────────────────── */
+.accent-otlp { border-left: 4px solid var(--otlp); }
+.accent-octo { border-left: 4px solid var(--octo); }
+.accent-bench { border-left: 4px solid var(--bench); }
+.accent-tsdb { border-left: 4px solid var(--tsdb); }
+
+.otlpkit h3, .otlpkit h2 { color: var(--otlp); }
+.octo11y h3, .octo11y h2 { color: var(--octo); }
+.benchkit h3, .benchkit h2 { color: var(--bench); }
+
+/* ─── Card links ───────────────────────────────────────────────────── */
+.card-links {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
-.product-card h3 {
-  margin-top: 6px;
+.card-links a {
+  text-decoration: none;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: white;
+  padding: 7px 12px;
+  transition: border-color 120ms ease;
 }
 
+.card-links a:hover {
+  border-color: var(--ink-soft);
+}
+
+/* Legacy .actions (compat with tsdb-engine) */
 .actions {
   margin-top: 14px;
   display: grid;
@@ -257,106 +332,262 @@ h3 {
 
 .actions a {
   text-decoration: none;
-  color: #0f263a;
+  color: var(--ink);
   font-size: 14px;
   font-weight: 500;
-  border: 1px solid rgba(52, 88, 113, 0.24);
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: white;
   padding: 10px 12px;
-  transition:
-    transform 120ms ease,
-    border-color 120ms ease;
+  transition: transform 120ms ease, border-color 120ms ease;
 }
 
 .actions a:hover {
   transform: translateX(2px);
+  border-color: var(--line-strong);
 }
 
-.otlpkit h3,
-.otlpkit h2 {
-  color: var(--otlp);
+/* ─── Pipeline flow diagram ────────────────────────────────────────── */
+.pipeline {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  overflow-x: auto;
+  padding: 4px 0;
 }
 
-.octo11y h3,
-.octo11y h2 {
-  color: var(--octo);
-}
-
-.benchkit h3,
-.benchkit h2 {
-  color: var(--bench);
-}
-
-.otlpkit .actions a:hover {
-  border-color: color-mix(in oklab, var(--otlp) 48%, white);
-}
-
-.octo11y .actions a:hover {
-  border-color: color-mix(in oklab, var(--octo) 48%, white);
-}
-
-.benchkit .actions a:hover {
-  border-color: color-mix(in oklab, var(--bench) 48%, white);
-}
-
-.checklist {
-  margin: 10px 0 0;
-  padding-left: 18px;
-  color: #203d53;
-  line-height: 1.4;
-  display: grid;
-  gap: 6px;
-}
-
-.checklist.wide {
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  padding-left: 0;
-  list-style: none;
-}
-
-.checklist.wide li {
-  border: 1px solid rgba(52, 86, 109, 0.2);
+.pipeline-stage {
+  flex: 1;
+  min-width: 140px;
+  text-align: center;
+  padding: 16px 12px;
+  background: white;
+  border: 1px solid var(--line);
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.84);
-  padding: 10px 12px;
+  position: relative;
 }
 
-.stack-flow {
+.pipeline-stage .stage-icon {
+  font-size: 24px;
+  margin-bottom: 6px;
+}
+
+.pipeline-stage .stage-name {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.pipeline-stage .stage-desc {
+  font-size: 12px;
+  color: var(--ink-muted);
+  margin-top: 4px;
+  line-height: 1.35;
+}
+
+.pipeline-arrow {
+  display: flex;
+  align-items: center;
+  padding: 0 6px;
+  color: var(--ink-muted);
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+/* ─── Inline mono stats ────────────────────────────────────────────── */
+.stat-inline {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+/* ─── Callout card ─────────────────────────────────────────────────── */
+.callout {
+  background: linear-gradient(135deg, #f6f0ff 0%, #eff6ff 100%);
+  border: 1px solid rgba(124, 58, 237, 0.15);
+  border-radius: 16px;
+  padding: 24px;
   display: grid;
-  gap: 11px;
+  gap: 8px;
 }
 
-.layer-otlp {
-  border-left: 6px solid var(--otlp);
+.callout h3 {
+  color: var(--tsdb);
 }
 
-.layer-octo {
-  border-left: 6px solid var(--octo);
+.callout p {
+  margin: 0;
+  color: var(--ink-soft);
+  line-height: 1.5;
+  font-size: 15px;
 }
 
-.layer-bench {
-  border-left: 6px solid var(--bench);
+.callout .card-links {
+  margin-top: 8px;
 }
 
+/* ─── Try-it strip ─────────────────────────────────────────────────── */
+.try-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
+}
+
+.try-strip a {
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+  transition: border-color 120ms ease, transform 120ms ease;
+}
+
+.try-strip a:hover {
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
+}
+
+.try-strip .try-icon {
+  font-size: 20px;
+  flex-shrink: 0;
+}
+
+/* ─── Package cards ────────────────────────────────────────────────── */
+.pkg-card {
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: var(--shadow-sm);
+}
+
+.pkg-card .pkg-name {
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.pkg-card .pkg-desc {
+  margin: 6px 0 0;
+  font-size: 13px;
+  color: var(--ink-soft);
+  line-height: 1.4;
+}
+
+.pkg-card .pkg-exports {
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.pkg-card .pkg-exports li {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-muted);
+  background: #f4f7f9;
+  border-radius: 4px;
+  padding: 2px 7px;
+}
+
+/* ─── Adapter / format strip ───────────────────────────────────────── */
+.format-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.format-strip .format-tag {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink);
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 6px 12px;
+}
+
+/* ─── Regression table ─────────────────────────────────────────────── */
+.regression-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  margin-top: 8px;
+}
+
+.regression-table th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--ink-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--line-strong);
+}
+
+.regression-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: 13px;
+}
+
+.regression-table .name-col {
+  font-weight: 500;
+  color: var(--ink);
+}
+
+.regression-table .pass { color: var(--octo); }
+.regression-table .fail { color: #dc2626; }
+
+/* ─── Data tree ────────────────────────────────────────────────────── */
+.data-tree {
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.7;
+  color: var(--ink-soft);
+  padding: 12px 16px;
+  background: #f8fafb;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  margin-top: 8px;
+}
+
+.data-tree .tree-dir { color: var(--ink); font-weight: 600; }
+.data-tree .tree-file { color: var(--ink-muted); }
+
+/* ─── Code blocks ──────────────────────────────────────────────────── */
 .code-panel pre {
   margin: 12px 0 0;
-  padding: 14px;
+  padding: 16px;
   overflow-x: auto;
-  border-radius: 14px;
-  border: 1px solid rgba(45, 74, 94, 0.35);
-  background: linear-gradient(145deg, #0c1f31, #132b42);
+  border-radius: 12px;
+  border: 1px solid rgba(45, 74, 94, 0.2);
+  background: #0c1f31;
   color: #dcf2ff;
   font-size: 12px;
-  line-height: 1.45;
+  line-height: 1.5;
 }
 
 code {
-  font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+  font-family: var(--mono);
   font-size: 12px;
-  background: rgba(255, 255, 255, 0.78);
-  border: 1px solid rgba(52, 90, 117, 0.22);
-  border-radius: 6px;
+  background: #f0f4f8;
+  border: 1px solid var(--line);
+  border-radius: 5px;
   padding: 2px 6px;
 }
 
@@ -367,36 +598,72 @@ code {
   color: inherit;
 }
 
+/* ─── Checklist ────────────────────────────────────────────────────── */
+.checklist {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  color: var(--ink-soft);
+  line-height: 1.4;
+  display: grid;
+  gap: 4px;
+}
+
+.checklist.wide {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding-left: 0;
+  list-style: none;
+}
+
+.checklist.wide li {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: white;
+  padding: 10px 12px;
+}
+
+/* ─── Stack flow (legacy compat with tsdb-engine) ──────────────────── */
+.stack-flow {
+  display: grid;
+  gap: 10px;
+}
+
+.layer-otlp { border-left: 4px solid var(--otlp); }
+.layer-octo { border-left: 4px solid var(--octo); }
+.layer-bench { border-left: 4px solid var(--bench); }
+
+/* ─── Footer ───────────────────────────────────────────────────────── */
+.site-footer {
+  padding-top: 8px;
+}
+
 .site-footer p {
   margin: 0;
-  color: #345166;
+  color: var(--ink-muted);
   font-size: 13px;
 }
 
 .site-footer a {
-  color: #0e5d8f;
+  color: var(--ink-soft);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
+/* ─── Animation ────────────────────────────────────────────────────── */
 @keyframes rise-in {
-  from {
-    opacity: 0;
-    transform: translateY(7px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
+/* ─── Mobile ───────────────────────────────────────────────────────── */
 @media (max-width: 760px) {
   .page {
-    padding: 18px 12px 34px;
+    padding: 16px 14px 32px;
     gap: 12px;
   }
 
   .panel {
-    border-radius: 16px;
-    padding: 15px;
+    border-radius: 14px;
+    padding: 16px;
   }
 
   .topbar {
@@ -409,33 +676,46 @@ code {
   }
 
   .hero h1 {
-    font-size: clamp(30px, 10vw, 44px);
+    font-size: clamp(28px, 9vw, 40px);
   }
 
   .cta {
     width: 100%;
   }
+
+  .pipeline {
+    flex-direction: column;
+  }
+
+  .pipeline-arrow {
+    justify-content: center;
+    transform: rotate(90deg);
+    padding: 4px 0;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .card,
   .product-card,
   .feature-card,
   .journey,
   .stack-layer,
   .cta,
   .actions a,
-  .topnav a {
+  .card-links a,
+  .topnav a,
+  .try-strip a {
     animation: none;
     transition: none;
   }
 }
 
-/* Skip link for keyboard navigation */
+/* ─── Accessibility ────────────────────────────────────────────────── */
 .skip-link {
   position: absolute;
   top: -40px;
   left: 0;
-  background: #112a3f;
+  background: var(--ink);
   color: white;
   padding: 8px 16px;
   text-decoration: none;
@@ -443,20 +723,19 @@ code {
   font-size: 14px;
   border-radius: 0 0 8px 0;
 }
+
 .skip-link:focus {
   top: 0;
 }
 
-/* Visible focus indicators for keyboard navigation */
 *:focus-visible {
-  outline: 2px solid #1259e0;
+  outline: 2px solid var(--bench);
   outline-offset: 2px;
 }
 
 button:focus-visible,
 .cta:focus-visible,
 .topnav a:focus-visible {
-  outline: 2px solid #1259e0;
+  outline: 2px solid var(--bench);
   outline-offset: 2px;
-  border-radius: 4px;
 }

--- a/site/tsdb-engine/index.html
+++ b/site/tsdb-engine/index.html
@@ -40,6 +40,7 @@
           <a href="/o11ykit/tsdb-engine/" aria-current="page">TSDB Engine</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
+          <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>
         </nav>
       </header>
 


### PR DESCRIPTION
## What Changed

Redesigned all site pages to fix content duplication and improve information architecture while keeping the light/white theme.

### Homepage
- **Deduplicated**: removed tripled product/stack/journey sections that said the same thing 3 times
- Added visual **pipeline flow diagram** (App → OtlpKit → Octo11y → Benchkit)
- Compact product cards with direct links
- TSDB Engine callout card with violet accent
- Try-it strip linking to playground, demos, and experiences

### OtlpKit Page
- Code-first: shows the 4-package pipeline (otlpjson → query → views → adapters)
- **Package cards** with key exports for each npm package
- Works-with adapter strip (Chart.js, ECharts, Recharts, uPlot, Visx)

### Octo11y Page
- **Pipeline diagram**: workflow → parse-results → stash → aggregate → dashboard
- All 6 GitHub Actions documented as cards
- **Data branch structure** tree visualization

### Benchkit Page
- Inline **regression comparison table** with pass/fail examples
- Pipeline-ordered actions: monitor → parse-results → aggregate → compare
- **Supported formats** strip (Go, Rust, Hyperfine, pytest-benchmark, OTLP)
- What Monitor Captures section

### Cross-Cutting
- Consistent nav across all pages (+ GitHub link on TSDB Engine)
- Refined CSS: cleaner cards, monospace accents, pipeline/diagram styles
- Technical voice: `Parse OTLP JSON.` not `For teams who want to...`
- All experience pages (`learn/*`) untouched

### Voice Change
**Before**: *For teams instrumenting apps with OpenTelemetry who need immediate browser-based diagnostics...*
**After**: *Parse OTLP JSON in the browser. Build time-series frames, trace waterfalls, and event timelines. Render with Chart.js, ECharts, Recharts, or uPlot.*