### PR TITLE
fix(o11ytsdb): return NaN when rate/irate/delta cannot be computed

### DIFF
--- a/packages/o11ytsdb/src/query.ts
+++ b/packages/o11ytsdb/src/query.ts
@@ -744,6 +744,12 @@ function pointAggregate(ranges: TimeRange[], fn: AggFn): TimeRange {
       );
     }
     const src = materializeRangeOwned(readItemAt(ranges, 0, "range"));
+    // Prometheus-compatible: if only 1 sample, cannot compute rate/irate/delta/increase.
+    // Set first point to NaN to indicate "cannot compute" (unlike 0 which means "rate is zero").
+    if (src.timestamps.length < 2) {
+      values[0] = NaN;
+      return { timestamps, values };
+    }
     if (fn === "irate") {
       for (let i = 1; i < src.timestamps.length; i++) {
         const currentValue = readNumberAt(src.values, i, "point value");


### PR DESCRIPTION
## Summary

Fix Prometheus-incompatible behavior where `rate`, `irate`, `delta`, and `increase` would return `0` for the first point when there was only 1 sample.

**Before:** First point was `0` (indistinguishable from "rate is actually zero")  
**After:** First point is `NaN` (clearly indicates "cannot compute rate with only 1 sample")

## Research

Prometheus returns empty/no data point when rate cannot be computed. Using `NaN` is the most appropriate JavaScript value for "undefined result".

## Changes

- `packages/o11ytsdb/src/query.ts`: Added check for single-sample case, returning `NaN` instead of `0`

## Testing

All 297 existing tests pass.