### PR TITLE
style: fix biome formatting in site/styles.css

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -18,7 +18,9 @@
   --sans: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
 
 body {
   margin: 0;
@@ -96,7 +98,9 @@ body {
   border: 1px solid var(--line);
   background: var(--surface-strong);
   padding: 6px 11px;
-  transition: border-color 120ms ease, color 120ms ease;
+  transition:
+    border-color 120ms ease,
+    color 120ms ease;
 }
 
 .topnav a[aria-current="page"] {
@@ -114,7 +118,7 @@ body {
 .hero h1 {
   margin: 6px 0 10px;
   font-size: clamp(32px, 5.5vw, 60px);
-  line-height: 1.0;
+  line-height: 1;
   letter-spacing: -0.035em;
 }
 
@@ -156,7 +160,9 @@ body {
   border: 1px solid var(--line-strong);
   background: white;
   padding: 10px 16px;
-  transition: transform 120ms ease, box-shadow 120ms ease;
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease;
 }
 
 .cta:hover {
@@ -247,9 +253,15 @@ h4 {
   animation: rise-in 380ms ease both;
 }
 
-.card:nth-child(2) { animation-delay: 60ms; }
-.card:nth-child(3) { animation-delay: 120ms; }
-.card:nth-child(4) { animation-delay: 180ms; }
+.card:nth-child(2) {
+  animation-delay: 60ms;
+}
+.card:nth-child(3) {
+  animation-delay: 120ms;
+}
+.card:nth-child(4) {
+  animation-delay: 180ms;
+}
 
 .card p {
   margin: 8px 0 0;
@@ -273,11 +285,15 @@ h4 {
 
 .product-card:nth-child(2),
 .feature-card:nth-child(2),
-.stack-layer:nth-child(2) { animation-delay: 60ms; }
+.stack-layer:nth-child(2) {
+  animation-delay: 60ms;
+}
 
 .product-card:nth-child(3),
 .feature-card:nth-child(3),
-.stack-layer:nth-child(3) { animation-delay: 120ms; }
+.stack-layer:nth-child(3) {
+  animation-delay: 120ms;
+}
 
 .product-card p,
 .feature-card p,
@@ -290,14 +306,31 @@ h4 {
 }
 
 /* ─── Per-product accent colors ────────────────────────────────────── */
-.accent-otlp { border-left: 4px solid var(--otlp); }
-.accent-octo { border-left: 4px solid var(--octo); }
-.accent-bench { border-left: 4px solid var(--bench); }
-.accent-tsdb { border-left: 4px solid var(--tsdb); }
+.accent-otlp {
+  border-left: 4px solid var(--otlp);
+}
+.accent-octo {
+  border-left: 4px solid var(--octo);
+}
+.accent-bench {
+  border-left: 4px solid var(--bench);
+}
+.accent-tsdb {
+  border-left: 4px solid var(--tsdb);
+}
 
-.otlpkit h3, .otlpkit h2 { color: var(--otlp); }
-.octo11y h3, .octo11y h2 { color: var(--octo); }
-.benchkit h3, .benchkit h2 { color: var(--bench); }
+.otlpkit h3,
+.otlpkit h2 {
+  color: var(--otlp);
+}
+.octo11y h3,
+.octo11y h2 {
+  color: var(--octo);
+}
+.benchkit h3,
+.benchkit h2 {
+  color: var(--bench);
+}
 
 /* ─── Card links ───────────────────────────────────────────────────── */
 .card-links {
@@ -339,7 +372,9 @@ h4 {
   border-radius: 10px;
   background: white;
   padding: 10px 12px;
-  transition: transform 120ms ease, border-color 120ms ease;
+  transition:
+    transform 120ms ease,
+    border-color 120ms ease;
 }
 
 .actions a:hover {
@@ -446,7 +481,9 @@ h4 {
   font-size: 14px;
   font-weight: 600;
   color: var(--ink);
-  transition: border-color 120ms ease, transform 120ms ease;
+  transition:
+    border-color 120ms ease,
+    transform 120ms ease;
 }
 
 .try-strip a:hover {
@@ -550,8 +587,12 @@ h4 {
   color: var(--ink);
 }
 
-.regression-table .pass { color: var(--octo); }
-.regression-table .fail { color: #dc2626; }
+.regression-table .pass {
+  color: var(--octo);
+}
+.regression-table .fail {
+  color: #dc2626;
+}
 
 /* ─── Data tree ────────────────────────────────────────────────────── */
 .data-tree {
@@ -566,8 +607,13 @@ h4 {
   margin-top: 8px;
 }
 
-.data-tree .tree-dir { color: var(--ink); font-weight: 600; }
-.data-tree .tree-file { color: var(--ink-muted); }
+.data-tree .tree-dir {
+  color: var(--ink);
+  font-weight: 600;
+}
+.data-tree .tree-file {
+  color: var(--ink-muted);
+}
 
 /* ─── Code blocks ──────────────────────────────────────────────────── */
 .code-panel pre {
@@ -627,9 +673,15 @@ code {
   gap: 10px;
 }
 
-.layer-otlp { border-left: 4px solid var(--otlp); }
-.layer-octo { border-left: 4px solid var(--octo); }
-.layer-bench { border-left: 4px solid var(--bench); }
+.layer-otlp {
+  border-left: 4px solid var(--otlp);
+}
+.layer-octo {
+  border-left: 4px solid var(--octo);
+}
+.layer-bench {
+  border-left: 4px solid var(--bench);
+}
 
 /* ─── Footer ───────────────────────────────────────────────────────── */
 .site-footer {
@@ -650,8 +702,14 @@ code {
 
 /* ─── Animation ────────────────────────────────────────────────────── */
 @keyframes rise-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ─── Mobile ───────────────────────────────────────────────────────── */


### PR DESCRIPTION
The biome formatting fix from PR #114 didn't fully make it through the merge. This expands single-line CSS rules to the multi-line format biome expects.

Single file changed: `site/styles.css` — formatting only, no functional changes.