### PR TITLE
fix(otlpjson): preserve empty string parentSpanId for root spans

### DIFF
--- a/packages/otlpjson/src/index.ts
+++ b/packages/otlpjson/src/index.ts
@@ -984,7 +984,7 @@ export function* iterSpans(document: OtlpTracesDocument): Generator<SpanRecord> 
           scope,
           traceId: span.traceId ?? null,
           spanId: span.spanId ?? null,
-          parentSpanId: span.parentSpanId || null,
+          parentSpanId: span.parentSpanId ?? null,
           name: span.name ?? null,
           kind: span.kind ?? null,
           startTimeUnixNano,

--- a/packages/otlpjson/test/index.test.ts
+++ b/packages/otlpjson/test/index.test.ts
@@ -564,6 +564,35 @@ describe("@otlpkit/otlpjson", () => {
     expect(() => makeEnvelope({ invalid: true } as never)).toThrowError(TypeError);
   });
 
+  it("preserves empty string parentSpanId for root spans", () => {
+    const doc = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [
+            {
+              scope: { name: "test", version: "1.0.0" },
+              spans: [
+                {
+                  traceId: "abc",
+                  spanId: "def",
+                  parentSpanId: "",
+                  name: "root-span",
+                  kind: 1,
+                  startTimeUnixNano: "1000000000",
+                  endTimeUnixNano: "2000000000",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const spans = [...iterSpans(doc as never)];
+    expect(spans).toHaveLength(1);
+    expect(spans[0]?.parentSpanId).toBe("");
+  });
+
   it("covers primitive conversion and timestamp fallbacks", () => {
     expect(attributeValueToJs("plain")).toBe("plain");
     expect(attributeValueToJs(null)).toBeNull();


### PR DESCRIPTION
## Summary

Use nullish coalescing (`??`) instead of logical OR (`||`) to correctly preserve empty string `parentSpanId` on root spans.

## Problem

In `iterSpans()` at `packages/otlpjson/src/index.ts:987`:
```typescript
parentSpanId: span.parentSpanId || null,
```

This incorrectly converts empty string `""` (root spans) to `null`. Real OTLP exports use empty string for root spans.

## Fix

```typescript
parentSpanId: span.parentSpanId ?? null,
```

## Testing

Added test that verifies empty string `parentSpanId` is preserved for root spans.

Fixes #208