### PR TITLE
feat: unify site design system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,14 @@ dev-uplot:
 
 pages-build:
 	BASE_PATH=$(BASE_PATH) $(NPM) run build --workspace @otlpkit/example-demo
+	BASE_PATH=/o11ykit/logsdb-engine/ npx vite build site/logsdb-engine
 	BASE_PATH=/o11ykit/tracesdb-engine/ npx vite build site/tracesdb-engine
 	BASE_PATH=/o11ykit/tsdb-engine/ npx vite build site/tsdb-engine
 	rm -rf .site
 	mkdir -p .site/otlpkit
 	cp -R site/* .site/
+	rm -rf .site/logsdb-engine/js .site/logsdb-engine/dist
+	cp -R site/logsdb-engine/dist/* .site/logsdb-engine/
 	rm -rf .site/tracesdb-engine/js .site/tracesdb-engine/dist
 	cp -R site/tracesdb-engine/dist/* .site/tracesdb-engine/
 	rm -rf .site/tsdb-engine/js .site/tsdb-engine/dist

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ GitHub Pages publishes a small portal:
 - `/o11ykit/otlpkit/` OtlpKit incident-story site
 - `/o11ykit/octo11y/` Octo11y guide and pipeline walkthrough
 - `/o11ykit/benchkit/` Benchkit demo and regression-automation handoff
+- `/o11ykit/logsdb-engine/` LogsDB engine site and interactive log storage/query demo
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
   ],
   "scripts": {
     "build": "npm run build:packages && npm run build:octo-packages && npm run build:examples && npm run build:actions",
-    "build:packages": "tsc -b packages/otlpjson packages/query packages/views packages/adapters packages/o11ytsdb packages/stardb packages/o11ylogsdb packages/o11ytracesdb --force",
+    "build:packages": "tsc -b packages/otlpjson packages/query packages/views packages/adapters packages/stardb packages/o11ytsdb packages/o11ylogsdb packages/o11ytracesdb --force",
     "build:octo-packages": "npm run build --workspace=@octo11y/core && npm run build --workspace=@benchkit/format && npm run build --workspace=@benchkit/chart && npm run build --workspace=@benchkit/adapters",
     "build:examples": "npm run build --workspace @otlpkit/example-chartjs && npm run build --workspace @otlpkit/example-echarts && npm run build --workspace @otlpkit/example-recharts && npm run build --workspace @otlpkit/example-uplot && npm run build --workspace @otlpkit/example-demo",
     "typecheck": "npm run typecheck:packages && npm run typecheck:octo-packages && npm run typecheck:examples && npm run typecheck:actions && npm run typecheck:site",
-    "typecheck:packages": "tsc -b packages/otlpjson packages/query packages/views packages/adapters packages/o11ytsdb packages/stardb packages/o11ylogsdb packages/o11ytracesdb --pretty false --force",
+    "typecheck:packages": "tsc -b packages/otlpjson packages/query packages/views packages/adapters packages/stardb packages/o11ytsdb packages/o11ylogsdb packages/o11ytracesdb --pretty false --force",
     "typecheck:octo-packages": "npm run build --workspace=@octo11y/core && npm run build --workspace=@benchkit/format && npm run lint --workspace=@octo11y/core && npm run lint --workspace=@benchkit/format && npm run lint --workspace=@benchkit/chart && npm run lint --workspace=@benchkit/adapters",
     "typecheck:examples": "npm run typecheck --workspace @otlpkit/example-chartjs && npm run typecheck --workspace @otlpkit/example-echarts && npm run typecheck --workspace @otlpkit/example-recharts && npm run typecheck --workspace @otlpkit/example-uplot && npm run typecheck --workspace @otlpkit/example-demo",
     "build:actions": "npm run build --workspace @o11ykit/action-parse-results",

--- a/packages/o11ylogsdb/src/codec-utils.ts
+++ b/packages/o11ylogsdb/src/codec-utils.ts
@@ -43,7 +43,7 @@ const enc = new TextEncoder();
  */
 export function encodeSidecar(
   records: readonly LogRecord[],
-  kinds: readonly number[],
+  kinds: ArrayLike<number>,
   buf: ByteBuf
 ): void {
   const n = records.length;

--- a/packages/stardb/test/shared-modules.test.ts
+++ b/packages/stardb/test/shared-modules.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BackpressureController,
   ByteBuf,
@@ -15,6 +15,10 @@ import {
   uint8IndexOf,
   upperBound,
 } from "../src/index.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 // ─── Interner ────────────────────────────────────────────────────────
 
@@ -57,6 +61,20 @@ describe("Interner", () => {
   it("throws on invalid resolve id", () => {
     const interner = new Interner();
     expect(() => interner.resolve(99)).toThrow(/invalid intern id/);
+  });
+
+  it("grows backing storage and preserves existing ids", () => {
+    const interner = new Interner(2_000);
+    const longValue = "x".repeat(1_500);
+    const longId = interner.intern(longValue);
+
+    for (let i = 0; i < 1_500; i++) {
+      expect(interner.intern(`value-${i}`)).toBe(i + 1);
+    }
+
+    expect(interner.resolve(longId)).toBe(longValue);
+    expect(interner.resolve(interner.intern("value-1499"))).toBe("value-1499");
+    expect(interner.size).toBe(1_501);
   });
 });
 
@@ -197,6 +215,17 @@ describe("uint8IndexOf", () => {
     const haystack = enc.encode("hi");
     const needle = enc.encode("hello world");
     expect(uint8IndexOf(haystack, needle)).toBe(-1);
+  });
+
+  it("falls back to browser-style byte scanning when Buffer is unavailable", () => {
+    vi.stubGlobal("Buffer", undefined);
+
+    const haystack = enc.encode("ababa");
+    expect(uint8IndexOf(haystack, enc.encode("aba"))).toBe(0);
+    expect(uint8IndexOf(haystack, enc.encode("bab"))).toBe(1);
+    expect(uint8IndexOf(haystack, enc.encode("ac"))).toBe(-1);
+    expect(uint8IndexOf(haystack, new Uint8Array(0))).toBe(0);
+    expect(uint8IndexOf(enc.encode("hi"), enc.encode("hello"))).toBe(-1);
   });
 });
 

--- a/site/benchkit/index.html
+++ b/site/benchkit/index.html
@@ -19,7 +19,7 @@
     <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="ambient" aria-hidden="true"></div>
     <main id="main-content" class="page">
-      <header class="topbar panel">
+      <header class="topbar">
         <a class="brand" href="/o11ykit/"><img class="brand-mark" src="../logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
@@ -31,20 +31,18 @@
         </nav>
       </header>
 
-      <section class="hero panel">
-        <p class="eyebrow">automation layer</p>
+      <section class="hero grid-bg">
+         <p class="t-eyebrow">automation layer</p>
         <h1>Catch regressions<br/>before they merge.</h1>
-        <p class="lede">
+         <p class="hero-lede">
           Monitor host telemetry during CI. Parse benchmark output from any major tool.
           Compare against rolling baselines. Post regression summaries to PRs.
           All as composable GitHub Actions.
         </p>
         <div class="hero-actions">
-          <a class="cta cta-primary" href="#regression-gate">See a Regression Gate</a>
-          <a class="cta" href="#quickstart">Start With Quickstart</a>
-          <a class="cta" href="https://github.com/strawgate/o11ykit/tree/main/octo11y/actions" target="_blank" rel="noreferrer">
-            Browse Actions
-          </a>
+          <a class="stamp-fill" href="#regression-gate">See a Regression Gate</a>
+          <a class="stamp" href="#quickstart">Start With Quickstart</a>
+          <a class="stamp" href="https://github.com/strawgate/o11ykit/tree/main/octo11y/actions" target="_blank" rel="noreferrer">Browse Actions</a>
         </div>
       </section>
 

--- a/site/logsdb-engine/css/base.css
+++ b/site/logsdb-engine/css/base.css
@@ -5,9 +5,6 @@
   --panel-bg: var(--paper, #f2efe7);
   --panel-border: var(--ink, #11110f);
   --accent: var(--signal, oklch(0.66 0.16 42));
-  --mono: var(--mono, "JetBrains Mono", monospace);
-  --sans: var(--sans, "Inter Tight", sans-serif);
-  --display: var(--display, "Fraunces", serif);
   --severity-trace: #6b7280;
   --severity-debug: #3b82f6;
   --severity-info: #10b981;

--- a/site/logsdb-engine/index.html
+++ b/site/logsdb-engine/index.html
@@ -34,19 +34,19 @@
       </header>
 
       <!-- ─── Hero ────────────────────────────────────────────── -->
-      <section class="hero">
-        <p class="eyebrow">o11ylogsdb engine</p>
+      <section class="hero grid-bg">
+         <p class="t-eyebrow">o11ylogsdb engine</p>
         <h1>A log database<br/>that runs in your browser.</h1>
-        <p class="lede">
+         <p class="hero-lede">
           Generate realistic observability log datasets, inspect byte-level storage
           efficiency, and query them in real-time. Drain template extraction + typed
           columnar codecs achieve 20–60× compression over raw OTLP/JSON.
         </p>
         <div class="hero-actions">
-          <a class="cta cta-primary" href="#section-dataset">Launch Live Demo ↓</a>
-          <a class="cta" href="https://github.com/strawgate/o11ykit/tree/main/packages/o11ylogsdb" target="_blank" rel="noreferrer">
-            Browse Source
-          </a>
+           <a class="stamp-fill" href="#section-dataset">Launch Live Demo ↓</a>
+           <a class="stamp" href="https://github.com/strawgate/o11ykit/tree/main/packages/o11ylogsdb" target="_blank" rel="noreferrer">
+             Browse Source
+           </a>
         </div>
       </section>
 
@@ -132,7 +132,7 @@
       </div>
 
       <!-- ─── Footer ──────────────────────────────────────────── -->
-      <footer style="padding: 2rem 0; text-align: center; border-top: 1px solid var(--panel-border); margin-top: 2rem;">
+      <footer class="site-footer">
         <p class="muted">
           o11ylogsdb · Part of <a href="/o11ykit/">o11ykit</a> · 
           <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>

--- a/site/logsdb-engine/js/app.js
+++ b/site/logsdb-engine/js/app.js
@@ -408,7 +408,7 @@ function renderQueryForm() {
     </div>
 
     <div class="query-actions">
-      <button id="run-query-btn" class="cta cta-primary">Run Query</button>
+       <button id="run-query-btn" class="stamp-fill demo-btn">Run Query</button>
     </div>
   `;
 

--- a/site/octo11y/index.html
+++ b/site/octo11y/index.html
@@ -19,7 +19,7 @@
     <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="ambient" aria-hidden="true"></div>
     <main id="main-content" class="page">
-      <header class="topbar panel">
+      <header class="topbar">
         <a class="brand" href="/o11ykit/"><img class="brand-mark" src="../logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
@@ -31,20 +31,18 @@
         </nav>
       </header>
 
-      <section class="hero panel">
-        <p class="eyebrow">pipeline layer</p>
+      <section class="hero grid-bg">
+         <p class="t-eyebrow">pipeline layer</p>
         <h1>GitHub activity →<br/>telemetry you can graph.</h1>
-        <p class="lede">
+         <p class="hero-lede">
           GitHub Actions that extract benchmark data from logs or files, stash run artifacts to a
           data branch, aggregate history into indexes and time-series, and serve it all through
           GitHub's CDN. No backend. No server. Just Git.
         </p>
         <div class="hero-actions">
-          <a class="cta cta-primary" href="#quickstart">Start With Quickstart</a>
-          <a class="cta" href="#what-you-get">See Data Branch Output</a>
-          <a class="cta" href="https://github.com/strawgate/o11ykit/tree/main/octo11y" target="_blank" rel="noreferrer">
-            Browse Source
-          </a>
+          <a class="stamp-fill" href="#quickstart">Start With Quickstart</a>
+          <a class="stamp" href="#what-you-get">See Data Branch Output</a>
+          <a class="stamp" href="https://github.com/strawgate/o11ykit/tree/main/octo11y" target="_blank" rel="noreferrer">Browse Source</a>
         </div>
       </section>
 

--- a/site/otlpkit-docs/index.html
+++ b/site/otlpkit-docs/index.html
@@ -19,7 +19,7 @@
     <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="ambient" aria-hidden="true"></div>
     <main id="main-content" class="page">
-      <header class="topbar panel">
+      <header class="topbar">
         <a class="brand" href="/o11ykit/"><img class="brand-mark" src="../logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/" aria-current="page">OtlpKit</a>
@@ -30,18 +30,16 @@
         </nav>
       </header>
 
-      <section class="hero panel">
-        <p class="eyebrow">foundation layer</p>
+      <section class="hero grid-bg">
+         <p class="t-eyebrow">foundation layer</p>
         <h1>OTLP in. Charts out.</h1>
-        <p class="lede">
+         <p class="hero-lede">
           Four packages that parse OTLP JSON, filter and group records, build library-agnostic frames,
           and project them into Chart.js, ECharts, Recharts, or uPlot configs. Zero backend required.
         </p>
         <div class="hero-actions">
-          <a class="cta cta-primary" href="/o11ykit/otlpkit/">Open OtlpKit Overview</a>
-          <a class="cta" href="https://www.npmjs.com/search?q=%40otlpkit" target="_blank" rel="noreferrer">
-            npm Packages
-          </a>
+           <a class="stamp-fill" href="/o11ykit/otlpkit/">Open OtlpKit Overview</a>
+           <a class="stamp" href="https://www.npmjs.com/search?q=%40otlpkit" target="_blank" rel="noreferrer">npm Packages</a>
         </div>
       </section>
 

--- a/site/otlpkit/index.html
+++ b/site/otlpkit/index.html
@@ -19,7 +19,7 @@
     <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="ambient" aria-hidden="true"></div>
     <main id="main-content" class="page">
-      <header class="topbar panel">
+      <header class="topbar">
         <a class="brand" href="/o11ykit/"><img class="brand-mark" src="../logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit/" aria-current="page">OtlpKit</a>
@@ -30,18 +30,18 @@
         </nav>
       </header>
 
-      <section class="hero panel">
-        <p class="eyebrow">shaping layer</p>
+      <section class="hero grid-bg">
+         <p class="t-eyebrow">shaping layer</p>
         <h1>Turn OTLP into queryable<br/>browser views.</h1>
-        <p class="lede">
+         <p class="hero-lede">
           OtlpKit parses OTLP JSON, filters and groups records, and projects them into chart-ready
           frames for browser apps, static dashboards, and telemetry experiments. Use it when you
           want OTLP ergonomics without committing to storage internals first.
         </p>
         <div class="hero-actions">
-          <a class="cta cta-primary" href="/o11ykit/otlpkit-docs/">Open package docs</a>
-          <a class="cta" href="/o11ykit/#experiences">Browse interactive routes</a>
-          <a class="cta" href="https://github.com/strawgate/o11ykit/tree/main/packages" target="_blank" rel="noreferrer">Browse package sources</a>
+           <a class="stamp-fill" href="/o11ykit/otlpkit-docs/">Open package docs</a>
+           <a class="stamp" href="/o11ykit/#experiences">Browse interactive routes</a>
+          <a class="stamp" href="https://github.com/strawgate/o11ykit/tree/main/packages" target="_blank" rel="noreferrer">Browse package sources</a>
         </div>
         <div class="pill-row" aria-label="Core capabilities">
           <span class="pill">OTLP JSON parsing</span>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,6 +1,7 @@
-/* ─── o11ykit — Brand System ────────────────────────────────────────── */
+/* ─── o11ykit — Unified Design System ─────────────────────────────────── */
 
 :root {
+  /* ── Brand Colors ────────────────────────────────────────────────────── */
   --paper: #f2efe7;
   --paper-2: #e8e3d5;
   --paper-3: #d9d2be;
@@ -9,35 +10,64 @@
   --ink-3: #6b6657;
   --rule: rgba(17, 17, 15, 0.16);
   --rule-2: rgba(17, 17, 15, 0.08);
-  --signal: oklch(0.66 0.16 42);
-  --signal-2: oklch(0.55 0.17 38);
-  --signal-3: oklch(0.86 0.06 60);
+
+   /* Global accent — engines override this in their base.css */
+   --signal: oklch(0.66 0.16 42);
+   --signal-2: oklch(0.55 0.17 38);
+   --signal-3: oklch(0.86 0.06 60);
+
+   /* Per-product accent defaults */
+   --accent-otlp: var(--signal);
+   --accent-tsdb: var(--signal);
+   --accent-octo: var(--signal-2);
+   --accent-bench: var(--ink-2);
+
+  /* ── Typography ───────────────────────────────────────────────────────── */
   --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
   --display: "Fraunces", "Iowan Old Style", Georgia, serif;
   --sans: "Inter Tight", ui-sans-serif, system-ui, sans-serif;
+
+  /* ── Layout ──────────────────────────────────────────────────────────── */
   --max-w: 1440px;
   --gutter: 48px;
+  --radius: 8px;
+  --radius-sm: 6px;
+  --radius-lg: 12px;
 
-  /* Legacy compat aliases for demo pages */
+  /* ── Shadows ─────────────────────────────────────────────────────────── */
+  --shadow-sm: 0 1px 2px rgba(17, 17, 15, 0.06);
+  --shadow-md: 0 4px 12px rgba(17, 17, 15, 0.08);
+  --shadow-lg: 0 8px 24px rgba(17, 17, 15, 0.12);
+
+  /* ── Transitions ─────────────────────────────────────────────────────── */
+  --ease: 120ms ease;
+  --ease-out: 200ms ease-out;
+
+  /* ── Compatibility aliases (used by legacy component CSS) ─────────────── */
   --ink-soft: var(--ink-2);
   --ink-muted: var(--ink-3);
   --surface: var(--paper);
   --surface-strong: var(--paper);
   --line: var(--rule);
   --line-strong: var(--rule);
-  --shadow-lg: none;
-  --shadow-sm: none;
-  --otlp: var(--signal);
-  --octo: var(--signal-2);
-  --bench: var(--ink-2);
-  --tsdb: var(--signal);
+  --bg: var(--paper);
+  --text: var(--ink);
+  --text-secondary: var(--ink-2);
+  --text-tertiary: var(--ink-3);
+  --border: var(--rule);
 }
 
-/* ─── Reset ────────────────────────────────────────────────────────── */
+/* ── Reset ─────────────────────────────────────────────────────────────── */
 *,
 *::before,
 *::after {
   box-sizing: border-box;
+  margin: 0;
+}
+
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 body {
@@ -48,18 +78,29 @@ body {
   font-size: 16px;
   line-height: 1.5;
   background: var(--paper);
-  -webkit-font-smoothing: antialiased;
 }
 
 img {
   max-width: 100%;
   display: block;
 }
+
 a {
   color: inherit;
+  text-decoration: none;
+/* Inline code */
+code {
+  font-family: var(--mono);
+  font-size: 12px;
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  padding: 2px 6px;
+  border-radius: 4px;
 }
 
-/* ─── Typography Scale ─────────────────────────────────────────────── */
+}
+
+/* ── Typography Scale ──────────────────────────────────────────────────── */
 .t-display {
   font-family: var(--display);
   font-size: clamp(40px, 6vw, 72px);
@@ -114,16 +155,23 @@ a {
   line-height: 1.4;
 }
 
-.t-eyebrow {
+.t-eyebrow,
+.eyebrow {
+  display: inline-block;
   font-family: var(--mono);
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: var(--ink-3);
+  margin-bottom: 12px;
+  padding: 4px 10px;
+  background: rgba(99, 102, 241, 0.08);
+  border-radius: 999px;
+  border: 1px solid rgba(99, 102, 241, 0.2);
 }
 
-/* ─── Grid Background Utilities ────────────────────────────────────── */
+/* ── Background Utilities ──────────────────────────────────────────────── */
 .grid-bg {
   background-image:
     linear-gradient(var(--rule-2) 1px, transparent 1px),
@@ -149,147 +197,125 @@ a {
   background-size: 16px 16px;
 }
 
-/* ─── Components: Stamp ────────────────────────────────────────────── */
+/* ── Buttons ───────────────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid var(--ink);
+  padding: 10px 18px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all var(--ease);
+  background: transparent;
+  color: var(--ink);
+  white-space: nowrap;
+}
+
+.btn:hover {
+  background: var(--paper-2);
+  border-color: var(--ink);
+}
+
+.btn-primary {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+
+ .btn-primary:hover {
+   background: var(--ink-2);
+   border-color: var(--ink-2);
+ }
+
+/* Stamp button aliases for backward compatibility */
 .stamp {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  border: 1px solid var(--ink);
-  padding: 6px 14px;
   text-decoration: none;
+  border: 1px solid var(--ink);
+  padding: 10px 18px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all var(--ease);
+  background: transparent;
   color: var(--ink);
-  transition:
-    background 120ms ease,
-    color 120ms ease;
+  white-space: nowrap;
 }
 
 .stamp:hover {
-  background: var(--ink);
-  color: var(--paper);
+  background: var(--paper-2);
+  border-color: var(--ink);
 }
 
 .stamp-fill {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  border: 1px solid var(--ink);
-  padding: 6px 14px;
   text-decoration: none;
+  border: 1px solid var(--ink);
+  padding: 10px 18px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all var(--ease);
   background: var(--ink);
   color: var(--paper);
-  transition:
-    background 120ms ease,
-    color 120ms ease;
+  white-space: nowrap;
 }
 
 .stamp-fill:hover {
   background: var(--ink-2);
+  border-color: var(--ink-2);
 }
 
-.stamp-ink {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-family: var(--mono);
+ .btn-secondary {
+  background: transparent;
+  color: var(--ink-2);
+  border-color: var(--rule);
+}
+
+.btn-secondary:hover {
+  color: var(--ink);
+  border-color: var(--ink);
+}
+
+.btn-ghost {
+  background: transparent;
+  border: none;
+  color: var(--ink-2);
+  padding: 8px 12px;
+}
+
+.btn-ghost:hover {
+  color: var(--ink);
+  background: var(--paper-2);
+}
+
+.btn-sm {
   font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  border: 1px solid var(--paper);
-  padding: 6px 14px;
-  text-decoration: none;
-  background: transparent;
-  color: var(--paper);
-  transition:
-    background 120ms ease,
-    color 120ms ease;
+  padding: 6px 12px;
 }
 
-.stamp-ink:hover {
-  background: var(--paper);
-  color: var(--ink);
+.btn-lg {
+  font-size: 15px;
+  padding: 12px 24px;
 }
 
-/* ─── Components: Tag ──────────────────────────────────────────────── */
-.tag {
-  display: inline-flex;
-  align-items: center;
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  border: 1px solid var(--rule);
-  padding: 4px 10px;
-  color: var(--ink-3);
-  background: transparent;
-}
-
-/* ─── Components: Stat Block ───────────────────────────────────────── */
-.stat {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.stat-value {
-  font-family: var(--display);
-  font-size: clamp(32px, 4vw, 48px);
-  font-weight: 300;
-  font-style: italic;
-  line-height: 1;
-  letter-spacing: -0.03em;
-  color: var(--ink);
-}
-
-.stat-label {
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--ink-3);
-}
-
-/* ─── Components: Hair Rule ────────────────────────────────────────── */
-.hair {
-  border: none;
-  border-top: 1px solid var(--rule);
-  margin: 0;
-}
-
-.section-rule {
-  border: none;
-  border-top: 1px solid var(--ink);
-  margin: 0;
-}
-
-/* ─── Layout: Section Container ────────────────────────────────────── */
-.section-inner {
-  max-width: var(--max-w);
-  margin: 0 auto;
-  padding: var(--gutter);
-}
-
-section {
-  border-bottom: 1px solid var(--ink);
-}
-
-section:last-of-type {
-  border-bottom: none;
-}
-
-/* ─── Topbar / Nav ─────────────────────────────────────────────────── */
+/* ── Topbar ────────────────────────────────────────────────────────────── */
 .topbar {
   position: sticky;
   top: 0;
@@ -334,8 +360,8 @@ section:last-of-type {
   padding: 14px 14px;
   border-bottom: 2px solid transparent;
   transition:
-    color 120ms ease,
-    border-color 120ms ease;
+    color var(--ease),
+    border-color var(--ease);
 }
 
 .topnav a:hover,
@@ -348,43 +374,280 @@ section:last-of-type {
   margin-left: 14px;
 }
 
-/* ─── Hero Section ─────────────────────────────────────────────────── */
+/* ── Hero Section ──────────────────────────────────────────────────────── */
 .hero {
   padding: 80px var(--gutter) 64px;
+  text-align: center;
 }
 
-.hero-inner {
-  max-width: var(--max-w);
-  margin: 0 auto;
+.hero-eyebrow {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--signal);
+  margin-bottom: 12px;
+  padding: 4px 12px;
+  background: rgba(99, 102, 241, 0.08);
+  border-radius: 999px;
+  border: 1px solid rgba(99, 102, 241, 0.2);
 }
 
-.hero-headline {
+.hero h1 {
+  font-family: var(--display);
+  font-size: clamp(40px, 6vw, 72px);
+  font-weight: 300;
+  font-style: italic;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  color: var(--ink);
   margin: 0 0 24px;
+}
+
+.hero h1 em {
+  font-style: normal;
+  color: var(--signal);
 }
 
 .hero-sub {
   max-width: 56ch;
-  margin: 0 0 32px;
+  margin: 0 auto 32px;
   font-size: 17px;
   line-height: 1.55;
   color: var(--ink-2);
+}
+
+.hero-lede {
+  max-width: 58ch;
+  margin: 0 auto 24px;
+  font-size: 17px;
+  line-height: 1.55;
+  color: var(--ink-2);
+}
+
+.hero-stats {
+  display: flex;
+  justify-content: center;
+  gap: 32px;
+  flex-wrap: wrap;
+  margin: 20px 0 24px;
+  padding: 16px 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.hero-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.hero-stat-value {
+  font-size: 28px;
+  font-weight: 800;
+  color: var(--signal);
+  letter-spacing: -0.02em;
+}
+
+.hero-stat-label {
+  font-size: 12px;
+  color: var(--ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
+  justify-content: center;
   margin-bottom: 48px;
 }
 
-/* ─── Pipeline Steps ───────────────────────────────────────────────── */
-.pipeline {
+/* ── Card / Panel ──────────────────────────────────────────────────────── */
+.panel {
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  padding: 24px;
+}
+
+.card {
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  padding: 16px;
+}
+
+.card p {
+  margin: 8px 0 0;
+  color: var(--ink-2);
+  line-height: 1.45;
+  font-size: 14px;
+}
+
+.card-links {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.card-links a {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ink);
+  border: 1px solid var(--rule);
+  padding: 6px 12px;
+  transition: border-color var(--ease);
+}
+
+.card-links a:hover {
+  border-color: var(--ink);
+}
+
+/* ── Section Containers ────────────────────────────────────────────────── */
+.section-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: var(--gutter);
+}
+
+section {
+  border-bottom: 1px solid var(--ink);
+}
+
+section:last-of-type {
+  border-bottom: none;
+}
+
+/* ── Section Intro ─────────────────────────────────────────────────────── */
+.section-intro {
+  margin: 0 0 18px;
+  color: var(--ink-2);
+  max-width: 72ch;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+/* ── Stat Strips ───────────────────────────────────────────────────────── */
+.stat-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  background: var(--paper);
+}
+
+.stat-strip .stat {
+  padding: 32px;
+  border-right: 1px solid var(--ink);
+  text-align: center;
+}
+
+.stat-strip .stat:last-child {
+  border-right: none;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.stat-value {
+  font-family: var(--display);
+  font-size: clamp(32px, 4vw, 48px);
+  font-weight: 300;
+  font-style: italic;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  color: var(--ink);
+}
+
+.stat-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-3);
+}
+
+/* ── Pipeline (used in hero only) ────────────────────────────────────────── */
+.hero .pipeline {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 0;
   border: 1px solid var(--ink);
 }
 
+.hero .pipeline-stage {
+  padding: 20px;
+  border-right: 1px solid var(--ink);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: center;
+}
+
+.hero .pipeline-stage:last-child {
+  border-right: none;
+}
+
+.hero .pipeline-stage.active {
+  background: var(--paper-2);
+}
+
+.hero .stage-icon {
+  font-size: 24px;
+  margin-bottom: 4px;
+}
+
+.hero .stage-name {
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.hero .stage-desc {
+  font-size: 12px;
+  color: var(--ink-3);
+  line-height: 1.4;
+}
+
+.hero .pipeline-arrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-3);
+  font-size: 18px;
+  background: var(--paper);
+  padding: 2px 0;
+  position: absolute;
+  right: -10px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+}
+
+/* ── Hair / Section Rules ──────────────────────────────────────────────── */
+.hair {
+  border: none;
+  border-top: 1px solid var(--rule);
+  margin: 0;
+}
+
+.section-rule {
+  border: none;
+  border-top: 1px solid var(--ink);
+  margin: 0;
+}
+
+/* ── Pipeline Step (grid-based hero pipeline) ─────────────────────────── */
 .pipeline-step {
   padding: 20px;
   border-right: 1px solid var(--ink);
@@ -433,25 +696,68 @@ section:last-of-type {
   z-index: 1;
 }
 
-/* ─── Stat Strip ───────────────────────────────────────────────────── */
-.stat-strip {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
+/* ── Accent Color Utilities ───────────────────────────────────────────── */
+.card.accent-otlp { border-left: 3px solid var(--accent-otlp); }
+.card.accent-tsdb { border-left: 3px solid var(--accent-tsdb); }
+.card.accent-octo { border-left: 3px solid var(--accent-octo); }
+.card.accent-bench { border-left: 3px solid var(--accent-bench); }
+
+.pipeline-stage.accent-otlp { border-top: 3px solid var(--accent-otlp); }
+.pipeline-stage.accent-tsdb { border-top: 3px solid var(--accent-tsdb); }
+.pipeline-stage.accent-octo { border-top: 3px solid var(--accent-octo); }
+.pipeline-stage.accent-bench { border-top: 3px solid var(--accent-bench); }
+
+/* ── Pipeline (default flex, used on product pages) ───────────────────── */
+.pipeline {
+  display: flex;
+  align-items: stretch;
   gap: 0;
-  background: var(--paper);
 }
 
-.stat-strip .stat {
-  padding: 32px;
-  border-right: 1px solid var(--ink);
+.pipeline-stage {
+  flex: 1;
+  min-width: 140px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 12px;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  position: relative;
   text-align: center;
 }
 
-.stat-strip .stat:last-child {
-  border-right: none;
+.pipeline-stage .stage-icon {
+  font-size: 24px;
+  margin-bottom: 4px;
 }
 
-/* ─── Primitives Grid (5-column) ───────────────────────────────────── */
+.pipeline-stage .stage-name {
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.pipeline-stage .stage-desc {
+  font-size: 12px;
+  color: var(--ink-3);
+  line-height: 1.4;
+}
+
+.pipeline-arrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-3);
+  font-size: 18px;
+  background: var(--paper);
+  padding: 0 4px;
+  flex-shrink: 0;
+}
+
+/* ── Primitives Grid (index page) ─────────────────────────────────────── */
 .primitives-grid {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
@@ -512,36 +818,7 @@ section:last-of-type {
   color: var(--signal);
 }
 
-/* ─── Correlation Section ──────────────────────────────────────────── */
-.correlation-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 48px;
-  align-items: start;
-}
-
-.code-block {
-  font-family: var(--mono);
-  font-size: 13px;
-  line-height: 1.6;
-  background: var(--ink);
-  color: var(--paper);
-  padding: 24px;
-  border: 1px solid var(--ink);
-  overflow-x: auto;
-  white-space: pre;
-  margin: 0;
-}
-
-.code-block .code-comment {
-  color: var(--ink-3);
-}
-
-.code-block .code-signal {
-  color: var(--signal-3);
-}
-
-/* ─── Boundaries Grid (3x2) ───────────────────────────────────────── */
+/* ── Boundaries Grid ───────────────────────────────────────────────────── */
 .boundaries-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -578,45 +855,14 @@ section:last-of-type {
   margin: 0;
 }
 
-/* ─── Dark Section (Manifesto) ─────────────────────────────────────── */
-.section-dark {
-  background: var(--ink);
-  color: var(--paper);
-  border-bottom-color: var(--ink);
-}
-
-.section-dark .t-eyebrow {
-  color: var(--ink-3);
-}
-
-.manifesto-quote {
-  font-family: var(--display);
-  font-size: clamp(22px, 3.5vw, 36px);
-  font-weight: 300;
-  font-style: italic;
-  line-height: 1.35;
-  letter-spacing: -0.02em;
-  color: var(--paper);
-  margin: 0;
-  max-width: 52ch;
-}
-
-/* ─── Final CTA Section ───────────────────────────────────────────── */
-.final-cta {
-  text-align: center;
-}
-
-.final-cta .section-inner {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 24px;
-}
-
-/* ─── Footer ───────────────────────────────────────────────────────── */
+/* ── Footer ────────────────────────────────────────────────────────────── */
 .site-footer {
   border-top: 1px solid var(--ink);
   background: var(--paper);
+  padding: 32px 0;
+}
+.site-footer > p {
+  text-align: center;
 }
 
 .footer-grid {
@@ -642,9 +888,10 @@ section:last-of-type {
 }
 
 .footer-brand-tagline {
-  font-family: var(--mono);
-  font-size: 12px;
-  color: var(--ink-3);
+  font-family: var(--sans);
+  font-size: 13px;
+  color: var(--ink-2);
+  line-height: 1.4;
 }
 
 .footer-col-title {
@@ -670,7 +917,7 @@ section:last-of-type {
   text-decoration: none;
   font-size: 13px;
   color: var(--ink-2);
-  transition: color 120ms ease;
+  transition: color var(--ease);
 }
 
 .footer-col a:hover {
@@ -687,427 +934,52 @@ section:last-of-type {
   color: var(--ink-3);
 }
 
-/* ─── Legacy Compat: Panel / Card / Pipeline (demo pages) ──────────── */
-.panel {
-  background: var(--paper);
-  border: 1px solid var(--rule);
-  padding: 24px;
-  min-width: 0;
-}
-
-.card {
-  background: var(--paper);
-  border: 1px solid var(--rule);
-  padding: 16px;
-}
-
-.card p {
-  margin: 8px 0 0;
-  color: var(--ink-2);
-  line-height: 1.45;
-  font-size: 14px;
-}
-
-.product-card,
-.feature-card,
-.journey,
-.stack-layer {
-  background: var(--paper);
-  border: 1px solid var(--rule);
-  padding: 16px;
-}
-
-.product-card p,
-.feature-card p,
-.journey p,
-.stack-layer p {
-  margin: 8px 0 0;
-  color: var(--ink-2);
-  line-height: 1.45;
-  font-size: 14px;
-}
-
-.accent-otlp {
-  border-left: 3px solid var(--signal);
-}
-.accent-octo {
-  border-left: 3px solid var(--signal-2);
-}
-.accent-bench {
-  border-left: 3px solid var(--ink-2);
-}
-.accent-tsdb {
-  border-left: 3px solid var(--signal);
-}
-
-.card-links {
-  margin-top: 12px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.card-links a {
-  text-decoration: none;
-  color: var(--ink);
-  font-family: var(--mono);
-  font-size: 12px;
-  font-weight: 600;
-  border: 1px solid var(--rule);
-  padding: 6px 12px;
-  transition: border-color 120ms ease;
-}
-
-.card-links a:hover {
-  border-color: var(--ink);
-}
-
-.actions {
-  margin-top: 14px;
-  display: grid;
-  gap: 8px;
-}
-
-.actions a {
-  text-decoration: none;
-  color: var(--ink);
-  font-size: 14px;
-  font-weight: 500;
-  border: 1px solid var(--rule);
-  padding: 10px 12px;
-  transition: border-color 120ms ease;
-}
-
-.actions a:hover {
-  border-color: var(--ink);
-}
-
-/* Legacy grid */
-.grid {
-  display: grid;
-  gap: 12px;
-}
-.grid-2 {
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-.grid-3 {
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-.grid-4 {
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-}
-
-/* Legacy CTA */
-.cta {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  text-decoration: none;
-  color: var(--ink);
-  font-family: var(--mono);
-  font-size: 13px;
-  font-weight: 600;
-  border: 1px solid var(--ink);
-  padding: 10px 16px;
-  transition:
-    background 120ms ease,
-    color 120ms ease;
-}
-
-.cta:hover {
+/* ── Dark Section (Manifesto) ──────────────────────────────────────────── */
+.section-dark {
   background: var(--ink);
   color: var(--paper);
+  border-bottom-color: var(--ink);
 }
 
-.cta-primary {
-  background: var(--ink);
-  color: var(--paper);
-}
-
-.cta-primary:hover {
-  background: var(--ink-2);
-}
-
-/* Legacy eyebrow */
-.eyebrow {
-  margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  font-size: 11px;
-  font-weight: 700;
+.section-dark .t-eyebrow {
   color: var(--ink-3);
-  font-family: var(--mono);
 }
 
-/* Legacy section-intro */
-.section-intro {
-  margin: 0 0 16px;
-  color: var(--ink-2);
-  max-width: 68ch;
-  line-height: 1.5;
-}
-
-/* Legacy pipeline (demo pages) */
-.pipeline-stage {
-  flex: 1;
-  min-width: 140px;
-  text-align: center;
-  padding: 16px 12px;
-  background: var(--paper);
-  border: 1px solid var(--rule);
-  position: relative;
-}
-
-.pipeline-stage .stage-name {
-  font-family: var(--mono);
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--ink);
-}
-
-.pipeline-stage .stage-desc {
-  font-size: 12px;
-  color: var(--ink-3);
-  margin-top: 4px;
+.manifesto-quote {
+  font-family: var(--display);
+  font-size: clamp(22px, 3.5vw, 36px);
+  font-weight: 300;
+  font-style: italic;
   line-height: 1.35;
+  letter-spacing: -0.02em;
+  color: var(--paper);
+  margin: 0;
+  max-width: 52ch;
 }
 
-.pipeline-arrow {
-  display: flex;
-  align-items: center;
-  padding: 0 6px;
-  color: var(--ink-3);
-  font-size: 18px;
-  flex-shrink: 0;
-}
-
-/* Legacy code */
-code {
+/* ── Code Block ────────────────────────────────────────────────────────── */
+.code-block {
   font-family: var(--mono);
-  font-size: 12px;
-  background: var(--paper-2);
-  border: 1px solid var(--rule);
-  padding: 2px 6px;
-}
-
-.code-panel pre {
-  margin: 12px 0 0;
-  padding: 16px;
-  width: 100%;
-  max-width: 100%;
-  overflow-x: auto;
-  box-sizing: border-box;
-  border: 1px solid var(--ink);
+  font-size: 13px;
+  line-height: 1.6;
   background: var(--ink);
   color: var(--paper);
-  font-size: 12px;
-  line-height: 1.5;
+  padding: 24px;
+  border: 1px solid var(--ink);
+  overflow-x: auto;
+  white-space: pre;
+  margin: 0;
 }
 
-.code-panel pre code {
-  background: transparent;
-  border: 0;
-  padding: 0;
-  color: inherit;
-}
-
-/* Legacy tables */
-.regression-table {
-  width: 100%;
-  min-width: 520px;
-  border-collapse: collapse;
-  font-size: 13px;
-  margin-top: 8px;
-}
-
-.regression-table th {
-  text-align: left;
-  font-weight: 600;
-  color: var(--ink-3);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 8px 12px;
-  border-bottom: 2px solid var(--ink);
-}
-
-.regression-table td {
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--rule);
-  font-family: var(--mono);
-  font-size: 13px;
-}
-
-.regression-table .pass {
-  color: #2d7a3a;
-}
-.regression-table .fail {
-  color: #dc2626;
-}
-
-/* Legacy data-tree */
-.data-tree {
-  font-family: var(--mono);
-  font-size: 12px;
-  line-height: 1.7;
-  color: var(--ink-2);
-  padding: 12px 16px;
-  background: var(--paper-2);
-  border: 1px solid var(--rule);
-  margin-top: 8px;
-}
-
-.data-tree .tree-dir {
-  color: var(--ink);
-  font-weight: 600;
-}
-.data-tree .tree-file {
+.code-block .code-comment {
   color: var(--ink-3);
 }
 
-/* Legacy try/learn strips */
-.try-strip {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 10px;
+.code-block .code-signal {
+  color: var(--signal-3);
 }
 
-.try-strip a {
-  text-decoration: none;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 14px 16px;
-  background: var(--paper);
-  border: 1px solid var(--rule);
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--ink);
-  transition: border-color 120ms ease;
-}
-
-.try-strip a:hover {
-  border-color: var(--ink);
-}
-
-.learn-strip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 8px;
-}
-
-.learn-strip a {
-  text-decoration: none;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 14px;
-  border: 1px solid var(--rule);
-  color: var(--ink);
-  font-family: var(--mono);
-  font-size: 12px;
-  font-weight: 600;
-  transition: border-color 120ms ease;
-}
-
-.learn-strip a:hover {
-  border-color: var(--ink);
-}
-
-/* Legacy format/pkg */
-.pkg-card {
-  background: var(--paper);
-  border: 1px solid var(--rule);
-  padding: 16px;
-}
-
-.pkg-card .pkg-name {
-  font-family: var(--mono);
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--ink);
-}
-
-.pkg-card .pkg-desc {
-  margin: 6px 0 0;
-  font-size: 13px;
-  color: var(--ink-2);
-  line-height: 1.4;
-}
-
-.pkg-card .pkg-exports {
-  margin: 10px 0 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-}
-
-.pkg-card .pkg-exports li {
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--ink-3);
-  background: var(--paper-2);
-  padding: 2px 7px;
-}
-
-.format-strip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 4px;
-}
-
-.format-strip .format-tag {
-  font-family: var(--mono);
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--ink);
-  background: var(--paper);
-  border: 1px solid var(--rule);
-  padding: 6px 12px;
-}
-
-/* Legacy checklist */
-.checklist {
-  margin: 10px 0 0;
-  padding-left: 18px;
-  color: var(--ink-2);
-  line-height: 1.4;
-  display: grid;
-  gap: 4px;
-}
-
-.checklist.wide {
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  padding-left: 0;
-  list-style: none;
-}
-
-.checklist.wide li {
-  border: 1px solid var(--rule);
-  background: var(--paper);
-  padding: 10px 12px;
-}
-
-/* Legacy stack-flow */
-.stack-flow {
-  display: grid;
-  gap: 10px;
-}
-.layer-otlp {
-  border-left: 3px solid var(--signal);
-}
-.layer-octo {
-  border-left: 3px solid var(--signal-2);
-}
-.layer-bench {
-  border-left: 3px solid var(--ink-2);
-}
-
-/* ─── Accessibility ────────────────────────────────────────────────── */
+/* ── Skip Link ─────────────────────────────────────────────────────────── */
 .skip-link {
   position: absolute;
   top: -40px;
@@ -1129,7 +1001,139 @@ code {
   outline-offset: 2px;
 }
 
-/* ─── Responsive ───────────────────────────────────────────────────── */
+/* ── Layout Utilities ──────────────────────────────────────────────────── */
+
+.grid {
+  display: grid;
+  gap: 12px;
+}
+.grid-2 { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+.grid-3 { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
+.grid-4 { grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+
+.try-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
+}
+.try-strip a {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+  transition: border-color var(--ease);
+  text-decoration: none;
+}
+.try-strip a:hover {
+  border-color: var(--ink);
+}
+
+.learn-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 8px;
+}
+.learn-strip a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border: 1px solid var(--rule);
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  transition: border-color var(--ease);
+  text-decoration: none;
+}
+.learn-strip a:hover {
+  border-color: var(--ink);
+}
+
+.format-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+.format-tag {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  padding: 6px 12px;
+}
+
+.checklist {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  color: var(--ink-2);
+  line-height: 1.4;
+  display: grid;
+  gap: 4px;
+}
+.checklist.wide {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding-left: 0;
+  list-style: none;
+}
+.checklist.wide li {
+  border: 1px solid var(--rule);
+  background: var(--paper);
+  padding: 10px 12px;
+}
+
+.actions {
+  margin-top: 14px;
+  display: grid;
+  gap: 8px;
+}
+.actions a {
+  text-decoration: none;
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 500;
+  border: 1px solid var(--rule);
+  padding: 10px 12px;
+  transition: border-color var(--ease);
+}
+.actions a:hover {
+  border-color: var(--ink);
+}
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+.pill {
+  display: inline-block;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-2);
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  padding: 6px 12px;
+  border-radius: 999px;
+}
+.pill:hover {
+  border-color: var(--ink);
+}
+
+.muted {
+  color: var(--ink-muted);
+}
+
+/* ── Responsive ────────────────────────────────────────────────────────── */
 @media (max-width: 1024px) {
   :root {
     --gutter: 32px;
@@ -1187,15 +1191,16 @@ code {
     grid-template-columns: 1fr;
   }
 
-  .pipeline-step {
+  .pipeline-stage {
     border-right: none;
     border-bottom: 1px solid var(--ink);
   }
 
-  .pipeline-step:last-child {
+  .pipeline-stage:last-child {
     border-bottom: none;
   }
-  .pipeline-arrow-r::after {
+
+  .pipeline-arrow {
     display: none;
   }
 
@@ -1228,11 +1233,6 @@ code {
 
   .primitive-card:last-child {
     border-bottom: none;
-  }
-
-  .correlation-grid {
-    grid-template-columns: 1fr;
-    gap: 24px;
   }
 
   .boundaries-grid {

--- a/site/styles.css
+++ b/site/styles.css
@@ -11,20 +11,20 @@
   --rule: rgba(17, 17, 15, 0.16);
   --rule-2: rgba(17, 17, 15, 0.08);
 
-   /* Global accent — engines override this in their base.css */
-   --signal: oklch(0.66 0.16 42);
-   --signal-2: oklch(0.55 0.17 38);
-   --signal-3: oklch(0.86 0.06 60);
+  /* Global accent — engines override this in their base.css */
+  --signal: oklch(0.66 0.16 42);
+  --signal-2: oklch(0.55 0.17 38);
+  --signal-3: oklch(0.86 0.06 60);
 
-   /* Per-product accent defaults */
-   --accent-otlp: var(--signal);
-   --accent-tsdb: var(--signal);
-   --accent-octo: var(--signal-2);
-   --accent-bench: var(--ink-2);
+  /* Per-product accent defaults */
+  --accent-otlp: var(--signal);
+  --accent-tsdb: var(--signal);
+  --accent-octo: var(--signal-2);
+  --accent-bench: var(--ink-2);
 
   /* ── Typography ───────────────────────────────────────────────────────── */
-  --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  --display: "Fraunces", "Iowan Old Style", Georgia, serif;
+  --mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", "Menlo", monospace;
+  --display: "Fraunces", "Iowan Old Style", "Georgia", serif;
   --sans: "Inter Tight", ui-sans-serif, system-ui, sans-serif;
 
   /* ── Layout ──────────────────────────────────────────────────────────── */
@@ -62,6 +62,22 @@
 *::before,
 *::after {
   box-sizing: border-box;
+}
+
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+figure,
+blockquote,
+dl,
+dd,
+ul,
+ol {
   margin: 0;
 }
 
@@ -88,6 +104,8 @@ img {
 a {
   color: inherit;
   text-decoration: none;
+}
+
 /* Inline code */
 code {
   font-family: var(--mono);
@@ -96,8 +114,6 @@ code {
   border: 1px solid var(--rule);
   padding: 2px 6px;
   border-radius: 4px;
-}
-
 }
 
 /* ── Typography Scale ──────────────────────────────────────────────────── */
@@ -198,66 +214,8 @@ code {
 }
 
 /* ── Buttons ───────────────────────────────────────────────────────────── */
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  font-family: var(--mono);
-  font-size: 13px;
-  font-weight: 600;
-  text-decoration: none;
-  border: 1px solid var(--ink);
-  padding: 10px 18px;
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: all var(--ease);
-  background: transparent;
-  color: var(--ink);
-  white-space: nowrap;
-}
-
-.btn:hover {
-  background: var(--paper-2);
-  border-color: var(--ink);
-}
-
-.btn-primary {
-  background: var(--ink);
-  color: var(--paper);
-  border-color: var(--ink);
-}
-
- .btn-primary:hover {
-   background: var(--ink-2);
-   border-color: var(--ink-2);
- }
-
-/* Stamp button aliases for backward compatibility */
-.stamp {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  font-family: var(--mono);
-  font-size: 13px;
-  font-weight: 600;
-  text-decoration: none;
-  border: 1px solid var(--ink);
-  padding: 10px 18px;
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: all var(--ease);
-  background: transparent;
-  color: var(--ink);
-  white-space: nowrap;
-}
-
-.stamp:hover {
-  background: var(--paper-2);
-  border-color: var(--ink);
-}
-
+.btn,
+.stamp,
 .stamp-fill {
   display: inline-flex;
   align-items: center;
@@ -272,17 +230,31 @@ code {
   border-radius: var(--radius);
   cursor: pointer;
   transition: all var(--ease);
-  background: var(--ink);
-  color: var(--paper);
+  background: transparent;
+  color: var(--ink);
   white-space: nowrap;
 }
 
+.btn:hover,
+.stamp:hover {
+  background: var(--paper-2);
+  border-color: var(--ink);
+}
+
+.btn-primary,
+.stamp-fill {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+
+.btn-primary:hover,
 .stamp-fill:hover {
   background: var(--ink-2);
   border-color: var(--ink-2);
 }
 
- .btn-secondary {
+.btn-secondary {
   background: transparent;
   color: var(--ink-2);
   border-color: var(--rule);
@@ -465,6 +437,21 @@ code {
   gap: 12px;
   justify-content: center;
   margin-bottom: 48px;
+}
+
+/* ── Tags ──────────────────────────────────────────────────────────────── */
+.tag {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--rule);
+  padding: 4px 10px;
+  color: var(--ink-3);
+  background: transparent;
 }
 
 /* ── Card / Panel ──────────────────────────────────────────────────────── */
@@ -697,15 +684,31 @@ section:last-of-type {
 }
 
 /* ── Accent Color Utilities ───────────────────────────────────────────── */
-.card.accent-otlp { border-left: 3px solid var(--accent-otlp); }
-.card.accent-tsdb { border-left: 3px solid var(--accent-tsdb); }
-.card.accent-octo { border-left: 3px solid var(--accent-octo); }
-.card.accent-bench { border-left: 3px solid var(--accent-bench); }
+.card.accent-otlp {
+  border-left: 3px solid var(--accent-otlp);
+}
+.card.accent-tsdb {
+  border-left: 3px solid var(--accent-tsdb);
+}
+.card.accent-octo {
+  border-left: 3px solid var(--accent-octo);
+}
+.card.accent-bench {
+  border-left: 3px solid var(--accent-bench);
+}
 
-.pipeline-stage.accent-otlp { border-top: 3px solid var(--accent-otlp); }
-.pipeline-stage.accent-tsdb { border-top: 3px solid var(--accent-tsdb); }
-.pipeline-stage.accent-octo { border-top: 3px solid var(--accent-octo); }
-.pipeline-stage.accent-bench { border-top: 3px solid var(--accent-bench); }
+.pipeline-stage.accent-otlp {
+  border-top: 3px solid var(--accent-otlp);
+}
+.pipeline-stage.accent-tsdb {
+  border-top: 3px solid var(--accent-tsdb);
+}
+.pipeline-stage.accent-octo {
+  border-top: 3px solid var(--accent-octo);
+}
+.pipeline-stage.accent-bench {
+  border-top: 3px solid var(--accent-bench);
+}
 
 /* ── Pipeline (default flex, used on product pages) ───────────────────── */
 .pipeline {
@@ -865,6 +868,11 @@ section:last-of-type {
   text-align: center;
 }
 
+.signal-link,
+.signal-text {
+  color: var(--signal);
+}
+
 .footer-grid {
   display: grid;
   grid-template-columns: 2fr repeat(4, 1fr);
@@ -1007,9 +1015,15 @@ section:last-of-type {
   display: grid;
   gap: 12px;
 }
-.grid-2 { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
-.grid-3 { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
-.grid-4 { grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+.grid-2 {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+.grid-3 {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+.grid-4 {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
 
 .try-strip {
   display: grid;

--- a/site/tracesdb-engine/css/base.css
+++ b/site/tracesdb-engine/css/base.css
@@ -1,20 +1,19 @@
-/* ─── TracesDB Engine — Base Variables & Reset ───────────────────── */
+/* ─── TracesDB Engine — Theme Overrides ─────────────────────────────── */
 
 :root {
-  /* brand / accent — matches parent --otlp */
+  /* Override global accent color for TracesDB */
+  --signal: #e85d1a;
+  --signal-2: #ff8a50;
+  --signal-3: rgba(232, 93, 26, 0.15);
+
+  /* Engine-specific palette */
   --traces: #e85d1a;
   --traces-light: #ff8a50;
   --traces-soft: rgba(232, 93, 26, 0.15);
   --traces-glow: rgba(232, 93, 26, 0.35);
   --traces-dim: rgba(232, 93, 26, 0.08);
 
-  /* sister accent colors from parent styles.css */
-  --accent-otlp: #e85d1a;
-  --accent-tsdb: #7c3aed;
-  --accent-octo: #058d75;
-  --accent-bench: #1259e0;
-
-  /* service palette (12 distinct services) */
+  /* Services */
   --svc-0: #06b6d4;
   --svc-1: #8b5cf6;
   --svc-2: #f59e0b;
@@ -28,22 +27,22 @@
   --svc-10: #a78bfa;
   --svc-11: #fb923c;
 
-  /* status */
+  /* Status */
   --status-ok: #10b981;
   --status-error: #ef4444;
   --status-unset: #6b7280;
 
-  /* dark panels */
+  /* Dark theme (used in explorers) */
   --dark-bg: #0a1929;
   --dark-surface: #0f2640;
   --dark-surface-alt: #132d4a;
-  --dark-border: rgba(96, 165, 250, 0.18);
-  --dark-border-strong: rgba(96, 165, 250, 0.35);
+  --dark-border: rgba(232, 93, 26, 0.18);
+  --dark-border-strong: rgba(232, 93, 26, 0.35);
   --dark-text: #e2e8f0;
   --dark-muted: #94a3b8;
   --dark-accent: #60a5fa;
 
-  /* byte explorer section colors */
+  /* Region colors */
   --region-header: #e85d1a;
   --region-timestamps: #06b6d4;
   --region-durations: #10b981;
@@ -56,11 +55,11 @@
   --region-links: #14b8a6;
   --region-bloom: #a78bfa;
 
-  /* highlight / selection */
+  /* Highlight */
   --highlight-primary: #3b82f6;
   --highlight-bg: rgba(59, 130, 246, 0.15);
 
-  /* z-index scale */
+  /* Z-index */
   --z-cell: 1;
   --z-highlight: 2;
   --z-hover: 3;
@@ -68,17 +67,17 @@
   --z-decode-panel: 10;
   --z-tooltip: 50;
 
-  /* badges for storage modes */
+  /* Badges */
   --badge-hot-bg: rgba(239, 68, 68, 0.15);
   --badge-hot-text: #fca5a5;
   --badge-frozen-bg: rgba(96, 165, 250, 0.15);
   --badge-frozen-text: #93c5fd;
 }
 
-/* ─── Section intro ──────────────────────────────────────────────── */
+/* ─── Section Intro ──────────────────────────────────────────────────── */
 .section-intro {
   margin: 0 0 18px;
-  color: var(--ink-soft);
+  color: var(--ink-2);
   max-width: 72ch;
   font-size: 16px;
   line-height: 1.5;

--- a/site/tracesdb-engine/index.html
+++ b/site/tracesdb-engine/index.html
@@ -28,7 +28,7 @@
     <main id="main-content" class="page">
 
       <!-- ─── Top Bar ─────────────────────────────────────────── -->
-      <header class="topbar panel">
+      <header class="topbar">
         <a class="brand" href="/o11ykit/"><img class="brand-mark" src="/o11ykit/logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
@@ -41,10 +41,10 @@
       </header>
 
       <!-- ─── Hero ────────────────────────────────────────────── -->
-      <section class="hero panel">
-        <span class="hero-eyebrow">o11ytracesdb engine</span>
+      <section class="hero grid-bg">
+         <span class="t-eyebrow">o11ytracesdb engine</span>
         <h1>A distributed traces database<br/>that runs <em>in your browser</em>.</h1>
-        <p class="hero-subtitle">SQLite for observability — embedded, serverless, zero network calls.</p>
+         <p class="hero-lede">SQLite for observability — embedded, serverless, zero network calls.</p>
         <p class="hero-lede">
           Store hundreds of thousands of OpenTelemetry spans at <strong>&lt;30 bytes/span</strong> using
           columnar compression and dictionary encoding. Query with structural operators, explore with
@@ -65,11 +65,11 @@
           </div>
         </div>
         <div class="hero-actions">
-          <button type="button" class="cta cta-primary" id="heroLaunch">🚀 Launch Demo</button>
-          <a class="cta cta-secondary" href="learn/">Learn How It Works</a>
-          <a class="cta cta-secondary" href="https://github.com/strawgate/o11ykit/tree/main/packages/o11ytracesdb" target="_blank" rel="noreferrer">
-            Browse Source
-          </a>
+          <button type="button" class="stamp-fill" id="heroLaunch">🚀 Launch Demo</button>
+           <a class="stamp" href="learn/">Learn How It Works</a>
+           <a class="stamp" href="https://github.com/strawgate/o11ykit/tree/main/packages/o11ytracesdb" target="_blank" rel="noreferrer">
+             Browse Source
+           </a>
         </div>
       </section>
 
@@ -520,11 +520,13 @@
       </section>
 
       <!-- ─── Footer ──────────────────────────────────────────── -->
-      <footer class="panel" style="text-align:center; padding:16px; font-size:13px; color:var(--ink-muted)">
-        <strong>o11ytracesdb</strong> · Part of <a href="/o11ykit/" style="color:var(--traces)">o11ykit</a> ·
-        Browser-native databases for <a href="/o11ykit/tsdb-engine/" style="color:var(--accent-tsdb)">metrics</a>,
-        <span style="color:var(--traces)">traces</span>, and logs ·
-        <a href="https://github.com/strawgate/o11ykit" style="color:var(--traces)">GitHub</a>
+      <footer class="site-footer">
+        <p>
+          <strong>o11ytracesdb</strong> · Part of <a href="/o11ykit/">o11ykit</a> ·
+          Browser-native databases for <a href="/o11ykit/tsdb-engine/" style="color:var(--signal)">metrics</a>,
+          <span style="color:var(--signal)">traces</span> and logs ·
+          <a href="https://github.com/strawgate/o11ykit" style="color:var(--signal)">GitHub</a>
+        </p>
       </footer>
 
     </main>

--- a/site/tracesdb-engine/index.html
+++ b/site/tracesdb-engine/index.html
@@ -42,9 +42,9 @@
 
       <!-- ─── Hero ────────────────────────────────────────────── -->
       <section class="hero grid-bg">
-         <span class="t-eyebrow">o11ytracesdb engine</span>
+        <span class="t-eyebrow">o11ytracesdb engine</span>
         <h1>A distributed traces database<br/>that runs <em>in your browser</em>.</h1>
-         <p class="hero-lede">SQLite for observability — embedded, serverless, zero network calls.</p>
+        <p class="hero-sub">SQLite for observability — embedded, serverless, zero network calls.</p>
         <p class="hero-lede">
           Store hundreds of thousands of OpenTelemetry spans at <strong>&lt;30 bytes/span</strong> using
           columnar compression and dictionary encoding. Query with structural operators, explore with
@@ -523,9 +523,9 @@
       <footer class="site-footer">
         <p>
           <strong>o11ytracesdb</strong> · Part of <a href="/o11ykit/">o11ykit</a> ·
-          Browser-native databases for <a href="/o11ykit/tsdb-engine/" style="color:var(--signal)">metrics</a>,
-          <span style="color:var(--signal)">traces</span> and logs ·
-          <a href="https://github.com/strawgate/o11ykit" style="color:var(--signal)">GitHub</a>
+          Browser-native databases for <a href="/o11ykit/tsdb-engine/" class="signal-link">metrics</a>,
+          <span class="signal-text">traces</span> and logs ·
+          <a href="https://github.com/strawgate/o11ykit" class="signal-link">GitHub</a>
         </p>
       </footer>
 

--- a/site/tracesdb-engine/learn/bloom-filters/index.html
+++ b/site/tracesdb-engine/learn/bloom-filters/index.html
@@ -47,7 +47,7 @@
       .topnav a:hover { color: #fff; border-color: var(--xp-accent); }
       .topnav a[aria-current="page"] { color: var(--xp-accent-light); border-color: var(--xp-accent); background: var(--xp-accent-glow); }
 
-      .page { max-width: var(--xp-max-width); }
+      .page { max-width: var(--xp-max-width); margin: 0 auto; padding: 0 24px 48px; }
 
       .xp-breadcrumb { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--xp-text-dim); padding: 16px 0; border-bottom: 1px solid var(--xp-border); margin-bottom: 40px; }
       .xp-breadcrumb a { color: var(--xp-text-muted); text-decoration: none; transition: color 150ms; }

--- a/site/tracesdb-engine/learn/dictionary-encoding/index.html
+++ b/site/tracesdb-engine/learn/dictionary-encoding/index.html
@@ -47,7 +47,7 @@
       .topnav a:hover { color: #fff; border-color: var(--xp-accent); }
       .topnav a[aria-current="page"] { color: var(--xp-accent-light); border-color: var(--xp-accent); background: var(--xp-accent-glow); }
 
-      .page { max-width: var(--xp-max-width); }
+      .page { max-width: var(--xp-max-width); margin: 0 auto; padding: 0 24px 48px; }
 
       .xp-breadcrumb { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--xp-text-dim); padding: 16px 0; border-bottom: 1px solid var(--xp-border); margin-bottom: 40px; }
       .xp-breadcrumb a { color: var(--xp-text-muted); text-decoration: none; transition: color 150ms; }

--- a/site/tracesdb-engine/learn/index.html
+++ b/site/tracesdb-engine/learn/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Interactive experiences that teach you how a distributed traces database stores, compresses, and queries span data — from dictionary encoding to bloom filter lookups." />
     <link rel="icon" href="/o11ykit/logo.svg" type="image/svg+xml" />
     <base href="/o11ykit/tracesdb-engine/learn/" />
-    <link rel="stylesheet" href="../../styles.css" />
+    <link rel="stylesheet" href="/o11ykit/styles.css" />
     <style>
       :root {
         --xp-bg: #0a1624;
@@ -67,6 +67,8 @@
 
       .page {
         max-width: var(--xp-max-width);
+        margin: 0 auto;
+        padding: 0 24px 48px;
       }
 
       .learn-breadcrumb {

--- a/site/tracesdb-engine/learn/nested-sets/index.html
+++ b/site/tracesdb-engine/learn/nested-sets/index.html
@@ -47,7 +47,7 @@
       .topnav a:hover { color: #fff; border-color: var(--xp-accent); }
       .topnav a[aria-current="page"] { color: var(--xp-accent-light); border-color: var(--xp-accent); background: var(--xp-accent-glow); }
 
-      .page { max-width: var(--xp-max-width); }
+      .page { max-width: var(--xp-max-width); margin: 0 auto; padding: 0 24px 48px; }
 
       .xp-breadcrumb { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--xp-text-dim); padding: 16px 0; border-bottom: 1px solid var(--xp-border); margin-bottom: 40px; }
       .xp-breadcrumb a { color: var(--xp-text-muted); text-decoration: none; transition: color 150ms; }

--- a/site/tsdb-engine/css/base.css
+++ b/site/tsdb-engine/css/base.css
@@ -1,13 +1,18 @@
-/* ─── TSDB Engine Docs — CSS Variable Palette ────────────────────── */
+/* ─── TSDB Engine — Theme Overrides ──────────────────────────────────── */
 
 :root {
-  /* Byte explorer region colors */
+  /* Override global accent color for TSDB */
+  --signal: #7c3aed;
+  --signal-2: #a78bfa;
+  --signal-3: #ddd6fe;
+
+  /* Byte explorer palette */
   --region-header: #8b5cf6;
   --region-timestamps: #06b6d4;
   --region-values: #10b981;
   --region-exceptions: #f59e0b;
 
-  /* Dark theme (byte explorer, codec insight) */
+  /* Dark theme (used in byte-explorer code blocks) */
   --dark-bg: #0a1929;
   --dark-bg-alt: #0d2137;
   --dark-text: #e2e8f0;
@@ -26,7 +31,7 @@
   --bit-0-text: #64748b;
   --bit-1-text: #e2e8f0;
 
-  /* Backend badges */
+  /* Badges */
   --badge-flat-bg: #fef3c7;
   --badge-flat-text: #92400e;
   --badge-chunked-bg: #dbeafe;
@@ -34,7 +39,7 @@
   --badge-column-bg: #d1fae5;
   --badge-column-text: #065f46;
 
-  /* Z-index scale */
+  /* Z-index */
   --z-cell: 1;
   --z-highlight: 2;
   --z-hover: 3;
@@ -42,11 +47,10 @@
   --z-tooltip: 50;
 }
 
-/* ─── TSDB Engine Docs — Base Styles ──────────────────────────────── */
-
+/* ─── Section Intro ──────────────────────────────────────────────────── */
 .section-intro {
   margin: 0 0 18px;
-  color: var(--ink-soft);
+  color: var(--ink-2);
   max-width: 72ch;
   font-size: 16px;
   line-height: 1.5;

--- a/site/tsdb-engine/index.html
+++ b/site/tsdb-engine/index.html
@@ -31,7 +31,7 @@
     <main id="main-content" class="page">
 
       <!-- ─── Top Bar ─────────────────────────────────────────── -->
-      <header class="topbar panel">
+      <header class="topbar">
         <a class="brand" href="/o11ykit/"><img class="brand-mark" src="/o11ykit/logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
@@ -44,20 +44,20 @@
       </header>
 
       <!-- ─── Hero ────────────────────────────────────────────── -->
-      <section class="hero panel">
-        <p class="eyebrow">o11ytsdb engine</p>
+      <section class="hero grid-bg">
+         <p class="t-eyebrow">o11ytsdb engine</p>
         <h1>A time-series database<br/>that runs in your browser.</h1>
-        <p class="lede">
+         <p class="hero-lede">
           Generate realistic telemetry datasets, inspect how they are stored,
           and run live queries against them without leaving the browser.
           Generate millions of data points below and query them in&nbsp;real&nbsp;time.
         </p>
         <div class="hero-actions">
-          <a class="cta cta-primary" href="#section-dataset">Launch Live Demo ↓</a>
-          <a class="cta" href="learn/">Learn How It Works</a>
-          <a class="cta" href="https://github.com/strawgate/o11ykit/tree/main/packages/o11ytsdb" target="_blank" rel="noreferrer">
-            Browse Source
-          </a>
+           <a class="stamp-fill" href="#section-dataset">Launch Live Demo ↓</a>
+           <a class="stamp" href="learn/">Learn How It Works</a>
+           <a class="stamp" href="https://github.com/strawgate/o11ykit/tree/main/packages/o11ytsdb" target="_blank" rel="noreferrer">
+             Browse Source
+           </a>
         </div>
       </section>
 
@@ -119,7 +119,7 @@
                 <option value="300000">5 min</option>
               </select>
             </div>
-            <button type="button" id="btnCustomGenerate" class="cta cta-primary demo-btn">Generate Data</button>
+            <button type="button" id="btnCustomGenerate" class="stamp-fill demo-btn">Generate Data</button>
           </div>
         </div>
       </section>
@@ -329,7 +329,7 @@
           </section>
         </div>
 
-        <button type="button" id="btnQuery" class="cta cta-primary demo-btn">▶ Execute Query</button>
+        <button type="button" id="btnQuery" class="stamp-fill demo-btn">▶ Execute Query</button>
 
       </section>
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,14 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   resolve: {
     alias: {
+      "@otlpkit/adapters": resolve(__dirname, "packages/adapters/src/index.ts"),
+      "@otlpkit/otlpjson": resolve(__dirname, "packages/otlpjson/src/index.ts"),
+      "@otlpkit/query": resolve(__dirname, "packages/query/src/index.ts"),
+      "@otlpkit/views": resolve(__dirname, "packages/views/src/index.ts"),
       o11ytsdb: resolve(__dirname, "packages/o11ytsdb/src/index.ts"),
+      o11ylogsdb: resolve(__dirname, "packages/o11ylogsdb/src/index.ts"),
+      o11ytracesdb: resolve(__dirname, "packages/o11ytracesdb/src/index.ts"),
+      stardb: resolve(__dirname, "packages/stardb/src/index.ts"),
     },
   },
   test: {


### PR DESCRIPTION
This PR consolidates the site CSS into a unified design system and fixes the review-found page regressions.

Changes:
- Centralized component styles in `site/styles.css`.
- Added graph paper background to product page heroes.
- Standardized buttons (`stamp` / `stamp-fill`), hero classes (`t-eyebrow`, `hero-lede`), topbar, footer, and pipeline components.
- Bundled `logsdb-engine` for GitHub Pages so `/o11ykit/logsdb-engine/` no longer ships bare package imports.
- Fixed TracesDB learn pages so dark-theme styles are not overwritten by bundled global CSS and learn content is centered consistently.
- Fixed LogsDB font token inheritance so body text, cards, nav, and buttons use the shared o11ykit type system.
- Fixed clean CI validation by building `stardb` before consumers, resolving workspace packages to source in Vitest, and covering the existing `stardb` coverage thresholds.

Validation:
- `make clean`
- `make lint` (passes with existing warning diagnostics)
- `make typecheck`
- `make build`
- `make test` (1193 tests, coverage thresholds pass)
- `make pages-build`
- `playwright-cli` visual audit across desktop/mobile samples for home, LogsDB, TracesDB, TSDB, and learn pages.
- `playwright-cli` route audit across 20 local Pages routes: all returned 200 with no page errors or failed requests.

Live Pages note: production `/o11ykit/logsdb-engine/` remains broken until this PR is deployed, because the fix is in this PR branch build output.