### PR TITLE
fix: normalize site navigation

### DIFF
--- a/site/benchkit/index.html
+++ b/site/benchkit/index.html
@@ -25,6 +25,7 @@
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
           <a href="/o11ykit/tracesdb-engine/">TracesDB</a>
+          <a href="/o11ykit/logsdb-engine/">LogsDB</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/" aria-current="page">Benchkit</a>
           <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>

--- a/site/index.html
+++ b/site/index.html
@@ -28,6 +28,7 @@
         <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
         <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
         <a href="/o11ykit/tracesdb-engine/">TracesDB</a>
+        <a href="/o11ykit/logsdb-engine/">LogsDB</a>
         <a href="/o11ykit/octo11y/">Octo11y</a>
         <a href="/o11ykit/benchkit/">Benchkit</a>
         <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>

--- a/site/logsdb-engine/index.html
+++ b/site/logsdb-engine/index.html
@@ -25,9 +25,10 @@
         <a class="brand" href="/o11ykit/"><img class="brand-mark" src="/o11ykit/logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
-          <a href="/o11ykit/tsdb-engine/">TSDB</a>
+          <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
           <a href="/o11ykit/tracesdb-engine/">TracesDB</a>
           <a href="/o11ykit/logsdb-engine/" aria-current="page">LogsDB</a>
+          <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
           <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>
         </nav>

--- a/site/octo11y/index.html
+++ b/site/octo11y/index.html
@@ -25,6 +25,7 @@
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
           <a href="/o11ykit/tracesdb-engine/">TracesDB</a>
+          <a href="/o11ykit/logsdb-engine/">LogsDB</a>
           <a href="/o11ykit/octo11y/" aria-current="page">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
           <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>

--- a/site/otlpkit-docs/index.html
+++ b/site/otlpkit-docs/index.html
@@ -24,6 +24,8 @@
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/" aria-current="page">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+          <a href="/o11ykit/tracesdb-engine/">TracesDB</a>
+          <a href="/o11ykit/logsdb-engine/">LogsDB</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
           <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>

--- a/site/otlpkit/index.html
+++ b/site/otlpkit/index.html
@@ -24,6 +24,8 @@
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit/" aria-current="page">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+          <a href="/o11ykit/tracesdb-engine/">TracesDB</a>
+          <a href="/o11ykit/logsdb-engine/">LogsDB</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
           <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>

--- a/site/styles.css
+++ b/site/styles.css
@@ -987,6 +987,28 @@ section:last-of-type {
   color: var(--signal-3);
 }
 
+.code-panel pre {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.code-panel pre code {
+  display: block;
+  width: max-content;
+  min-width: 100%;
+}
+
+.table-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.regression-table {
+  min-width: 420px;
+  width: 100%;
+  border-collapse: collapse;
+}
+
 /* ── Skip Link ─────────────────────────────────────────────────────────── */
 .skip-link {
   position: absolute;
@@ -1202,10 +1224,30 @@ section:last-of-type {
   }
 
   .pipeline {
+    flex-direction: column;
     grid-template-columns: 1fr;
   }
 
+  .hero .pipeline {
+    grid-template-columns: 1fr;
+  }
+
+  .pipeline-step {
+    border-right: none;
+    border-bottom: 1px solid var(--ink);
+  }
+
+  .pipeline-step:last-child {
+    border-bottom: none;
+  }
+
+  .pipeline-arrow-r::after {
+    display: none;
+  }
+
   .pipeline-stage {
+    min-width: 0;
+    width: 100%;
     border-right: none;
     border-bottom: 1px solid var(--ink);
   }

--- a/site/tracesdb-engine/index.html
+++ b/site/tracesdb-engine/index.html
@@ -34,6 +34,7 @@
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
           <a href="/o11ykit/tracesdb-engine/" aria-current="page">TracesDB</a>
+          <a href="/o11ykit/logsdb-engine/">LogsDB</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
           <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>

--- a/site/tracesdb-engine/learn/bloom-filters/index.html
+++ b/site/tracesdb-engine/learn/bloom-filters/index.html
@@ -217,6 +217,7 @@
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
           <a href="/o11ykit/tracesdb-engine/" aria-current="page">TracesDB</a>
+          <a href="/o11ykit/logsdb-engine/">LogsDB</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
           <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>

--- a/site/tracesdb-engine/learn/dictionary-encoding/index.html
+++ b/site/tracesdb-engine/learn/dictionary-encoding/index.html
@@ -129,6 +129,7 @@
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
           <a href="/o11ykit/tracesdb-engine/" aria-current="page">TracesDB</a>
+          <a href="/o11ykit/logsdb-engine/">LogsDB</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
           <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>

--- a/site/tracesdb-engine/learn/index.html
+++ b/site/tracesdb-engine/learn/index.html
@@ -277,6 +277,7 @@
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
           <a href="/o11ykit/tracesdb-engine/" aria-current="page">TracesDB</a>
+          <a href="/o11ykit/logsdb-engine/">LogsDB</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
           <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>

--- a/site/tracesdb-engine/learn/nested-sets/index.html
+++ b/site/tracesdb-engine/learn/nested-sets/index.html
@@ -192,6 +192,7 @@
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
           <a href="/o11ykit/tracesdb-engine/" aria-current="page">TracesDB</a>
+          <a href="/o11ykit/logsdb-engine/">LogsDB</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
           <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>

--- a/site/tsdb-engine/index.html
+++ b/site/tsdb-engine/index.html
@@ -37,6 +37,7 @@
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/" aria-current="page">TSDB Engine</a>
           <a href="/o11ykit/tracesdb-engine/">TracesDB</a>
+          <a href="/o11ykit/logsdb-engine/">LogsDB</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
           <a href="/o11ykit/benchkit/">Benchkit</a>
           <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>


### PR DESCRIPTION
## Summary
- normalize the shared static site nav so product pages list OtlpKit, TSDB Engine, TracesDB, LogsDB, Octo11y, Benchkit, and GitHub consistently
- add LogsDB/TracesDB links where they were missing and align the LogsDB TSDB label with the rest of the site
- fix mobile overflow exposed by the longer nav audit by stacking pipelines and constraining code/table overflow inside panels

## Validation
- make pages-build
- playwright-cli route audit against http://127.0.0.1:4174/o11ykit/: 20 generated routes at 1440px desktop and 20 generated routes at 390px mobile, failures=[]
- git diff --check