### PR TITLE
chore(o11y-codec-rt): polish — lift ms_to_ns, drop dead test_lock, PLAN cleanup

### DIFF
--- a/packages/o11y-codec-rt/core/src/lib.rs
+++ b/packages/o11y-codec-rt/core/src/lib.rs
@@ -270,6 +270,47 @@ pub fn extract_packed_safe(buf: &[u8], i: usize, bw: u8) -> u64 {
     (raw << bit_pos) >> (64 - bw)
 }
 
+// ── OTLP timestamp normalization ─────────────────────────────────────
+
+/// Convert an array of f64 millisecond timestamps to i64 nanoseconds.
+/// Used by both engines when normalizing OTLP timestamps. The wasm32
+/// build uses SIMD (`f64x2_mul`); other targets use a scalar loop.
+///
+/// Caller guarantees `input.len() == output.len()`.
+pub fn ms_to_ns(input: &[f64], output: &mut [i64]) {
+    debug_assert_eq!(input.len(), output.len());
+    let n = input.len();
+    if n == 0 {
+        return;
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        use core::arch::wasm32::*;
+        let pairs = n / 2;
+        let scale = f64x2_splat(1_000_000.0);
+        for i in 0..pairs {
+            let idx = i * 2;
+            let v = unsafe { v128_load(input.as_ptr().add(idx) as *const v128) };
+            let scaled = f64x2_mul(v, scale);
+            let a = f64x2_extract_lane::<0>(scaled) as i64;
+            let b = f64x2_extract_lane::<1>(scaled) as i64;
+            let result = i64x2_replace_lane::<1>(i64x2_splat(a), b);
+            unsafe {
+                v128_store(output.as_mut_ptr().add(idx) as *mut v128, result);
+            }
+        }
+        if n % 2 != 0 {
+            output[n - 1] = (input[n - 1] * 1_000_000.0) as i64;
+        }
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        for i in 0..n {
+            output[i] = (input[i] * 1_000_000.0) as i64;
+        }
+    }
+}
+
 // ── Tests ────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -540,5 +581,48 @@ mod tests {
         let buf = [0b10100000u8];
         let got = extract_packed_safe(&buf, 0, 3);
         assert_eq!(got, 0b101);
+    }
+
+    // ── ms_to_ns ─────────────────────────────────────────────────────
+
+    #[test]
+    fn ms_to_ns_basic() {
+        let input = [1000.0, 1500.5, 0.0, 2.0];
+        let mut output = [0i64; 4];
+        ms_to_ns(&input, &mut output);
+        assert_eq!(output, [1_000_000_000, 1_500_500_000, 0, 2_000_000]);
+    }
+
+    #[test]
+    fn ms_to_ns_single_and_odd() {
+        let mut out = [0i64; 1];
+        ms_to_ns(&[42.0], &mut out);
+        assert_eq!(out[0], 42_000_000);
+        let mut out3 = [0i64; 3];
+        ms_to_ns(&[1.0, 2.0, 3.0], &mut out3);
+        assert_eq!(out3, [1_000_000, 2_000_000, 3_000_000]);
+    }
+
+    #[test]
+    fn ms_to_ns_negative() {
+        let mut out = [0i64; 1];
+        ms_to_ns(&[-100.0], &mut out);
+        assert_eq!(out[0], -100_000_000);
+    }
+
+    #[test]
+    fn ms_to_ns_empty_is_noop() {
+        let mut out: [i64; 0] = [];
+        ms_to_ns(&[], &mut out);
+    }
+
+    #[test]
+    fn ms_to_ns_large_array() {
+        let input: std::vec::Vec<f64> = (0..1000).map(|i| i as f64).collect();
+        let mut output = std::vec![0i64; 1000];
+        ms_to_ns(&input, &mut output);
+        for i in 0..1000 {
+            assert_eq!(output[i], (i as i64) * 1_000_000);
+        }
     }
 }

--- a/packages/o11ylogsdb/PLAN.md
+++ b/packages/o11ylogsdb/PLAN.md
@@ -225,7 +225,9 @@ the M1-only baseline; the current shipped binary is 18 KB gzipped.
 | `o11ylogsdb-rust.wasm` | 50 KB | **<25 KB** | Combined cdylib of FSST + Roaring-lite + binary-fuse + in-house Drain currently builds to 21 KB gz; budget includes headroom. |
 | `o11ytracesdb-rust.wasm` (future) | 50 KB | <25 KB | Similar codec stack minus Drain. |
 
-Per-engine budget enforced in CI. Overshooting blocks merge.
+Per-engine budget tracked manually for now (each codec-workspace PR
+reports its size delta in the PR body). A proper CI gate is a
+follow-up.
 
 Measurements validated:
 

--- a/packages/o11ytsdb/rust/src/batch.rs
+++ b/packages/o11ytsdb/rust/src/batch.rs
@@ -211,7 +211,6 @@ mod tests {
 
     #[test]
     fn batch_xor_single_array() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let vals: [f64; 10] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
         let mut out = [0u8; 1024];
         let mut offsets = [0u32; 1];
@@ -240,7 +239,6 @@ mod tests {
 
     #[test]
     fn batch_xor_multiple_arrays() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let cs = 10;
         let mut vals = [0f64; 30];
         for i in 0..30 {
@@ -269,7 +267,6 @@ mod tests {
 
     #[test]
     fn batch_alp_single_array() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let vals: std::vec::Vec<f64> = (0..100).map(|i| (i as f64) * 0.01).collect();
         let mut out = [0u8; 4096];
         let mut offsets = [0u32; 1];
@@ -294,7 +291,6 @@ mod tests {
 
     #[test]
     fn batch_alp_counter_uses_delta() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let vals: std::vec::Vec<f64> = (0..640).map(|i| (i * 100) as f64).collect();
         let mut out = [0u8; 65536];
         let mut offsets = [0u32; 1];
@@ -321,7 +317,6 @@ mod tests {
 
     #[test]
     fn batch_xor_stats_fields() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let vals = [1.0f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let mut out = [0u8; 4096];
         let mut offsets = [0u32; 1];
@@ -342,7 +337,6 @@ mod tests {
 
     #[test]
     fn batch_alp_stats_fields() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let vals: std::vec::Vec<f64> = (0..100).map(|i| i as f64 * 0.01).collect();
         let mut out = [0u8; 65536];
         let mut offsets = [0u32; 1];
@@ -360,7 +354,6 @@ mod tests {
 
     #[test]
     fn batch_xor_decode_roundtrip() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let cs: usize = 8;
         let vals = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
                     10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0];
@@ -385,7 +378,6 @@ mod tests {
 
     #[test]
     fn batch_alp_decode_roundtrip() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let cs: usize = 50;
         let vals: std::vec::Vec<f64> = (0..100).map(|i| i as f64 * 0.1).collect();
         let mut out = [0u8; 65536];

--- a/packages/o11ytsdb/rust/src/range_decode.rs
+++ b/packages/o11ytsdb/rust/src/range_decode.rs
@@ -108,7 +108,6 @@ mod tests {
 
     #[test]
     fn lower_bound_basic() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let buf = [10i64, 20, 30, 40, 50];
         assert_eq!(lower_bound_i64(&buf, 5, 10), 0);
         assert_eq!(lower_bound_i64(&buf, 5, 25), 2);
@@ -119,7 +118,6 @@ mod tests {
 
     #[test]
     fn upper_bound_basic() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let buf = [10i64, 20, 30, 40, 50];
         assert_eq!(upper_bound_i64(&buf, 5, 10), 1);
         assert_eq!(upper_bound_i64(&buf, 5, 25), 2);
@@ -129,7 +127,6 @@ mod tests {
 
     #[test]
     fn lower_upper_bound_duplicates() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let buf = [10i64, 20, 20, 20, 30];
         assert_eq!(lower_bound_i64(&buf, 5, 20), 1); // first 20
         assert_eq!(upper_bound_i64(&buf, 5, 20), 4); // past last 20
@@ -137,7 +134,6 @@ mod tests {
 
     #[test]
     fn range_decode_full() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let n = 100;
         let ts: std::vec::Vec<i64> = (0..n).map(|i| 1000 + i * 15).collect();
         let vals: std::vec::Vec<f64> = (0..n).map(|i| (i as f64) * 0.1).collect();
@@ -168,7 +164,6 @@ mod tests {
 
     #[test]
     fn range_decode_partial() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let n = 100;
         let ts: std::vec::Vec<i64> = (0..n).map(|i| 1000 + i * 15).collect();
         let vals: std::vec::Vec<f64> = (0..n).map(|i| (i as f64) * 0.1).collect();
@@ -195,7 +190,6 @@ mod tests {
 
     #[test]
     fn range_decode_no_match() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let ts: [i64; 5] = [100, 200, 300, 400, 500];
         let vals = [1.0f64; 5];
 
@@ -218,7 +212,6 @@ mod tests {
 
     #[test]
     fn range_decode_single_match() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let ts: [i64; 5] = [100, 200, 300, 400, 500];
         let vals: [f64; 5] = [1.0, 2.0, 3.0, 4.0, 5.0];
 
@@ -243,7 +236,6 @@ mod tests {
 
     #[test]
     fn range_decode_boundary_timestamps() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         // Encode a chunk with known timestamps.
         let ts: std::vec::Vec<i64> = (0..100).map(|i| 1000i64 + i * 10).collect();
         let vals: std::vec::Vec<f64> = (0..100).map(|i| i as f64 * 0.1).collect();

--- a/packages/o11ytsdb/rust/src/simd.rs
+++ b/packages/o11ytsdb/rust/src/simd.rs
@@ -1,50 +1,20 @@
-// ── SIMD accelerators: msToNs, quantizeBatch ────────────────────────
+// ── SIMD-accelerated extern "C" shims ───────────────────────────────
 //
-// WASM SIMD-accelerated bulk transforms:
-//   - msToNs: convert f64 millisecond timestamps to i64 nanoseconds
-//   - quantizeBatch: round f64 values to a given decimal precision
+// `msToNs` is the OTLP timestamp normalization (ms→ns) that both
+// engines need; the pure logic lives in `o11y-codec-rt-core` and
+// this file just marshals raw pointers. `quantizeBatch` is metric-
+// specific (round to decimal precision) and stays here.
 
-/// Convert an array of f64 millisecond timestamps to i64 nanosecond timestamps.
-/// Uses SIMD i64x2_mul to process 2 timestamps per iteration.
+/// Convert an array of f64 millisecond timestamps to i64 nanoseconds.
 #[no_mangle]
 pub extern "C" fn msToNs(in_ptr: *const f64, out_ptr: *mut i64, count: u32) {
     if count == 0 {
         return;
     }
-    #[cfg(target_arch = "wasm32")]
-    {
-        use core::arch::wasm32::*;
-        let n = count as usize;
-        let input = unsafe { core::slice::from_raw_parts(in_ptr, n) };
-        let output = unsafe { core::slice::from_raw_parts_mut(out_ptr, n) };
-
-        let pairs = n / 2;
-        let scale = f64x2_splat(1_000_000.0);
-        for i in 0..pairs {
-            let idx = i * 2;
-            let v = unsafe { v128_load(input.as_ptr().add(idx) as *const v128) };
-            let scaled = f64x2_mul(v, scale);
-            let a = f64x2_extract_lane::<0>(scaled) as i64;
-            let b = f64x2_extract_lane::<1>(scaled) as i64;
-            let result = i64x2_replace_lane::<1>(i64x2_splat(a), b);
-            unsafe {
-                v128_store(output.as_mut_ptr().add(idx) as *mut v128, result);
-            }
-        }
-        if n % 2 != 0 {
-            output[n - 1] = (input[n - 1] * 1_000_000.0) as i64;
-        }
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        let n = count as usize;
-        let input = unsafe { core::slice::from_raw_parts(in_ptr, n) };
-        let output = unsafe { core::slice::from_raw_parts_mut(out_ptr, n) };
-        for i in 0..n {
-            output[i] = (input[i] * 1_000_000.0) as i64;
-        }
-    }
+    let n = count as usize;
+    let input = unsafe { core::slice::from_raw_parts(in_ptr, n) };
+    let output = unsafe { core::slice::from_raw_parts_mut(out_ptr, n) };
+    o11y_codec_rt_core::ms_to_ns(input, output);
 }
 
 /// Quantize an array of f64 values to a given decimal precision.
@@ -192,7 +162,6 @@ mod tests {
 
     #[test]
     fn ms_to_ns_large_array() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let input: std::vec::Vec<f64> = (0..1000).map(|i| i as f64).collect();
         let mut output = std::vec![0i64; 1000];
         msToNs(input.as_ptr(), output.as_mut_ptr(), 1000);
@@ -203,7 +172,6 @@ mod tests {
 
     #[test]
     fn quantize_batch_large_scale() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let input = [123456.789f64, 0.001234, 999.9995, 0.0];
         let mut output = [0f64; 4];
         quantizeBatch(input.as_ptr(), output.as_mut_ptr(), 4, 100.0); // 2 decimals
@@ -214,7 +182,6 @@ mod tests {
 
     #[test]
     fn quantize_batch_negative_values() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
         let input = [-1.5f64, -0.005, -100.999];
         let mut output = [0f64; 3];
         quantizeBatch(input.as_ptr(), output.as_mut_ptr(), 3, 10.0); // 1 decimal


### PR DESCRIPTION
## Summary

Three small follow-ups after the M0 codec workspace migration is substantially complete.

1. **Lift \`ms_to_ns\` to \`o11y-codec-rt-core\`.** Both engines need OTLP timestamp normalization (ms → ns), and it was a pure slice-in / slice-out function. Wasm32 SIMD fast path preserved. \`o11ytsdb/rust/src/simd.rs\`'s \`msToNs\` becomes a thin extern "C" shim. 5 unit tests moved with it.

2. **Drop \`crate::test_lock::LOCK\` from tests** in \`batch.rs\`, \`range_decode.rs\`, and \`simd.rs\`. The lock existed to serialize tests that touched process-global \`static mut\` ALP scratch buffers. After the M0 body lift replaced those with stack-locals, those test sites no longer need serialization. Locks **remain** in \`alloc.rs\` (touches \`ALP_EXC_MODE\` atomic) and \`interner.rs\` (still has \`static mut INTERN_*\`).

3. **Soften PLAN.md** — replace "per-engine budget enforced in CI. Overshooting blocks merge." with "tracked manually for now (each codec-workspace PR reports its size delta in the PR body)". A proper CI gate is a follow-up.

## Verification

| Test suite | Count |
|---|--:|
| \`o11y-codec-rt-core\` | 24 ✅ (was 19, +5 for ms_to_ns) |
| \`o11y-codec-rt-xor-delta\` | 26 ✅ |
| \`o11y-codec-rt-alp\` | 39 ✅ |
| \`o11ytsdb-wasm\` | 41 ✅ |
| Repo TS suite | 561 ✅ |
| typecheck + biome | clean |

## Wasm size

\`o11ytsdb-rust.wasm\`: 2,143,421 raw / 18,350 gz — unchanged within noise vs PR #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)