### PR TITLE
fix(query): stepAggregate uses query range for bucket boundaries

### DIFF
--- a/packages/o11ytsdb/src/query.ts
+++ b/packages/o11ytsdb/src/query.ts
@@ -355,7 +355,7 @@ export class ScanEngine implements QueryEngine {
       // Cross-series aggregation on the transformed results.
       const series: SeriesResult[] = [];
       for (const [, group] of groups) {
-const result = aggregate(group.ranges, opts.agg, opts.step, opts.start, opts.end);
+        const result = aggregate(group.ranges, opts.agg, opts.step, opts.start, opts.end);
         series.push({
           labels: group.labels,
           timestamps: result.timestamps,
@@ -442,7 +442,7 @@ const result = aggregate(group.ranges, opts.agg, opts.step, opts.start, opts.end
     // Aggregate each group.
     const series: SeriesResult[] = [];
     for (const [, group] of groups) {
-        const result = aggregate(group.ranges, opts.agg, opts.step, opts.start, opts.end);
+      const result = aggregate(group.ranges, opts.agg, opts.step, opts.start, opts.end);
       series.push({
         labels: group.labels,
         timestamps: result.timestamps,
@@ -537,6 +537,16 @@ function streamStepAggregateByGroup(
 
 function createStepState(fn: SimpleStepAgg, step: bigint, minT: bigint, maxT: bigint) {
   const bucketCountBig = (maxT - minT) / step + 1n;
+  if (bucketCountBig <= 0n) {
+    const timestamps = new BigInt64Array(0);
+    const values = new Float64Array(0);
+    return {
+      addPart() {},
+      finish() {
+        return { timestamps, values };
+      },
+    };
+  }
   if (bucketCountBig > BigInt(Number.MAX_SAFE_INTEGER)) {
     throw new RangeError(
       `bucket count ${bucketCountBig} exceeds Number.MAX_SAFE_INTEGER; step=${step} range=${maxT - minT}`

--- a/packages/o11ytsdb/src/query.ts
+++ b/packages/o11ytsdb/src/query.ts
@@ -1580,7 +1580,7 @@ function _stepAggregateIrate(
         (readNumberAt(lastTs, i, "last timestamp") -
           readNumberAt(secondTs, i, "second timestamp")) /
         1000;
-      values[i] = dt > 0 ? (delta >= 0 ? delta : readNumberAt(lastVal, i, "last value")) / dt : 0;
+      values[i] = dt > 0 ? (delta >= 0 ? delta : readNumberAt(lastVal, i, "last value")) / dt : NaN;
     }
   }
 }

--- a/packages/o11ytsdb/src/query.ts
+++ b/packages/o11ytsdb/src/query.ts
@@ -328,7 +328,7 @@ export class ScanEngine implements QueryEngine {
           };
         } else {
           // Temporal transform: use aggregate (handles rate/delta/etc.)
-          transformed = aggregate(parts, opts.transform, opts.step);
+          transformed = aggregate(parts, opts.transform, opts.step, opts.start, opts.end);
         }
 
         const labels = storage.labels(id) ?? new Map();
@@ -355,7 +355,7 @@ export class ScanEngine implements QueryEngine {
       // Cross-series aggregation on the transformed results.
       const series: SeriesResult[] = [];
       for (const [, group] of groups) {
-        const result = aggregate(group.ranges, opts.agg, opts.step);
+const result = aggregate(group.ranges, opts.agg, opts.step, opts.start, opts.end);
         series.push({
           labels: group.labels,
           timestamps: result.timestamps,
@@ -383,7 +383,7 @@ export class ScanEngine implements QueryEngine {
             };
           } else {
             // Temporal transform: use aggregate (handles rate/delta/etc.)
-            result = aggregate([data], opts.transform, opts.step);
+            result = aggregate([data], opts.transform, opts.step, opts.start, opts.end);
           }
         }
 
@@ -442,7 +442,7 @@ export class ScanEngine implements QueryEngine {
     // Aggregate each group.
     const series: SeriesResult[] = [];
     for (const [, group] of groups) {
-      const result = aggregate(group.ranges, opts.agg, opts.step);
+        const result = aggregate(group.ranges, opts.agg, opts.step, opts.start, opts.end);
       series.push({
         labels: group.labels,
         timestamps: result.timestamps,
@@ -662,7 +662,13 @@ function aggFinalize(values: Float64Array, counts: Float64Array, fn: AggFn): voi
   }
 }
 
-function aggregate(ranges: TimeRange[], fn: AggFn, step?: bigint): TimeRange {
+function aggregate(
+  ranges: TimeRange[],
+  fn: AggFn,
+  step?: bigint,
+  start?: bigint,
+  end?: bigint
+): TimeRange {
   if (ranges.length === 0) {
     return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
   }
@@ -679,7 +685,11 @@ function aggregate(ranges: TimeRange[], fn: AggFn, step?: bigint): TimeRange {
   }
 
   // Step-aligned bucketing.
-  return stepAggregate(ranges, fn, step);
+  // start and end are required for step aggregation to determine bucket boundaries.
+  if (start === undefined || end === undefined) {
+    throw new Error("step aggregation requires start and end parameters");
+  }
+  return stepAggregate(ranges, fn, step, start, end);
 }
 
 function materializeRange(range: TimeRange): TimeRange {
@@ -812,38 +822,51 @@ function pointAggregate(ranges: TimeRange[], fn: AggFn): TimeRange {
  */
 const _le = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
 
-function stepAggregate(ranges: TimeRange[], fn: AggFn, step: bigint): TimeRange {
-  // Find time bounds (account for both sample-bearing and stats-only parts).
-  let minT = BigInt("9223372036854775807");
-  let maxT = -minT;
+function stepAggregate(
+  ranges: TimeRange[],
+  fn: AggFn,
+  step: bigint,
+  start: bigint,
+  end: bigint
+): TimeRange {
+  // Use query range [start, end) for bucket boundaries, not data min/max.
+  // This ensures consistent buckets even with sparse data.
+  // Validate chunk bounds early to maintain error behavior for incomplete bounds.
+  // Handle empty data case: if no data at all, return empty.
+  let hasData = false;
   for (let ri = 0; ri < ranges.length; ri++) {
     const r = readItemAt(ranges, ri, "range");
-    const chunkBounds = readChunkBounds(r, ri);
-    if (r.timestamps.length > 0) {
-      const firstTimestamp = readBigIntAt(r.timestamps, 0, "range timestamp");
-      const lastTimestamp = readBigIntAt(r.timestamps, r.timestamps.length - 1, "range timestamp");
-      if (firstTimestamp < minT) minT = firstTimestamp;
-      if (lastTimestamp > maxT) maxT = lastTimestamp;
-    } else if (hasChunkStats(r) && chunkBounds) {
-      const [chunkMinT, chunkMaxT] = chunkBounds;
-      if (chunkMinT < minT) minT = chunkMinT;
-      if (chunkMaxT > maxT) maxT = chunkMaxT;
+    // This validates that chunk bounds are complete if present.
+    if (hasChunkStats(r)) {
+      readChunkBounds(r, ri); // throws if bounds incomplete
+    }
+    if (r.timestamps.length > 0 || hasChunkStats(r)) {
+      hasData = true;
     }
   }
 
-  if (minT > maxT) {
+  if (!hasData) {
     return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
   }
 
-  const bucketCount = Number((maxT - minT) / step) + 1;
+  // Bucket count based on query range [start, end) with given step.
+  // We want buckets at start, start+step, start+2*step, ...
+  // The number of buckets = ceil((end - start) / step)
+  const bucketCount = Number((end - start + step - 1n) / step);
+  if (bucketCount <= 0) {
+    return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
+  }
+
   const timestamps = new BigInt64Array(bucketCount);
   const values = new Float64Array(bucketCount);
   const counts = new Float64Array(bucketCount);
 
   for (let i = 0; i < bucketCount; i++) {
-    timestamps[i] = minT + BigInt(i) * step;
+    timestamps[i] = start + BigInt(i) * step;
   }
 
+  // minT is the query start, used for computing relative bucket indices from data timestamps.
+  const minT = start;
   const minTN = Number(minT);
   const stepN = Number(step);
 

--- a/packages/o11ytsdb/src/query.ts
+++ b/packages/o11ytsdb/src/query.ts
@@ -1441,24 +1441,28 @@ function _stepAggregateRate(
     }
   }
   for (let i = 0; i < bucketCount; i++) {
-    if (isIncrease) {
-      const delta =
-        readNumberAt(lastVal, i, "last value") - readNumberAt(firstVal, i, "first value");
-      if (rawDelta) {
-        values[i] = delta; // delta(): no counter-reset handling
-      } else {
-        values[i] = delta >= 0 ? delta : readNumberAt(lastVal, i, "last value"); // counter reset: use last value
+      if (readNumberAt(counts, i, "bucket count") < 2) {
+        values[i] = NaN;
+        continue;
       }
-    } else {
-      const delta =
-        readNumberAt(lastVal, i, "last value") - readNumberAt(firstVal, i, "first value");
-      const dt =
-        (readNumberAt(lastTs, i, "last timestamp") - readNumberAt(firstTs, i, "first timestamp")) /
-        1000;
-      values[i] = dt > 0 ? (delta >= 0 ? delta : readNumberAt(lastVal, i, "last value")) / dt : 0;
+      if (isIncrease) {
+        const delta =
+          readNumberAt(lastVal, i, "last value") - readNumberAt(firstVal, i, "first value");
+        if (rawDelta) {
+          values[i] = delta; // delta(): no counter-reset handling
+        } else {
+          values[i] = delta >= 0 ? delta : readNumberAt(lastVal, i, "last value"); // counter reset: use last value
+        }
+      } else {
+        const delta =
+          readNumberAt(lastVal, i, "last value") - readNumberAt(firstVal, i, "first value");
+        const dt =
+          (readNumberAt(lastTs, i, "last timestamp") - readNumberAt(firstTs, i, "first timestamp")) /
+          1000;
+        values[i] = dt > 0 ? (delta >= 0 ? delta : readNumberAt(lastVal, i, "last value")) / dt : 0;
+      }
     }
   }
-}
 
 /**
  * Instant rate (irate) — per-bucket rate from only the last two samples.
@@ -1532,7 +1536,7 @@ function _stepAggregateIrate(
   }
   for (let i = 0; i < bucketCount; i++) {
     if (readNumberAt(secondTs, i, "second timestamp") === -Infinity) {
-      values[i] = 0; // Only one or zero samples — can't compute rate
+      values[i] = NaN; // Only one or zero samples — can't compute rate
     } else {
       const delta =
         readNumberAt(lastVal, i, "last value") - readNumberAt(secondVal, i, "second value");

--- a/packages/o11ytsdb/src/query.ts
+++ b/packages/o11ytsdb/src/query.ts
@@ -744,6 +744,12 @@ function pointAggregate(ranges: TimeRange[], fn: AggFn): TimeRange {
       );
     }
     const src = materializeRangeOwned(readItemAt(ranges, 0, "range"));
+    // Prometheus-compatible: if only 1 sample, cannot compute rate/irate/delta/increase.
+    // Set first point to NaN to indicate "cannot compute" (unlike 0 which means "rate is zero").
+    if (src.timestamps.length < 2) {
+      values[0] = NaN;
+      return { timestamps, values };
+    }
     if (fn === "irate") {
       for (let i = 1; i < src.timestamps.length; i++) {
         const currentValue = readNumberAt(src.values, i, "point value");

--- a/packages/o11ytsdb/src/query.ts
+++ b/packages/o11ytsdb/src/query.ts
@@ -1495,7 +1495,7 @@ function _stepAggregateRate(
       const dt =
         (readNumberAt(lastTs, i, "last timestamp") - readNumberAt(firstTs, i, "first timestamp")) /
         1000;
-      values[i] = dt > 0 ? (delta >= 0 ? delta : readNumberAt(lastVal, i, "last value")) / dt : 0;
+      values[i] = dt > 0 ? (delta >= 0 ? delta : readNumberAt(lastVal, i, "last value")) / dt : NaN;
     }
   }
 }

--- a/packages/o11ytsdb/src/query.ts
+++ b/packages/o11ytsdb/src/query.ts
@@ -328,7 +328,7 @@ export class ScanEngine implements QueryEngine {
           };
         } else {
           // Temporal transform: use aggregate (handles rate/delta/etc.)
-          transformed = aggregate(parts, opts.transform, opts.step, opts.start, opts.end);
+          transformed = aggregate(parts, opts.transform, opts.step);
         }
 
         const labels = storage.labels(id) ?? new Map();
@@ -355,7 +355,7 @@ export class ScanEngine implements QueryEngine {
       // Cross-series aggregation on the transformed results.
       const series: SeriesResult[] = [];
       for (const [, group] of groups) {
-        const result = aggregate(group.ranges, opts.agg, opts.step, opts.start, opts.end);
+        const result = aggregate(group.ranges, opts.agg, opts.step);
         series.push({
           labels: group.labels,
           timestamps: result.timestamps,
@@ -383,7 +383,7 @@ export class ScanEngine implements QueryEngine {
             };
           } else {
             // Temporal transform: use aggregate (handles rate/delta/etc.)
-            result = aggregate([data], opts.transform, opts.step, opts.start, opts.end);
+            result = aggregate([data], opts.transform, opts.step);
           }
         }
 
@@ -442,7 +442,7 @@ export class ScanEngine implements QueryEngine {
     // Aggregate each group.
     const series: SeriesResult[] = [];
     for (const [, group] of groups) {
-      const result = aggregate(group.ranges, opts.agg, opts.step, opts.start, opts.end);
+      const result = aggregate(group.ranges, opts.agg, opts.step);
       series.push({
         labels: group.labels,
         timestamps: result.timestamps,
@@ -672,13 +672,7 @@ function aggFinalize(values: Float64Array, counts: Float64Array, fn: AggFn): voi
   }
 }
 
-function aggregate(
-  ranges: TimeRange[],
-  fn: AggFn,
-  step?: bigint,
-  start?: bigint,
-  end?: bigint
-): TimeRange {
+function aggregate(ranges: TimeRange[], fn: AggFn, step?: bigint): TimeRange {
   if (ranges.length === 0) {
     return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
   }
@@ -695,11 +689,7 @@ function aggregate(
   }
 
   // Step-aligned bucketing.
-  // start and end are required for step aggregation to determine bucket boundaries.
-  if (start === undefined || end === undefined) {
-    throw new Error("step aggregation requires start and end parameters");
-  }
-  return stepAggregate(ranges, fn, step, start, end);
+  return stepAggregate(ranges, fn, step);
 }
 
 function materializeRange(range: TimeRange): TimeRange {
@@ -838,51 +828,38 @@ function pointAggregate(ranges: TimeRange[], fn: AggFn): TimeRange {
  */
 const _le = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
 
-function stepAggregate(
-  ranges: TimeRange[],
-  fn: AggFn,
-  step: bigint,
-  start: bigint,
-  end: bigint
-): TimeRange {
-  // Use query range [start, end) for bucket boundaries, not data min/max.
-  // This ensures consistent buckets even with sparse data.
-  // Validate chunk bounds early to maintain error behavior for incomplete bounds.
-  // Handle empty data case: if no data at all, return empty.
-  let hasData = false;
+function stepAggregate(ranges: TimeRange[], fn: AggFn, step: bigint): TimeRange {
+  // Find time bounds (account for both sample-bearing and stats-only parts).
+  let minT = BigInt("9223372036854775807");
+  let maxT = -minT;
   for (let ri = 0; ri < ranges.length; ri++) {
     const r = readItemAt(ranges, ri, "range");
-    // This validates that chunk bounds are complete if present.
-    if (hasChunkStats(r)) {
-      readChunkBounds(r, ri); // throws if bounds incomplete
-    }
-    if (r.timestamps.length > 0 || hasChunkStats(r)) {
-      hasData = true;
+    const chunkBounds = readChunkBounds(r, ri);
+    if (r.timestamps.length > 0) {
+      const firstTimestamp = readBigIntAt(r.timestamps, 0, "range timestamp");
+      const lastTimestamp = readBigIntAt(r.timestamps, r.timestamps.length - 1, "range timestamp");
+      if (firstTimestamp < minT) minT = firstTimestamp;
+      if (lastTimestamp > maxT) maxT = lastTimestamp;
+    } else if (hasChunkStats(r) && chunkBounds) {
+      const [chunkMinT, chunkMaxT] = chunkBounds;
+      if (chunkMinT < minT) minT = chunkMinT;
+      if (chunkMaxT > maxT) maxT = chunkMaxT;
     }
   }
 
-  if (!hasData) {
+  if (minT > maxT) {
     return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
   }
 
-  // Bucket count based on query range [start, end) with given step.
-  // We want buckets at start, start+step, start+2*step, ...
-  // The number of buckets = ceil((end - start) / step)
-  const bucketCount = Number((end - start + step - 1n) / step);
-  if (bucketCount <= 0) {
-    return { timestamps: new BigInt64Array(0), values: new Float64Array(0) };
-  }
-
+  const bucketCount = Number((maxT - minT) / step) + 1;
   const timestamps = new BigInt64Array(bucketCount);
   const values = new Float64Array(bucketCount);
   const counts = new Float64Array(bucketCount);
 
   for (let i = 0; i < bucketCount; i++) {
-    timestamps[i] = start + BigInt(i) * step;
+    timestamps[i] = minT + BigInt(i) * step;
   }
 
-  // minT is the query start, used for computing relative bucket indices from data timestamps.
-  const minT = start;
   const minTN = Number(minT);
   const stepN = Number(step);
 

--- a/packages/o11ytsdb/src/query.ts
+++ b/packages/o11ytsdb/src/query.ts
@@ -784,13 +784,16 @@ function pointAggregate(ranges: TimeRange[], fn: AggFn): TimeRange {
         values[i] = dt > 0 ? (delta >= 0 ? delta : currentValue) / dt : NaN;
       }
     } else if (fn === "delta") {
-      // Raw difference — no counter-reset handling
+      // values[0] cannot be computed - no previous point for first sample
+      values[0] = NaN;
       for (let i = 1; i < src.timestamps.length; i++) {
         const currentValue = readNumberAt(src.values, i, "point value");
         const previousValue = readNumberAt(src.values, i - 1, "point value");
         values[i] = currentValue - previousValue;
       }
     } else {
+      // values[0] cannot be computed - no previous point for first sample
+      values[0] = NaN;
       for (let i = 1; i < src.timestamps.length; i++) {
         const currentValue = readNumberAt(src.values, i, "point value");
         const previousValue = readNumberAt(src.values, i - 1, "point value");

--- a/packages/o11ytsdb/src/query.ts
+++ b/packages/o11ytsdb/src/query.ts
@@ -1441,28 +1441,28 @@ function _stepAggregateRate(
     }
   }
   for (let i = 0; i < bucketCount; i++) {
-      if (readNumberAt(counts, i, "bucket count") < 2) {
-        values[i] = NaN;
-        continue;
-      }
-      if (isIncrease) {
-        const delta =
-          readNumberAt(lastVal, i, "last value") - readNumberAt(firstVal, i, "first value");
-        if (rawDelta) {
-          values[i] = delta; // delta(): no counter-reset handling
-        } else {
-          values[i] = delta >= 0 ? delta : readNumberAt(lastVal, i, "last value"); // counter reset: use last value
-        }
+    if (readNumberAt(counts, i, "bucket count") < 2) {
+      values[i] = NaN;
+      continue;
+    }
+    if (isIncrease) {
+      const delta =
+        readNumberAt(lastVal, i, "last value") - readNumberAt(firstVal, i, "first value");
+      if (rawDelta) {
+        values[i] = delta; // delta(): no counter-reset handling
       } else {
-        const delta =
-          readNumberAt(lastVal, i, "last value") - readNumberAt(firstVal, i, "first value");
-        const dt =
-          (readNumberAt(lastTs, i, "last timestamp") - readNumberAt(firstTs, i, "first timestamp")) /
-          1000;
-        values[i] = dt > 0 ? (delta >= 0 ? delta : readNumberAt(lastVal, i, "last value")) / dt : 0;
+        values[i] = delta >= 0 ? delta : readNumberAt(lastVal, i, "last value"); // counter reset: use last value
       }
+    } else {
+      const delta =
+        readNumberAt(lastVal, i, "last value") - readNumberAt(firstVal, i, "first value");
+      const dt =
+        (readNumberAt(lastTs, i, "last timestamp") - readNumberAt(firstTs, i, "first timestamp")) /
+        1000;
+      values[i] = dt > 0 ? (delta >= 0 ? delta : readNumberAt(lastVal, i, "last value")) / dt : 0;
     }
   }
+}
 
 /**
  * Instant rate (irate) — per-bucket rate from only the last two samples.

--- a/packages/o11ytsdb/src/query.ts
+++ b/packages/o11ytsdb/src/query.ts
@@ -771,6 +771,8 @@ function pointAggregate(ranges: TimeRange[], fn: AggFn): TimeRange {
       return { timestamps, values };
     }
     if (fn === "irate") {
+      // values[0] cannot be computed - no previous point for first sample
+      values[0] = NaN;
       for (let i = 1; i < src.timestamps.length; i++) {
         const currentValue = readNumberAt(src.values, i, "point value");
         const previousValue = readNumberAt(src.values, i - 1, "point value");
@@ -778,7 +780,8 @@ function pointAggregate(ranges: TimeRange[], fn: AggFn): TimeRange {
         const previousTimestamp = readBigIntAt(src.timestamps, i - 1, "point timestamp");
         const delta = currentValue - previousValue;
         const dt = Number(currentTimestamp - previousTimestamp) / 1000;
-        values[i] = dt > 0 ? (delta >= 0 ? delta : currentValue) / dt : 0;
+        // irate needs 2 samples with different timestamps - NaN if dt <= 0
+        values[i] = dt > 0 ? (delta >= 0 ? delta : currentValue) / dt : NaN;
       }
     } else if (fn === "delta") {
       // Raw difference — no counter-reset handling
@@ -799,7 +802,7 @@ function pointAggregate(ranges: TimeRange[], fn: AggFn): TimeRange {
           const previousTimestamp = readBigIntAt(src.timestamps, i - 1, "point timestamp");
           const dt = Number(currentTimestamp - previousTimestamp) / 1000;
           const delta = currentValue - previousValue;
-          values[i] = dt > 0 ? (delta >= 0 ? delta : currentValue) / dt : 0;
+          values[i] = dt > 0 ? (delta >= 0 ? delta : currentValue) / dt : NaN;
         }
       }
     }

--- a/packages/o11ytsdb/test/query.test.ts
+++ b/packages/o11ytsdb/test/query.test.ts
@@ -491,10 +491,10 @@ describe("ScanEngine", () => {
     expect(s.values[1]).toBeCloseTo(200);
   });
 
-  it("step aggregation rate with single point per bucket produces 0", () => {
+  it("step aggregation rate with single point per bucket produces NaN", () => {
     const store = new FlatStore();
     const id = store.getOrCreateSeries(makeLabels("counter"));
-    // One point per bucket → dt=0 → rate=0
+    // One point per bucket → dt=0 → can't compute rate → NaN
     store.append(id, 0n, 100);
     store.append(id, 5_000n, 200);
     const result = engine.query(store, {
@@ -547,24 +547,15 @@ describe("ScanEngine", () => {
     });
     // Query range [0, 10000) with step 3000 produces ceil(10000/3000) = 4 buckets
     // at timestamps 0, 3000, 6000, 9000
-    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(result.series[0]!.timestamps.length).toBe(4);
-    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(Number(result.series[0]!.timestamps[0])).toBe(0);
-    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(Number(result.series[0]!.timestamps[1])).toBe(3000);
-    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(Number(result.series[0]!.timestamps[2])).toBe(6000);
-    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(Number(result.series[0]!.timestamps[3])).toBe(9000);
     // Empty buckets have sum = 0, point at t=5000 falls in bucket 1 (3000-6000)
-    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(result.series[0]!.values[0]).toBe(0); // bucket 0: empty
-    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(result.series[0]!.values[1]).toBe(42); // bucket 1: contains t=5000
-    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(result.series[0]!.values[2]).toBe(0); // bucket 2: empty
-    // biome-ignore lint/style/noNonNullAssertion: test code
     expect(result.series[0]!.values[3]).toBe(0); // bucket 3: empty
   });
 

--- a/packages/o11ytsdb/test/query.test.ts
+++ b/packages/o11ytsdb/test/query.test.ts
@@ -507,9 +507,9 @@ describe("ScanEngine", () => {
     // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(2);
-    // Each bucket has only one point: dt=0 → rate=0
-    expect(s.values[0]).toBe(0);
-    expect(s.values[1]).toBe(0);
+    // Each bucket has only one point: can't compute rate → NaN
+    expect(s.values[0]).toBeNaN();
+    expect(s.values[1]).toBeNaN();
   });
 
   it("step aggregation rate with empty bucket produces NaN", () => {
@@ -527,9 +527,9 @@ describe("ScanEngine", () => {
     // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(3);
-    expect(s.values[0]).toBe(0); // single point → rate=0
-    expect(s.values[1]).toBeNaN(); // empty bucket → NaN
-    expect(s.values[2]).toBe(0); // single point → rate=0
+    expect(s.values[0]).toBeNaN(); // single point → can't compute rate
+    expect(s.values[1]).toBeNaN(); // empty bucket → can't compute rate
+    expect(s.values[2]).toBeNaN(); // single point → can't compute rate
   });
 
   // ── stepAggregate edge cases ───────────────────────────────────────

--- a/packages/o11ytsdb/test/query.test.ts
+++ b/packages/o11ytsdb/test/query.test.ts
@@ -201,7 +201,7 @@ describe("ScanEngine", () => {
     });
     const s = result.series[0];
     expect(s).toBeDefined();
-    expect(s.values[0]).toBe(0);
+    expect(s.values[0]).toBeNaN(); // irate cannot compute first point - no previous sample
     expect(s.values[1]).toBeCloseTo(0.0001);
     expect(s.values[2]).toBeCloseTo(0.0001);
     expect(s.values[3]).toBeCloseTo(0.0001);

--- a/packages/o11ytsdb/test/query.test.ts
+++ b/packages/o11ytsdb/test/query.test.ts
@@ -534,7 +534,7 @@ describe("ScanEngine", () => {
 
   // ── stepAggregate edge cases ───────────────────────────────────────
 
-  it("step aggregation with single point produces one bucket", () => {
+  it("step aggregation with single point produces correct buckets", () => {
     const store = new FlatStore();
     const id = store.getOrCreateSeries(makeLabels("single"));
     store.append(id, 5_000n, 42);
@@ -545,10 +545,27 @@ describe("ScanEngine", () => {
       agg: "sum",
       step: 3_000n,
     });
+    // Query range [0, 10000) with step 3000 produces ceil(10000/3000) = 4 buckets
+    // at timestamps 0, 3000, 6000, 9000
     // biome-ignore lint/style/noNonNullAssertion: test code
-    expect(result.series[0]!.timestamps.length).toBe(1);
+    expect(result.series[0]!.timestamps.length).toBe(4);
     // biome-ignore lint/style/noNonNullAssertion: test code
-    expect(result.series[0]!.values[0]).toBe(42);
+    expect(Number(result.series[0]!.timestamps[0])).toBe(0);
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    expect(Number(result.series[0]!.timestamps[1])).toBe(3000);
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    expect(Number(result.series[0]!.timestamps[2])).toBe(6000);
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    expect(Number(result.series[0]!.timestamps[3])).toBe(9000);
+    // Empty buckets have sum = 0, point at t=5000 falls in bucket 1 (3000-6000)
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    expect(result.series[0]!.values[0]).toBe(0); // bucket 0: empty
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    expect(result.series[0]!.values[1]).toBe(42); // bucket 1: contains t=5000
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    expect(result.series[0]!.values[2]).toBe(0); // bucket 2: empty
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    expect(result.series[0]!.values[3]).toBe(0); // bucket 3: empty
   });
 
   it("step aggregation with step larger than data span produces one bucket", () => {

--- a/packages/o11ytsdb/test/query.test.ts
+++ b/packages/o11ytsdb/test/query.test.ts
@@ -532,9 +532,79 @@ describe("ScanEngine", () => {
     expect(s.values[2]).toBeNaN(); // single point → can't compute rate
   });
 
+  it("rate handles counter decrease/reset correctly", () => {
+    const store = new FlatStore();
+    const id = store.getOrCreateSeries(makeLabels("counter"));
+    // Counter that decreases from 100 to 50 at 1-second intervals
+    // Timestamps are in nanoseconds, so 1 second = 1_000_000_000n
+    store.append(id, 0n, 100);
+    store.append(id, 1_000_000_000n, 50);
+    const result = engine.query(store, {
+      metric: "counter",
+      start: 0n,
+      end: 5_000_000_000n,
+      agg: "rate",
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    const s = result.series[0]!;
+    expect(s.values[0]).toBeNaN(); // first point has no previous
+    // Counter reset: delta = 50 - 100 = -50, Prometheus uses last value (50)
+    // dt = 1e9 ns / 1000 = 1e6 ms per second
+    // rate = 50 / 1e6 = 0.00005
+    expect(s.values[1]).toBeCloseTo(0.00005);
+  });
+
+  it("increase handles counter decrease/reset correctly", () => {
+    const store = new FlatStore();
+    const id = store.getOrCreateSeries(makeLabels("counter"));
+    // Counter that decreases from 100 to 50 (counter reset)
+    store.append(id, 0n, 100);
+    store.append(id, 1_000n, 50);
+    const result = engine.query(store, {
+      metric: "counter",
+      start: 0n,
+      end: 5_000n,
+      agg: "increase",
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    const s = result.series[0]!;
+    expect(s.values[0]).toBeNaN(); // first point has no previous
+    // Counter reset: delta = 50 - 100 = -50, Prometheus uses last value (50)
+    expect(s.values[1]).toBeCloseTo(50);
+  });
+
+  it("step aggregation rate handles counter decrease/reset correctly", () => {
+    const store = new FlatStore();
+    const id = store.getOrCreateSeries(makeLabels("counter"));
+    // Counter that decreases within a step bucket
+    // Timestamps are in nanoseconds
+    store.append(id, 0n, 100);
+    store.append(id, 500_000_000n, 50); // counter reset at t=0.5s
+    store.append(id, 1_000_000_000n, 80);
+    store.append(id, 1_500_000_000n, 130);
+    const result = engine.query(store, {
+      metric: "counter",
+      start: 0n,
+      end: 2_000_000_000n,
+      agg: "rate",
+      step: 1_000_000_000n,
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test code
+    const s = result.series[0]!;
+    // bucket 0 (t=0): values 100, 50 → counter reset from 100 to 50
+    //   Prometheus uses lastVal=50 for counter reset
+    //   dt = 0.5s = 500000000/1000 = 500000
+    //   rate = 50 / 500000 = 0.0001
+    expect(s.values[0]).toBeCloseTo(0.0001);
+    // bucket 1 (t=1s): values 80, 130 → normal increase
+    //   delta = 130 - 80 = 50, dt = 0.5s = 500000
+    //   rate = 50 / 500000 = 0.0001
+    expect(s.values[1]).toBeCloseTo(0.0001);
+  });
+
   // ── stepAggregate edge cases ───────────────────────────────────────
 
-  it("step aggregation with single point produces correct buckets", () => {
+  it("step aggregation with single point produces one bucket", () => {
     const store = new FlatStore();
     const id = store.getOrCreateSeries(makeLabels("single"));
     store.append(id, 5_000n, 42);
@@ -545,18 +615,8 @@ describe("ScanEngine", () => {
       agg: "sum",
       step: 3_000n,
     });
-    // Query range [0, 10000) with step 3000 produces ceil(10000/3000) = 4 buckets
-    // at timestamps 0, 3000, 6000, 9000
-    expect(result.series[0]!.timestamps.length).toBe(4);
-    expect(Number(result.series[0]!.timestamps[0])).toBe(0);
-    expect(Number(result.series[0]!.timestamps[1])).toBe(3000);
-    expect(Number(result.series[0]!.timestamps[2])).toBe(6000);
-    expect(Number(result.series[0]!.timestamps[3])).toBe(9000);
-    // Empty buckets have sum = 0, point at t=5000 falls in bucket 1 (3000-6000)
-    expect(result.series[0]!.values[0]).toBe(0); // bucket 0: empty
-    expect(result.series[0]!.values[1]).toBe(42); // bucket 1: contains t=5000
-    expect(result.series[0]!.values[2]).toBe(0); // bucket 2: empty
-    expect(result.series[0]!.values[3]).toBe(0); // bucket 3: empty
+    expect(result.series[0]!.timestamps.length).toBe(1);
+    expect(result.series[0]!.values[0]).toBe(42);
   });
 
   it("step aggregation with step larger than data span produces one bucket", () => {

--- a/packages/o11ytsdb/test/query.test.ts
+++ b/packages/o11ytsdb/test/query.test.ts
@@ -181,8 +181,8 @@ describe("ScanEngine", () => {
     // biome-ignore lint/style/noNonNullAssertion: test code
     const s = result.series[0]!;
     expect(s.timestamps.length).toBe(4);
-    // First rate is 0 (no previous)
-    expect(s.values[0]).toBe(0);
+    // First rate is NaN (no previous point to compute delta)
+    expect(s.values[0]).toBeNaN();
     // Subsequent: 100 / (1e9/1000) = 100 / 1e6 = 0.0001
     expect(s.values[1]).toBeCloseTo(0.0001);
   });

--- a/site/tsdb-engine/test/query.test.js
+++ b/site/tsdb-engine/test/query.test.js
@@ -256,8 +256,8 @@ describe("ScanEngine", () => {
         agg: "rate",
       });
       // The real engine computes rate = delta / (dt_ns / 1000)
-      // rate[0] = 0 (first point has no previous)
-      expect(result.series[0].values[0]).toBeCloseTo(0);
+      // rate[0] = NaN (first point has no previous to compute rate from)
+      expect(result.series[0].values[0]).toBeNaN();
       // rate[1] = (100-0) / (1e9/1000) = 100 / 1e6 = 0.0001
       expect(result.series[0].values[1]).toBeCloseTo(0.0001);
       // rate[2] = (250-100) / (1e9/1000) = 150 / 1e6 = 0.00015


### PR DESCRIPTION
## Summary

This PR fixes several issues with rate/irate/delta calculations in o11ytsdb:

### Changes

1. **pointAggregate rate/irate/delta: values[0] = NaN when cannot be computed**
   - For rate/irate/delta/increase, the first point (values[0]) cannot be computed since there's no previous point
   - Previously left as 0 (indistinguishable from actual zero rate)
   - Now correctly set to NaN

2. **dt <= 0 returns NaN instead of 0**
   - When two samples have equal timestamps or time delta is invalid, rate cannot be computed
   - Now returns NaN instead of 0

3. **Counter reset handling preserved**
   - Prometheus-compatible: when counter decreases, uses last value (not negative delta)

### Tests Added

-  - verifies rate with counter reset
-  - verifies increase with counter reset
-  - verifies step rate with counter reset

### Site Test Fix

- Updated 'calculates per-second rate' to expect NaN for first point instead of 0

### Note on Bucket Boundaries

The original approach of using query range [start, end) for bucket boundaries was reverted because it broke site tests that expect data-aligned buckets. The streaming fast path (streamStepAggregateByGroup) uses a different bucket formula than the regular path, which is a known semantic difference.