### PR TITLE
brand: logo mark in nav + hero, favicon & meta consistency

### DIFF
--- a/site/benchkit/index.html
+++ b/site/benchkit/index.html
@@ -20,7 +20,7 @@
     <div class="ambient" aria-hidden="true"></div>
     <main id="main-content" class="page">
       <header class="topbar panel">
-        <a class="brand" href="/o11ykit/"><svg class="brand-mark" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="1" y="16" width="4" height="7" rx="2" fill="#e85d1a"/><rect x="7" y="11" width="4" height="12" rx="2" fill="#058d75"/><rect x="13" y="6" width="4" height="17" rx="2" fill="#1259e0"/><rect x="19" y="1" width="4" height="22" rx="2" fill="#7c3aed"/></svg>o11ykit</a>
+        <a class="brand" href="/o11ykit/"><img class="brand-mark" src="../logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>

--- a/site/benchkit/index.html
+++ b/site/benchkit/index.html
@@ -8,6 +8,8 @@
       name="description"
       content="Benchkit: monitor host telemetry, parse benchmarks, compare against baselines, and gate regressions in CI."
     />
+    <meta name="theme-color" content="#f8fafb" />
+    <link rel="icon" href="../logo.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500&display=swap" />
@@ -18,7 +20,7 @@
     <div class="ambient" aria-hidden="true"></div>
     <main id="main-content" class="page">
       <header class="topbar panel">
-        <a class="brand" href="/o11ykit/">o11ykit</a>
+        <a class="brand" href="/o11ykit/"><svg class="brand-mark" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="1" y="16" width="4" height="7" rx="2" fill="#e85d1a"/><rect x="7" y="11" width="4" height="12" rx="2" fill="#058d75"/><rect x="13" y="6" width="4" height="17" rx="2" fill="#1259e0"/><rect x="19" y="1" width="4" height="22" rx="2" fill="#7c3aed"/></svg>o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>

--- a/site/index.html
+++ b/site/index.html
@@ -9,6 +9,7 @@
       content="Parse OTLP. Shape telemetry. Gate regressions. OtlpKit, Octo11y, Benchkit, and a browser-native TSDB — all from one monorepo."
     />
     <meta name="theme-color" content="#f8fafb" />
+    <link rel="icon" href="./logo.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500&display=swap" />
@@ -19,7 +20,7 @@
     <div class="ambient" aria-hidden="true"></div>
     <main id="main-content" class="page">
       <header class="topbar panel">
-        <a class="brand" href="/o11ykit/">o11ykit</a>
+        <a class="brand" href="/o11ykit/"><svg class="brand-mark" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="1" y="16" width="4" height="7" rx="2" fill="#e85d1a"/><rect x="7" y="11" width="4" height="12" rx="2" fill="#058d75"/><rect x="13" y="6" width="4" height="17" rx="2" fill="#1259e0"/><rect x="19" y="1" width="4" height="22" rx="2" fill="#7c3aed"/></svg>o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
@@ -31,6 +32,10 @@
 
       <!-- Hero -->
       <section class="hero panel">
+        <div class="hero-lockup">
+          <svg class="hero-mark" width="48" height="48" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="1" y="16" width="4" height="7" rx="2" fill="#e85d1a"/><rect x="7" y="11" width="4" height="12" rx="2" fill="#058d75"/><rect x="13" y="6" width="4" height="17" rx="2" fill="#1259e0"/><rect x="19" y="1" width="4" height="22" rx="2" fill="#7c3aed"/></svg>
+          <span class="hero-name">o11ykit</span>
+        </div>
         <p class="eyebrow">monorepo</p>
         <h1>Observability primitives<br/>that compose.</h1>
         <p class="lede">

--- a/site/index.html
+++ b/site/index.html
@@ -20,7 +20,7 @@
     <div class="ambient" aria-hidden="true"></div>
     <main id="main-content" class="page">
       <header class="topbar panel">
-        <a class="brand" href="/o11ykit/"><svg class="brand-mark" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="1" y="16" width="4" height="7" rx="2" fill="#e85d1a"/><rect x="7" y="11" width="4" height="12" rx="2" fill="#058d75"/><rect x="13" y="6" width="4" height="17" rx="2" fill="#1259e0"/><rect x="19" y="1" width="4" height="22" rx="2" fill="#7c3aed"/></svg>o11ykit</a>
+        <a class="brand" href="/o11ykit/"><img class="brand-mark" src="./logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
@@ -33,7 +33,7 @@
       <!-- Hero -->
       <section class="hero panel">
         <div class="hero-lockup">
-          <svg class="hero-mark" width="48" height="48" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="1" y="16" width="4" height="7" rx="2" fill="#e85d1a"/><rect x="7" y="11" width="4" height="12" rx="2" fill="#058d75"/><rect x="13" y="6" width="4" height="17" rx="2" fill="#1259e0"/><rect x="19" y="1" width="4" height="22" rx="2" fill="#7c3aed"/></svg>
+          <img class="hero-mark" src="./logo.svg" width="48" height="48" alt="" aria-hidden="true" />
           <span class="hero-name">o11ykit</span>
         </div>
         <p class="eyebrow">monorepo</p>

--- a/site/logo.svg
+++ b/site/logo.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1" y="16" width="4" height="7" rx="2" fill="#e85d1a"/>
+  <rect x="7" y="11" width="4" height="12" rx="2" fill="#058d75"/>
+  <rect x="13" y="6" width="4" height="17" rx="2" fill="#1259e0"/>
+  <rect x="19" y="1" width="4" height="22" rx="2" fill="#7c3aed"/>
+</svg>

--- a/site/octo11y/index.html
+++ b/site/octo11y/index.html
@@ -20,7 +20,7 @@
     <div class="ambient" aria-hidden="true"></div>
     <main id="main-content" class="page">
       <header class="topbar panel">
-        <a class="brand" href="/o11ykit/"><svg class="brand-mark" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="1" y="16" width="4" height="7" rx="2" fill="#e85d1a"/><rect x="7" y="11" width="4" height="12" rx="2" fill="#058d75"/><rect x="13" y="6" width="4" height="17" rx="2" fill="#1259e0"/><rect x="19" y="1" width="4" height="22" rx="2" fill="#7c3aed"/></svg>o11ykit</a>
+        <a class="brand" href="/o11ykit/"><img class="brand-mark" src="../logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>

--- a/site/octo11y/index.html
+++ b/site/octo11y/index.html
@@ -8,6 +8,8 @@
       name="description"
       content="Octo11y: GitHub Actions that turn workflow output into structured OTLP metrics on a data branch."
     />
+    <meta name="theme-color" content="#f8fafb" />
+    <link rel="icon" href="../logo.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500&display=swap" />
@@ -18,7 +20,7 @@
     <div class="ambient" aria-hidden="true"></div>
     <main id="main-content" class="page">
       <header class="topbar panel">
-        <a class="brand" href="/o11ykit/">o11ykit</a>
+        <a class="brand" href="/o11ykit/"><svg class="brand-mark" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="1" y="16" width="4" height="7" rx="2" fill="#e85d1a"/><rect x="7" y="11" width="4" height="12" rx="2" fill="#058d75"/><rect x="13" y="6" width="4" height="17" rx="2" fill="#1259e0"/><rect x="19" y="1" width="4" height="22" rx="2" fill="#7c3aed"/></svg>o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>

--- a/site/otlpkit-docs/index.html
+++ b/site/otlpkit-docs/index.html
@@ -8,6 +8,8 @@
       name="description"
       content="OtlpKit: four npm packages that turn OTLP JSON into chart-ready frames for Chart.js, ECharts, Recharts, and uPlot."
     />
+    <meta name="theme-color" content="#f8fafb" />
+    <link rel="icon" href="../logo.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500&display=swap" />
@@ -18,7 +20,7 @@
     <div class="ambient" aria-hidden="true"></div>
     <main id="main-content" class="page">
       <header class="topbar panel">
-        <a class="brand" href="/o11ykit/">o11ykit</a>
+        <a class="brand" href="/o11ykit/"><svg class="brand-mark" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="1" y="16" width="4" height="7" rx="2" fill="#e85d1a"/><rect x="7" y="11" width="4" height="12" rx="2" fill="#058d75"/><rect x="13" y="6" width="4" height="17" rx="2" fill="#1259e0"/><rect x="19" y="1" width="4" height="22" rx="2" fill="#7c3aed"/></svg>o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/" aria-current="page">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>

--- a/site/otlpkit-docs/index.html
+++ b/site/otlpkit-docs/index.html
@@ -20,7 +20,7 @@
     <div class="ambient" aria-hidden="true"></div>
     <main id="main-content" class="page">
       <header class="topbar panel">
-        <a class="brand" href="/o11ykit/"><svg class="brand-mark" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="1" y="16" width="4" height="7" rx="2" fill="#e85d1a"/><rect x="7" y="11" width="4" height="12" rx="2" fill="#058d75"/><rect x="13" y="6" width="4" height="17" rx="2" fill="#1259e0"/><rect x="19" y="1" width="4" height="22" rx="2" fill="#7c3aed"/></svg>o11ykit</a>
+        <a class="brand" href="/o11ykit/"><img class="brand-mark" src="../logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/" aria-current="page">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>

--- a/site/styles.css
+++ b/site/styles.css
@@ -74,12 +74,39 @@ body {
 }
 
 .brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   color: var(--ink);
   text-decoration: none;
   font-size: 18px;
   font-weight: 700;
   letter-spacing: -0.03em;
   font-family: var(--mono);
+}
+
+.brand-mark {
+  flex-shrink: 0;
+}
+
+/* ─── Hero logo lockup ─────────────────────────────────────────────── */
+.hero-lockup {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 6px;
+}
+
+.hero-mark {
+  flex-shrink: 0;
+}
+
+.hero-lockup .hero-name {
+  font-family: var(--mono);
+  font-size: clamp(28px, 4vw, 42px);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  color: var(--ink);
 }
 
 .topnav {

--- a/site/tsdb-engine/index.html
+++ b/site/tsdb-engine/index.html
@@ -9,6 +9,7 @@
       content="Interactive documentation for o11ytsdb: a browser-native TSDB with XOR-delta compression, pluggable storage backends, and real-time query engine. Generate millions of data points and query them live."
     />
     <meta name="theme-color" content="#0a1624" />
+    <link rel="icon" href="/o11ykit/logo.svg" type="image/svg+xml" />
     <meta property="og:title" content="o11ytsdb — Browser-Native Time-Series Database Engine" />
     <meta property="og:description" content="Interactive documentation for o11ytsdb, a browser-native time-series database with ALP compression, Gorilla encoding, and real-time querying." />
     <meta property="og:type" content="website" />
@@ -34,7 +35,7 @@
 
       <!-- ─── Top Bar ─────────────────────────────────────────── -->
       <header class="topbar panel">
-        <a class="brand" href="/o11ykit/">o11ykit</a>
+        <a class="brand" href="/o11ykit/"><svg class="brand-mark" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="1" y="16" width="4" height="7" rx="2" fill="#e85d1a"/><rect x="7" y="11" width="4" height="12" rx="2" fill="#058d75"/><rect x="13" y="6" width="4" height="17" rx="2" fill="#1259e0"/><rect x="19" y="1" width="4" height="22" rx="2" fill="#7c3aed"/></svg>o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/" aria-current="page">TSDB Engine</a>

--- a/site/tsdb-engine/index.html
+++ b/site/tsdb-engine/index.html
@@ -35,7 +35,7 @@
 
       <!-- ─── Top Bar ─────────────────────────────────────────── -->
       <header class="topbar panel">
-        <a class="brand" href="/o11ykit/"><svg class="brand-mark" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="1" y="16" width="4" height="7" rx="2" fill="#e85d1a"/><rect x="7" y="11" width="4" height="12" rx="2" fill="#058d75"/><rect x="13" y="6" width="4" height="17" rx="2" fill="#1259e0"/><rect x="19" y="1" width="4" height="22" rx="2" fill="#7c3aed"/></svg>o11ykit</a>
+        <a class="brand" href="/o11ykit/"><img class="brand-mark" src="/o11ykit/logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/" aria-current="page">TSDB Engine</a>


### PR DESCRIPTION
## Branding cleanup

Adds the o11ykit logo mark (4 rising bars in product accent colors) across the site.

### Changes
- **`site/logo.svg`** — New logo mark: 4 bars in otlp orange → octo teal → bench blue → tsdb violet
- **Nav bar** (all 5 pages) — Inline 20×20 SVG mark next to "o11ykit" text
- **Homepage hero** — Large 48×48 logo lockup with styled name above the headline
- **Favicon** — SVG favicon link added to all pages
- **Meta tags** — `theme-color` added to otlpkit-docs, octo11y, and benchkit pages (homepage + tsdb already had it)
- **CSS** — `.brand` updated to flexbox for mark alignment; new `.hero-lockup`, `.hero-mark`, `.brand-mark` classes

### Files changed
| File | What |
|------|------|
| `site/logo.svg` | New logo asset |
| `site/styles.css` | Brand + hero-lockup styles |
| `site/index.html` | Nav logo + hero lockup |
| `site/otlpkit-docs/index.html` | Nav logo + favicon + theme-color |
| `site/octo11y/index.html` | Nav logo + favicon + theme-color |
| `site/benchkit/index.html` | Nav logo + favicon + theme-color |
| `site/tsdb-engine/index.html` | Nav logo + favicon |