### PR TITLE
feat(o11y-codec-rt): lift string interner into workspace crate

### DIFF
--- a/packages/o11y-codec-rt/Cargo.lock
+++ b/packages/o11y-codec-rt/Cargo.lock
@@ -14,6 +14,10 @@ name = "o11y-codec-rt-core"
 version = "0.0.1"
 
 [[package]]
+name = "o11y-codec-rt-interner"
+version = "0.0.1"
+
+[[package]]
 name = "o11y-codec-rt-xor-delta"
 version = "0.0.1"
 dependencies = [

--- a/packages/o11y-codec-rt/Cargo.toml
+++ b/packages/o11y-codec-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["core", "xor-delta", "alp"]
+members = ["core", "xor-delta", "alp", "interner"]
 
 # Shared codec runtime for o11ykit engines. Each engine's binding crate
 # (packages/o11ytsdb/rust, packages/o11ylogsdb/rust, …) depends on the

--- a/packages/o11y-codec-rt/interner/Cargo.toml
+++ b/packages/o11y-codec-rt/interner/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "o11y-codec-rt-interner"
+version = "0.0.1"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+
+# String interner: FNV-1a hash + linear probing. Pure-Rust, no_std,
+# no allocator — buffers are borrowed from the caller. The host engine
+# (o11ytsdb metric names + label keys/values; o11ylogsdb attribute
+# keys, body templates, stream-registry interning) supplies storage
+# of whatever capacity it wants.
+
+[lib]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/packages/o11y-codec-rt/interner/src/lib.rs
+++ b/packages/o11y-codec-rt/interner/src/lib.rs
@@ -1,0 +1,397 @@
+//! o11y-codec-rt-interner — string interner.
+//!
+//! FNV-1a hash + open-addressing linear probing. The host engine
+//! supplies the four backing buffers and the two scalar counters:
+//! a byte arena for the strings themselves, a parallel offsets table
+//! that delimits each interned string, and a hash-table pair (slots
+//! + parallel hash array) for lookup.
+//!
+//! Why borrow rather than allocate: the workspace is `#![no_std]`
+//! with no allocator, and the engines that consume the interner
+//! already own static-mut storage sized to their workload (metric
+//! cardinality for `o11ytsdb`, log-attribute cardinality for
+//! `o11ylogsdb`). Borrowing keeps the codec runtime allocator-free
+//! and lets each engine pick its own capacity.
+//!
+//! Safety: the four buffers must be of the right shapes:
+//!
+//!   - `bytes`: arbitrary length (capacity for the string arena);
+//!   - `offsets`: `max_strings + 1` entries — one per string, plus a
+//!     trailing sentinel that holds `bytes_used` so each string's
+//!     length is `offsets[i+1] - offsets[i]`;
+//!   - `table` and `hashes`: equal length, must be a power of two.
+//!
+//! `Interner::new` validates the shapes and returns `None` on a
+//! mismatch. Single-threaded use only — no internal synchronization.
+
+#![cfg_attr(not(test), no_std)]
+
+/// Sentinel for an empty hash-table slot. Exposed so callers can
+/// initialize their `table` storage to the right value.
+pub const EMPTY: u32 = u32::MAX;
+
+#[inline(always)]
+pub fn fnv1a32(bytes: &[u8]) -> u32 {
+    let mut hash: u32 = 0x811c9dc5;
+    for &b in bytes {
+        hash ^= b as u32;
+        hash = hash.wrapping_mul(0x01000193);
+    }
+    hash
+}
+
+/// Borrowed view of an interner. Construct with `Interner::new` and
+/// call `intern` / `resolve` / `reset`. The struct itself holds no
+/// data — all state lives in the host's buffers.
+pub struct Interner<'a> {
+    /// Byte arena. Strings are written sequentially.
+    bytes: &'a mut [u8],
+    /// `offsets[i]` = start byte of string `i`; `offsets[i+1]` = end.
+    offsets: &'a mut [u32],
+    /// Hash-table slots: each entry is either `EMPTY` or a string id.
+    /// Length must be a power of two.
+    table: &'a mut [u32],
+    /// Parallel array of full hashes for collision distinguishing.
+    /// Same length as `table`.
+    hashes: &'a mut [u32],
+    /// Number of interned strings (next id to assign).
+    count: &'a mut u32,
+    /// Bytes used in `bytes`; offsets's first slot equals 0 at empty.
+    bytes_used: &'a mut u32,
+}
+
+impl<'a> Interner<'a> {
+    /// Build a new interner over caller-owned buffers. Returns
+    /// `None` if the shapes don't match the documented invariants
+    /// (table length not a power of two, offsets too short, etc.).
+    ///
+    /// Does *not* clear the buffers — the caller is responsible for
+    /// calling [`reset`](Self::reset) to initialize a fresh interner,
+    /// or for restoring previously-saved state.
+    pub fn new(
+        bytes: &'a mut [u8],
+        offsets: &'a mut [u32],
+        table: &'a mut [u32],
+        hashes: &'a mut [u32],
+        count: &'a mut u32,
+        bytes_used: &'a mut u32,
+    ) -> Option<Self> {
+        if offsets.len() < 2 {
+            return None;
+        }
+        if table.len() != hashes.len() || !table.len().is_power_of_two() {
+            return None;
+        }
+        Some(Self { bytes, offsets, table, hashes, count, bytes_used })
+    }
+
+    /// Maximum strings this interner can hold (`offsets.len() - 1`).
+    pub fn max_strings(&self) -> usize {
+        self.offsets.len() - 1
+    }
+
+    /// Capacity of the byte arena.
+    pub fn bytes_capacity(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Number of interned strings so far.
+    pub fn count(&self) -> u32 {
+        *self.count
+    }
+
+    /// Bytes used in the arena so far.
+    pub fn bytes_used(&self) -> u32 {
+        *self.bytes_used
+    }
+
+    /// Clear all state. Required before first use, or to recycle.
+    pub fn reset(&mut self) {
+        *self.count = 0;
+        *self.bytes_used = 0;
+        self.offsets[0] = 0;
+        for slot in self.table.iter_mut() {
+            *slot = EMPTY;
+        }
+        for h in self.hashes.iter_mut() {
+            *h = 0;
+        }
+    }
+
+    /// Intern `key`. Returns the assigned (or pre-existing) id, or
+    /// `None` if either the string-count or byte-arena capacity is
+    /// exhausted.
+    ///
+    /// `key` may be empty — empty strings get a stable id like any
+    /// other.
+    pub fn intern(&mut self, key: &[u8]) -> Option<u32> {
+        let hash = fnv1a32(key);
+        let mask = (self.table.len() - 1) as u32;
+        let mut slot = hash & mask;
+
+        loop {
+            let existing = self.table[slot as usize];
+            if existing == EMPTY {
+                let id = *self.count;
+                if id as usize >= self.max_strings() {
+                    return None;
+                }
+                let start = *self.bytes_used as usize;
+                let end = start + key.len();
+                if end > self.bytes.len() {
+                    return None;
+                }
+                self.bytes[start..end].copy_from_slice(key);
+                self.offsets[id as usize] = *self.bytes_used;
+                *self.bytes_used = end as u32;
+                self.offsets[id as usize + 1] = *self.bytes_used;
+                self.table[slot as usize] = id;
+                self.hashes[slot as usize] = hash;
+                *self.count = id + 1;
+                return Some(id);
+            }
+            if self.hashes[slot as usize] == hash && self.equals(existing, key) {
+                return Some(existing);
+            }
+            slot = (slot + 1) & mask;
+        }
+    }
+
+    /// Resolve `id` to its byte slice. Returns `None` if `id` is
+    /// out of range.
+    pub fn resolve(&self, id: u32) -> Option<&[u8]> {
+        if id >= *self.count {
+            return None;
+        }
+        let start = self.offsets[id as usize] as usize;
+        let end = self.offsets[id as usize + 1] as usize;
+        Some(&self.bytes[start..end])
+    }
+
+    #[inline(always)]
+    fn equals(&self, id: u32, key: &[u8]) -> bool {
+        let start = self.offsets[id as usize] as usize;
+        let end = self.offsets[id as usize + 1] as usize;
+        if end - start != key.len() {
+            return false;
+        }
+        self.bytes[start..end] == *key
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The tests build a small interner over local buffers — no static
+    // state, so cargo test's parallel runner is fine.
+
+    fn fixture() -> (
+        std::vec::Vec<u8>,
+        std::vec::Vec<u32>,
+        std::vec::Vec<u32>,
+        std::vec::Vec<u32>,
+        u32,
+        u32,
+    ) {
+        // 1 KB arena, 64 strings max, 256-slot hash table (power of two).
+        let bytes = std::vec![0u8; 1024];
+        let offsets = std::vec![0u32; 65];
+        let table = std::vec![EMPTY; 256];
+        let hashes = std::vec![0u32; 256];
+        (bytes, offsets, table, hashes, 0u32, 0u32)
+    }
+
+    fn with_interner<F, R>(f: F) -> R
+    where
+        F: FnOnce(&mut Interner<'_>) -> R,
+    {
+        let (mut bytes, mut offsets, mut table, mut hashes, mut count, mut bytes_used) = fixture();
+        let mut interner = Interner::new(
+            &mut bytes,
+            &mut offsets,
+            &mut table,
+            &mut hashes,
+            &mut count,
+            &mut bytes_used,
+        )
+        .unwrap();
+        interner.reset();
+        f(&mut interner)
+    }
+
+    #[test]
+    fn intern_and_resolve_single() {
+        with_interner(|i| {
+            let id = i.intern(b"hello").unwrap();
+            assert_eq!(id, 0);
+            assert_eq!(i.resolve(id), Some(&b"hello"[..]));
+        });
+    }
+
+    #[test]
+    fn intern_deduplication() {
+        with_interner(|i| {
+            let id1 = i.intern(b"metric.cpu").unwrap();
+            let id2 = i.intern(b"metric.cpu").unwrap();
+            assert_eq!(id1, id2);
+            assert_eq!(i.count(), 1);
+        });
+    }
+
+    #[test]
+    fn intern_distinct_strings() {
+        with_interner(|i| {
+            let id1 = i.intern(b"alpha").unwrap();
+            let id2 = i.intern(b"beta").unwrap();
+            assert_ne!(id1, id2);
+            assert_eq!(i.resolve(id1), Some(&b"alpha"[..]));
+            assert_eq!(i.resolve(id2), Some(&b"beta"[..]));
+        });
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        with_interner(|i| {
+            i.intern(b"before").unwrap();
+            assert_eq!(i.count(), 1);
+            i.reset();
+            assert_eq!(i.count(), 0);
+            assert_eq!(i.resolve(0), None);
+            let id = i.intern(b"after").unwrap();
+            assert_eq!(id, 0);
+            assert_eq!(i.resolve(id), Some(&b"after"[..]));
+        });
+    }
+
+    #[test]
+    fn intern_empty_string() {
+        with_interner(|i| {
+            let id = i.intern(b"").unwrap();
+            assert_eq!(id, 0);
+            assert_eq!(i.resolve(id), Some(&b""[..]));
+        });
+    }
+
+    #[test]
+    fn resolve_invalid_id() {
+        with_interner(|i| {
+            assert_eq!(i.resolve(0), None); // never interned
+            assert_eq!(i.resolve(999), None);
+        });
+    }
+
+    #[test]
+    fn intern_many_strings() {
+        with_interner(|i| {
+            let mut ids = std::vec::Vec::new();
+            for n in 0u32..50 {
+                let s = std::format!("metric_{n:04}");
+                let id = i.intern(s.as_bytes()).unwrap();
+                ids.push((id, s));
+            }
+            for (id, s) in &ids {
+                assert_eq!(i.resolve(*id), Some(s.as_bytes()));
+            }
+            // Dedup on second pass.
+            for (id, s) in &ids {
+                assert_eq!(i.intern(s.as_bytes()).unwrap(), *id);
+            }
+        });
+    }
+
+    #[test]
+    fn intern_returns_none_at_string_capacity() {
+        // 4-string fixture: 0..3 succeed, 4th returns None.
+        let mut bytes = std::vec![0u8; 1024];
+        let mut offsets = std::vec![0u32; 5]; // 4 strings + sentinel
+        let mut table = std::vec![EMPTY; 16];
+        let mut hashes = std::vec![0u32; 16];
+        let mut count = 0u32;
+        let mut bytes_used = 0u32;
+        let mut i = Interner::new(
+            &mut bytes,
+            &mut offsets,
+            &mut table,
+            &mut hashes,
+            &mut count,
+            &mut bytes_used,
+        )
+        .unwrap();
+        i.reset();
+        assert_eq!(i.intern(b"a").unwrap(), 0);
+        assert_eq!(i.intern(b"b").unwrap(), 1);
+        assert_eq!(i.intern(b"c").unwrap(), 2);
+        assert_eq!(i.intern(b"d").unwrap(), 3);
+        assert_eq!(i.intern(b"e"), None);
+    }
+
+    #[test]
+    fn intern_returns_none_at_byte_capacity() {
+        // 8-byte arena: "hello" + "world" (5+5=10) busts the limit.
+        let mut bytes = std::vec![0u8; 8];
+        let mut offsets = std::vec![0u32; 4];
+        let mut table = std::vec![EMPTY; 8];
+        let mut hashes = std::vec![0u32; 8];
+        let mut count = 0u32;
+        let mut bytes_used = 0u32;
+        let mut i = Interner::new(
+            &mut bytes,
+            &mut offsets,
+            &mut table,
+            &mut hashes,
+            &mut count,
+            &mut bytes_used,
+        )
+        .unwrap();
+        i.reset();
+        assert_eq!(i.intern(b"hello").unwrap(), 0);
+        assert_eq!(i.intern(b"world"), None);
+    }
+
+    #[test]
+    fn new_rejects_non_power_of_two_table() {
+        let mut bytes = std::vec![0u8; 64];
+        let mut offsets = std::vec![0u32; 4];
+        let mut table = std::vec![EMPTY; 17]; // not power of two
+        let mut hashes = std::vec![0u32; 17];
+        let mut count = 0u32;
+        let mut bytes_used = 0u32;
+        let r = Interner::new(
+            &mut bytes,
+            &mut offsets,
+            &mut table,
+            &mut hashes,
+            &mut count,
+            &mut bytes_used,
+        );
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn new_rejects_table_hashes_length_mismatch() {
+        let mut bytes = std::vec![0u8; 64];
+        let mut offsets = std::vec![0u32; 4];
+        let mut table = std::vec![EMPTY; 16];
+        let mut hashes = std::vec![0u32; 32];
+        let mut count = 0u32;
+        let mut bytes_used = 0u32;
+        let r = Interner::new(
+            &mut bytes,
+            &mut offsets,
+            &mut table,
+            &mut hashes,
+            &mut count,
+            &mut bytes_used,
+        );
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn fnv1a_known_values() {
+        assert_eq!(fnv1a32(b""), 0x811c9dc5);
+        assert_ne!(fnv1a32(b"a"), fnv1a32(b"b"));
+    }
+}

--- a/packages/o11ylogsdb/PLAN.md
+++ b/packages/o11ylogsdb/PLAN.md
@@ -295,6 +295,10 @@ already live in `core/` (`extract_packed`, `BitWriter::write_bits`).
   `delta_alp_decode_range`, `decode_values_alp`, dispatcher.
   Scratch buffers stack-allocated (worst case ~50 KB on the wasm32
   1 MB stack). ✅
+- `packages/o11y-codec-rt/interner/` — string interner (FNV-1a hash +
+  open-addressing linear probing). `Interner<'a>` borrows caller-
+  supplied storage so the workspace stays `#![no_std]` / allocator-
+  free. Each engine sizes its own buffers. ✅
 - `packages/o11ytsdb/rust/Cargo.toml` depends on `core` + `xor-delta`
   + `alp`. ✅
 - `packages/o11ytsdb/rust/src/{gorilla,timestamp,delta_alp}.rs` reduced

--- a/packages/o11ytsdb/rust/Cargo.lock
+++ b/packages/o11ytsdb/rust/Cargo.lock
@@ -14,6 +14,10 @@ name = "o11y-codec-rt-core"
 version = "0.0.1"
 
 [[package]]
+name = "o11y-codec-rt-interner"
+version = "0.0.1"
+
+[[package]]
 name = "o11y-codec-rt-xor-delta"
 version = "0.0.1"
 dependencies = [
@@ -26,5 +30,6 @@ version = "0.0.1"
 dependencies = [
  "o11y-codec-rt-alp",
  "o11y-codec-rt-core",
+ "o11y-codec-rt-interner",
  "o11y-codec-rt-xor-delta",
 ]

--- a/packages/o11ytsdb/rust/Cargo.toml
+++ b/packages/o11ytsdb/rust/Cargo.toml
@@ -28,3 +28,4 @@ panic = "abort"      # No unwinding — smaller binary
 o11y-codec-rt-core = { path = "../../o11y-codec-rt/core" }
 o11y-codec-rt-xor-delta = { path = "../../o11y-codec-rt/xor-delta" }
 o11y-codec-rt-alp = { path = "../../o11y-codec-rt/alp" }
+o11y-codec-rt-interner = { path = "../../o11y-codec-rt/interner" }

--- a/packages/o11ytsdb/rust/src/interner.rs
+++ b/packages/o11ytsdb/rust/src/interner.rs
@@ -1,56 +1,45 @@
-// ── String interner: FNV-1a hash, linear probing ────────────────────
+// ── String interner extern "C" shims ────────────────────────────────
 //
-// WASM-side string deduplication for metric names and label keys/values.
-// Capacity: 200K unique strings, 8 MB total bytes, 512K hash table slots.
+// The pure-Rust interner lives in packages/o11y-codec-rt/interner/.
+// This file owns the WASM-side static-mut storage (8 MB byte arena,
+// 200K offset table, 512K hash table) that the workspace `Interner`
+// borrows on each call.
+
+use o11y_codec_rt_interner::{Interner, EMPTY};
 
 const INTERN_MAX_STRINGS: usize = 200_000;
 const INTERN_MAX_BYTES: usize = 8 * 1024 * 1024;
 const INTERN_TABLE_SIZE: usize = 1 << 19;
-const INTERN_EMPTY: u32 = u32::MAX;
 
 static mut INTERN_BYTES: [u8; INTERN_MAX_BYTES] = [0; INTERN_MAX_BYTES];
 static mut INTERN_OFFSETS: [u32; INTERN_MAX_STRINGS + 1] = [0; INTERN_MAX_STRINGS + 1];
-static mut INTERN_TABLE: [u32; INTERN_TABLE_SIZE] = [INTERN_EMPTY; INTERN_TABLE_SIZE];
+static mut INTERN_TABLE: [u32; INTERN_TABLE_SIZE] = [EMPTY; INTERN_TABLE_SIZE];
 static mut INTERN_HASHES: [u32; INTERN_TABLE_SIZE] = [0; INTERN_TABLE_SIZE];
 static mut INTERN_COUNT: u32 = 0;
 static mut INTERN_BYTES_USED: u32 = 0;
 
-#[inline(always)]
-fn fnv1a32(bytes: &[u8]) -> u32 {
-    let mut hash: u32 = 0x811c9dc5;
-    for &b in bytes {
-        hash ^= b as u32;
-        hash = hash.wrapping_mul(0x01000193);
+/// Build an `Interner` borrowing the static-mut backing store. Single-
+/// threaded use only — wasm32 cdylib runs single-threaded by design.
+#[allow(static_mut_refs)]
+fn with_interner<R>(f: impl FnOnce(&mut Interner<'_>) -> R) -> R {
+    // SAFETY: single-threaded WASM cdylib; one borrow at a time per call.
+    let mut interner = unsafe {
+        Interner::new(
+            &mut INTERN_BYTES,
+            &mut INTERN_OFFSETS,
+            &mut INTERN_TABLE,
+            &mut INTERN_HASHES,
+            &mut INTERN_COUNT,
+            &mut INTERN_BYTES_USED,
+        )
     }
-    hash
-}
-
-#[inline(always)]
-unsafe fn intern_equals(id: u32, bytes: &[u8]) -> bool {
-    let start = INTERN_OFFSETS[id as usize] as usize;
-    let end = INTERN_OFFSETS[id as usize + 1] as usize;
-    if end - start != bytes.len() {
-        return false;
-    }
-    for i in 0..bytes.len() {
-        if INTERN_BYTES[start + i] != bytes[i] {
-            return false;
-        }
-    }
-    true
+    .expect("interner buffer shapes are statically valid");
+    f(&mut interner)
 }
 
 #[no_mangle]
 pub extern "C" fn internerReset() {
-    unsafe {
-        INTERN_COUNT = 0;
-        INTERN_BYTES_USED = 0;
-        INTERN_OFFSETS[0] = 0;
-        for i in 0..INTERN_TABLE_SIZE {
-            INTERN_TABLE[i] = INTERN_EMPTY;
-            INTERN_HASHES[i] = 0;
-        }
-    }
+    with_interner(|i| i.reset());
 }
 
 #[no_mangle]
@@ -59,38 +48,7 @@ pub extern "C" fn internerIntern(ptr: *const u8, len: u32) -> u32 {
         return u32::MAX;
     }
     let input = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
-    let hash = fnv1a32(input);
-    let mask = (INTERN_TABLE_SIZE - 1) as u32;
-    let mut slot = hash & mask;
-
-    unsafe {
-        loop {
-            let existing = INTERN_TABLE[slot as usize];
-            if existing == INTERN_EMPTY {
-                let id = INTERN_COUNT;
-                if id as usize >= INTERN_MAX_STRINGS {
-                    return u32::MAX;
-                }
-                let start = INTERN_BYTES_USED as usize;
-                let end = start + input.len();
-                if end > INTERN_MAX_BYTES {
-                    return u32::MAX;
-                }
-                INTERN_BYTES[start..end].copy_from_slice(input);
-                INTERN_OFFSETS[id as usize] = INTERN_BYTES_USED;
-                INTERN_BYTES_USED = end as u32;
-                INTERN_OFFSETS[id as usize + 1] = INTERN_BYTES_USED;
-                INTERN_TABLE[slot as usize] = id;
-                INTERN_HASHES[slot as usize] = hash;
-                INTERN_COUNT += 1;
-                return id;
-            }
-            if INTERN_HASHES[slot as usize] == hash && intern_equals(existing, input) {
-                return existing;
-            }
-            slot = (slot + 1) & mask;
-        }
-    }
+    with_interner(|i| i.intern(input).unwrap_or(u32::MAX))
 }
 
 #[no_mangle]
@@ -98,20 +56,18 @@ pub extern "C" fn internerResolve(id: u32, out_ptr: *mut u8, out_cap: u32) -> u3
     if out_ptr.is_null() {
         return 0;
     }
-    unsafe {
-        if id >= INTERN_COUNT {
-            return 0;
+    with_interner(|i| match i.resolve(id) {
+        Some(bytes) => {
+            if bytes.len() > out_cap as usize {
+                return 0;
+            }
+            // SAFETY: caller-supplied pointer with a declared capacity.
+            let out = unsafe { core::slice::from_raw_parts_mut(out_ptr, bytes.len()) };
+            out.copy_from_slice(bytes);
+            bytes.len() as u32
         }
-        let start = INTERN_OFFSETS[id as usize] as usize;
-        let end = INTERN_OFFSETS[id as usize + 1] as usize;
-        let len = end - start;
-        if len > out_cap as usize {
-            return 0;
-        }
-        let out = core::slice::from_raw_parts_mut(out_ptr, len);
-        out.copy_from_slice(&INTERN_BYTES[start..end]);
-        len as u32
-    }
+        None => 0,
+    })
 }
 
 // ── Tests ────────────────────────────────────────────────────────────
@@ -146,7 +102,7 @@ mod tests {
         internerReset();
         let id1 = reset_and_intern(b"metric.cpu");
         let id2 = reset_and_intern(b"metric.cpu");
-        assert_eq!(id1, id2, "same string should return same id");
+        assert_eq!(id1, id2);
     }
 
     #[test]
@@ -161,34 +117,10 @@ mod tests {
     }
 
     #[test]
-    fn intern_reset_clears_state() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
-        internerReset();
-        reset_and_intern(b"before_reset");
-        internerReset();
-        // After reset, resolving id 0 should fail.
-        let len = internerResolve(0, [0u8; 64].as_mut_ptr(), 64);
-        assert_eq!(len, 0);
-        // New intern should get id 0.
-        let id = reset_and_intern(b"after_reset");
-        assert_eq!(id, 0);
-        assert_eq!(resolve_to_vec(id), b"after_reset");
-    }
-
-    #[test]
     fn intern_null_ptr_returns_max() {
         let _g = crate::test_lock::LOCK.lock().unwrap();
         let id = internerIntern(core::ptr::null(), 5);
         assert_eq!(id, u32::MAX);
-    }
-
-    #[test]
-    fn resolve_invalid_id() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
-        internerReset();
-        let mut buf = [0u8; 64];
-        let len = internerResolve(999, buf.as_mut_ptr(), 64);
-        assert_eq!(len, 0);
     }
 
     #[test]
@@ -199,43 +131,10 @@ mod tests {
     }
 
     #[test]
-    fn intern_empty_string() {
+    fn resolve_invalid_id() {
         let _g = crate::test_lock::LOCK.lock().unwrap();
         internerReset();
-        let id = reset_and_intern(b"");
-        assert_eq!(id, 0);
-        assert_eq!(resolve_to_vec(id), b"");
-    }
-
-    #[test]
-    fn intern_many_strings() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
-        internerReset();
-        let mut ids = std::vec::Vec::new();
-        for i in 0u32..100 {
-            let s = std::format!("metric_{i:04}");
-            let id = internerIntern(s.as_ptr(), s.len() as u32);
-            assert_ne!(id, u32::MAX);
-            ids.push((id, s));
-        }
-        // Verify all resolve correctly.
-        for (id, s) in &ids {
-            assert_eq!(resolve_to_vec(*id), s.as_bytes());
-        }
-        // Verify dedup — intern same strings again.
-        for (id, s) in &ids {
-            let id2 = internerIntern(s.as_ptr(), s.len() as u32);
-            assert_eq!(*id, id2);
-        }
-    }
-
-    #[test]
-    fn fnv1a32_basic() {
-        let _g = crate::test_lock::LOCK.lock().unwrap();
-        // Known FNV-1a values.
-        assert_eq!(fnv1a32(b""), 0x811c9dc5);
-        let h1 = fnv1a32(b"a");
-        let h2 = fnv1a32(b"b");
-        assert_ne!(h1, h2, "different inputs should hash differently");
+        let len = internerResolve(999, [0u8; 64].as_mut_ptr(), 64);
+        assert_eq!(len, 0);
     }
 }


### PR DESCRIPTION
## Summary

Beyond M0 — \`o11ylogsdb\` will need string interning soon (stream registry, attribute keys, body templates), and the existing o11ytsdb interner is a clean primitive worth sharing.

**Approach:** workspace crate exposes an \`Interner<'a>\` struct that **borrows** caller-supplied storage (4 buffers + 2 scalar counts). The crate stays \`#![no_std]\` and allocator-free; each engine supplies storage of its own choice of capacity. The o11ytsdb binding retains its \`static mut\` arrays sized for metric workloads (200 K strings, 8 MB byte arena, 512 K-slot table) and constructs an \`Interner\` view on each call.

## Workspace API

- \`Interner::new(bytes, offsets, table, hashes, count, bytes_used) -> Option<Self>\` — validates buffer shapes (table is a power of two, offsets has ≥ 2 entries, \`table.len() == hashes.len()\`).
- \`reset() / intern(&[u8]) -> Option<u32> / resolve(u32) -> Option<&[u8]>\`. Returns \`None\` when capacity is exhausted (rather than the \`u32::MAX\` sentinel — the binding shim translates back to the existing C ABI).
- \`fnv1a32\` exported for callers that want to hash directly.
- \`EMPTY: u32\` sentinel exposed so callers can initialize their hash-table slots.

## What stays in \`o11ytsdb/rust/\`

\`internerReset\` / \`internerIntern\` / \`internerResolve\` extern "C" exports — unchanged ABI. Implementation now delegates to the workspace crate via a tiny \`with_interner\` helper that constructs the borrowed view from the static-mut storage.

## Verification

| Test suite | Count |
|---|--:|
| \`o11y-codec-rt-core\` | 24 ✅ |
| \`o11y-codec-rt-xor-delta\` | 26 ✅ |
| \`o11y-codec-rt-alp\` | 39 ✅ |
| \`o11y-codec-rt-interner\` | **12 ✅** (new) |
| \`o11ytsdb-wasm\` | 37 ✅ (was 41; 4 dropped — workspace tests cover the same surface) |
| Repo TS suite | 561 ✅ |
| typecheck + biome | clean |

## Wasm size

\`o11ytsdb-rust.wasm\`: 2,144,387 raw / 18,738 gz. +966 raw / +388 gz vs PR #187. The borrowed-view abstraction adds a small fixed overhead the optimizer can't fully eliminate — still well under the <25 KB gz per-engine target.

| Cumulative vs pre-M0 baseline | Raw | Gz |
|---|---:|---:|
| 2,143,340 → 2,144,387 | +1,047 (+0.049%) | +594 (+3.27%) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)