### PR TITLE
fix: add site nav to TSDB learn pages

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -58,6 +58,7 @@
         "packages/o11ylogsdb/src/chunk.ts",
         "packages/o11ylogsdb/src/drain.ts",
         "packages/o11ylogsdb/bench/**",
+        "packages/o11ylogsdb/test/**",
         "packages/o11ytsdb/test/**"
       ],
       "linter": {

--- a/biome.json
+++ b/biome.json
@@ -58,8 +58,7 @@
         "packages/o11ylogsdb/src/chunk.ts",
         "packages/o11ylogsdb/src/drain.ts",
         "packages/o11ylogsdb/bench/**",
-        "packages/o11ylogsdb/test/**",
-        "packages/o11ytsdb/test/**"
+        "packages/o11ylogsdb/test/**"
       ],
       "linter": {
         "rules": {

--- a/biome.json
+++ b/biome.json
@@ -19,7 +19,8 @@
       "!examples/demo/src/browser-scraper.ts",
       "!octo11y",
       "!packages/o11ytsdb/bench",
-      "!research"
+      "!research",
+      "!**/*.html"
     ]
   },
   "formatter": {

--- a/octo11y/package-lock.json
+++ b/octo11y/package-lock.json
@@ -1621,9 +1621,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.129.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+      "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1837,9 +1837,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
       "cpu": [
         "arm64"
       ],
@@ -1854,9 +1854,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
       "cpu": [
         "arm64"
       ],
@@ -1871,9 +1871,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
       "cpu": [
         "x64"
       ],
@@ -1888,9 +1888,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+      "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
       "cpu": [
         "x64"
       ],
@@ -1905,9 +1905,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
       "cpu": [
         "arm"
       ],
@@ -1922,9 +1922,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
       "cpu": [
         "arm64"
       ],
@@ -1939,9 +1939,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
       "cpu": [
         "arm64"
       ],
@@ -1956,9 +1956,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+      "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
       "cpu": [
         "ppc64"
       ],
@@ -1973,9 +1973,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+      "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
       "cpu": [
         "s390x"
       ],
@@ -1990,9 +1990,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
       "cpu": [
         "x64"
       ],
@@ -2007,9 +2007,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
       "cpu": [
         "x64"
       ],
@@ -2024,9 +2024,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+      "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
       "cpu": [
         "arm64"
       ],
@@ -2041,9 +2041,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+      "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
       "cpu": [
         "wasm32"
       ],
@@ -2060,9 +2060,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
       "cpu": [
         "arm64"
       ],
@@ -2077,9 +2077,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
       "cpu": [
         "x64"
       ],
@@ -2094,9 +2094,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+      "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2511,9 +2511,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -5176,9 +5176,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -5410,14 +5410,14 @@
       "license": "Unlicense"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+      "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.129.0",
+        "@rolldown/pluginutils": "1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -5426,21 +5426,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.0",
+        "@rolldown/binding-darwin-arm64": "1.0.0",
+        "@rolldown/binding-darwin-x64": "1.0.0",
+        "@rolldown/binding-freebsd-x64": "1.0.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-musl": "1.0.0",
+        "@rolldown/binding-openharmony-arm64": "1.0.0",
+        "@rolldown/binding-wasm32-wasi": "1.0.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/rollup": {
@@ -6026,7 +6026,7 @@
       },
       "devDependencies": {
         "@preact/preset-vite": "^2.9.0",
-        "vite": "^8.0.10"
+        "vite": "^8.0.11"
       }
     },
     "packages/dashboard/node_modules/@esbuild/aix-ppc64": {
@@ -6542,16 +6542,16 @@
       }
     },
     "packages/dashboard/node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+      "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -6568,7 +6568,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/packages/o11ylogsdb/src/codec-typed.ts
+++ b/packages/o11ylogsdb/src/codec-typed.ts
@@ -39,7 +39,7 @@ import {
   type SidecarEntry,
 } from "./codec-utils.js";
 import { Drain, PARAM_STR, tokenize } from "./drain.js";
-import type { AnyValue, LogRecord, SeverityText } from "./types.js";
+import type { AnyValue, LogRecord } from "./types.js";
 
 // Body kinds (same enum as ColumnarDrainPolicy).
 const KIND_RAW_STRING = 0;

--- a/packages/o11ylogsdb/test/codec-typed-correctness.test.ts
+++ b/packages/o11ylogsdb/test/codec-typed-correctness.test.ts
@@ -248,7 +248,7 @@ describe("TypedColumnarDrainPolicy: toks in codecMeta", () => {
     expect(meta.toks).toBeDefined();
     expect(Array.isArray(meta.toks)).toBe(true);
     // Should contain literal tokens from the template (not wildcards)
-    expect(meta.toks!.length).toBeGreaterThan(0);
+    expect(meta.toks?.length).toBeGreaterThan(0);
     // "user", "logged", "in", "from" should appear as literal tokens
     const toks = meta.toks!;
     expect(toks.some((t) => t === "user" || t === "logged" || t === "in" || t === "from")).toBe(

--- a/packages/o11ylogsdb/test/compact-extended.test.ts
+++ b/packages/o11ylogsdb/test/compact-extended.test.ts
@@ -36,8 +36,8 @@ describe("compact: codec diversity", () => {
     // Verify records round-trip
     const records = readRecords(result.chunk, registry, policy);
     expect(records).toHaveLength(16);
-    expect(records[0]!.body).toBe("line 0");
-    expect(records[15]!.body).toBe("line 15");
+    expect(records[0]?.body).toBe("line 0");
+    expect(records[15]?.body).toBe("line 15");
   });
 
   it("compact from zstd-19 to zstd-3 (lower compression)", () => {
@@ -53,7 +53,7 @@ describe("compact: codec diversity", () => {
 
     const records = readRecords(result.chunk, registry, policy);
     expect(records).toHaveLength(32);
-    expect(records[0]!.body).toBe("log entry number 0 with some padding text");
+    expect(records[0]?.body).toBe("log entry number 0 with some padding text");
   });
 
   it("compact preserves non-string bodies (kvlist)", () => {
@@ -68,9 +68,9 @@ describe("compact: codec diversity", () => {
     const result = compactChunk(chunk, registry, "zstd-3");
     const records = readRecords(result.chunk, registry, policy);
     expect(records).toHaveLength(3);
-    expect(records[0]!.body).toEqual({ method: "GET", status: 200 });
-    expect(records[1]!.body).toEqual({ method: "POST", status: 201 });
-    expect(records[2]!.body).toBe("plain string body");
+    expect(records[0]?.body).toEqual({ method: "GET", status: 200 });
+    expect(records[1]?.body).toEqual({ method: "POST", status: 201 });
+    expect(records[2]?.body).toBe("plain string body");
   });
 
   it("compact preserves rich metadata (traceId, spanId, eventName)", () => {
@@ -138,8 +138,8 @@ describe("compact: TypedColumnar chunks", () => {
     // Read back with policy (needed because typed columnar needs codec meta)
     const records = readRecords(result.chunk, registry, policy);
     expect(records).toHaveLength(16);
-    expect(records[0]!.body).toContain("192.168.1.0");
-    expect(records[15]!.body).toContain("192.168.1.15");
+    expect(records[0]?.body).toContain("192.168.1.0");
+    expect(records[15]?.body).toContain("192.168.1.15");
   });
 });
 

--- a/packages/o11ylogsdb/test/engine-extended.test.ts
+++ b/packages/o11ylogsdb/test/engine-extended.test.ts
@@ -63,7 +63,7 @@ describe("LogStore flush edge cases", () => {
     // First 4 records auto-freeze a chunk
     let lastStats: IngestStats | undefined;
     for (let i = 0; i < 4; i++) lastStats = store.append(resource, scope, rec(i));
-    expect(lastStats!.chunksClosed).toBe(1);
+    expect(lastStats?.chunksClosed).toBe(1);
 
     // Next 2 records are in-flight
     store.append(resource, scope, rec(10));
@@ -93,7 +93,7 @@ describe("LogStore iterRecords edge cases", () => {
     const results = [...store.iterRecords()];
     expect(results).toHaveLength(2);
     // Different resources → different stream IDs
-    expect(results[0]!.streamId).not.toBe(results[1]!.streamId);
+    expect(results[0]?.streamId).not.toBe(results[1]?.streamId);
   });
 
   it("iterRecords with multiple chunks from same stream", () => {
@@ -104,12 +104,12 @@ describe("LogStore iterRecords edge cases", () => {
     const results = [...store.iterRecords()];
     // 10 records → 2 full chunks (4 each) + 1 partial (2)
     expect(results).toHaveLength(3);
-    expect(results[0]!.records).toHaveLength(4);
-    expect(results[1]!.records).toHaveLength(4);
-    expect(results[2]!.records).toHaveLength(2);
+    expect(results[0]?.records).toHaveLength(4);
+    expect(results[1]?.records).toHaveLength(4);
+    expect(results[2]?.records).toHaveLength(2);
     // All same streamId
-    expect(results[0]!.streamId).toBe(results[1]!.streamId);
-    expect(results[1]!.streamId).toBe(results[2]!.streamId);
+    expect(results[0]?.streamId).toBe(results[1]?.streamId);
+    expect(results[1]?.streamId).toBe(results[2]?.streamId);
   });
 });
 
@@ -148,8 +148,8 @@ describe("LogStore with TypedColumnarDrainPolicy", () => {
     const allRecords = results.flatMap((r) => r.records);
     expect(allRecords).toHaveLength(10);
     // Verify round-trip correctness
-    expect(allRecords[0]!.body).toBe("log line 0");
-    expect(allRecords[9]!.body).toBe("log line 9");
-    expect(Number(allRecords[5]!.timeUnixNano)).toBe(1000000005);
+    expect(allRecords[0]?.body).toBe("log line 0");
+    expect(allRecords[9]?.body).toBe("log line 9");
+    expect(Number(allRecords[5]?.timeUnixNano)).toBe(1000000005);
   });
 });

--- a/packages/o11ylogsdb/test/filtered-decode.test.ts
+++ b/packages/o11ylogsdb/test/filtered-decode.test.ts
@@ -54,8 +54,8 @@ describe("decodeFilteredByBodyNeedle: correctness", () => {
     const filtered = readRecordsFilteredFromRaw(raw, chunk.header, "connection", policy);
     const matches = filtered.filter((r) => r !== undefined);
     expect(matches).toHaveLength(2);
-    expect(matches[0]!.body).toContain("connection");
-    expect(matches[1]!.body).toContain("connection");
+    expect(matches[0]?.body).toContain("connection");
+    expect(matches[1]?.body).toContain("connection");
   });
 
   it("returns empty sparse array when no bodies match", () => {
@@ -103,7 +103,7 @@ describe("decodeFilteredByBodyNeedle: correctness", () => {
     expect(match.body).toBe("error in handler");
     expect(match.severityText).toBe("WARN");
     expect(match.attributes).toHaveLength(1);
-    expect(match.attributes[0]!.key).toBe("method");
+    expect(match.attributes[0]?.key).toBe("method");
     expect(match.traceId).toBeDefined();
     expect(match.spanId).toBeDefined();
   });
@@ -153,9 +153,9 @@ describe("decodeFilteredByBodyNeedle: correctness", () => {
 
     expect(filteredRecords).toHaveLength(allRecords.length);
     for (let i = 0; i < allRecords.length; i++) {
-      expect(filteredRecords[i]!.body).toBe(allRecords[i]!.body);
-      expect(filteredRecords[i]!.timeUnixNano).toBe(allRecords[i]!.timeUnixNano);
-      expect(filteredRecords[i]!.severityNumber).toBe(allRecords[i]!.severityNumber);
+      expect(filteredRecords[i]?.body).toBe(allRecords[i]?.body);
+      expect(filteredRecords[i]?.timeUnixNano).toBe(allRecords[i]?.timeUnixNano);
+      expect(filteredRecords[i]?.severityNumber).toBe(allRecords[i]?.severityNumber);
     }
   });
 });
@@ -202,7 +202,7 @@ describe("decodeFilteredByBodyNeedle: template-literal shortcut", () => {
     const filtered = readRecordsFilteredFromRaw(raw, chunk.header, "admin", policy);
     const matches = filtered.filter((r) => r !== undefined);
     expect(matches).toHaveLength(1);
-    expect(matches[0]!.body).toContain("admin");
+    expect(matches[0]?.body).toContain("admin");
   });
 });
 
@@ -226,7 +226,7 @@ describe("decodeFilteredByBodyNeedle: non-string bodies", () => {
     const matches = filtered.filter((r) => r !== undefined);
     // Only the string body "text with map in it" should match
     expect(matches).toHaveLength(1);
-    expect(matches[0]!.body).toBe("text with map in it");
+    expect(matches[0]?.body).toBe("text with map in it");
   });
 });
 

--- a/packages/o11ylogsdb/test/ndjson-roundtrip.test.ts
+++ b/packages/o11ylogsdb/test/ndjson-roundtrip.test.ts
@@ -22,7 +22,7 @@ describe("NDJSON round-trip: falsy field preservation", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.eventName).toBe("");
+    expect(records[0]?.eventName).toBe("");
   });
 
   it("droppedAttributesCount=0 round-trips correctly", () => {
@@ -38,7 +38,7 @@ describe("NDJSON round-trip: falsy field preservation", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.droppedAttributesCount).toBe(0);
+    expect(records[0]?.droppedAttributesCount).toBe(0);
   });
 
   it("flags=0 round-trips correctly", () => {
@@ -54,7 +54,7 @@ describe("NDJSON round-trip: falsy field preservation", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.flags).toBe(0);
+    expect(records[0]?.flags).toBe(0);
   });
 
   it("all optional fields undefined stay undefined on round-trip", () => {
@@ -69,12 +69,12 @@ describe("NDJSON round-trip: falsy field preservation", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.eventName).toBeUndefined();
-    expect(records[0]!.droppedAttributesCount).toBeUndefined();
-    expect(records[0]!.flags).toBeUndefined();
-    expect(records[0]!.traceId).toBeUndefined();
-    expect(records[0]!.spanId).toBeUndefined();
-    expect(records[0]!.observedTimeUnixNano).toBeUndefined();
+    expect(records[0]?.eventName).toBeUndefined();
+    expect(records[0]?.droppedAttributesCount).toBeUndefined();
+    expect(records[0]?.flags).toBeUndefined();
+    expect(records[0]?.traceId).toBeUndefined();
+    expect(records[0]?.spanId).toBeUndefined();
+    expect(records[0]?.observedTimeUnixNano).toBeUndefined();
   });
 
   it("observedTimeUnixNano=0n round-trips correctly", () => {
@@ -90,7 +90,7 @@ describe("NDJSON round-trip: falsy field preservation", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.observedTimeUnixNano).toBe(0n);
+    expect(records[0]?.observedTimeUnixNano).toBe(0n);
   });
 
   it("traceId and spanId with all zeros round-trip", () => {
@@ -107,8 +107,8 @@ describe("NDJSON round-trip: falsy field preservation", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.traceId).toEqual(new Uint8Array(16));
-    expect(records[0]!.spanId).toEqual(new Uint8Array(8));
+    expect(records[0]?.traceId).toEqual(new Uint8Array(16));
+    expect(records[0]?.spanId).toEqual(new Uint8Array(8));
   });
 });
 
@@ -125,7 +125,7 @@ describe("NDJSON round-trip: complex bodies", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.body).toBeNull();
+    expect(records[0]?.body).toBeNull();
   });
 
   it("nested object body round-trips", () => {
@@ -141,7 +141,7 @@ describe("NDJSON round-trip: complex bodies", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.body).toEqual(body);
+    expect(records[0]?.body).toEqual(body);
   });
 
   it("numeric body round-trips", () => {
@@ -156,7 +156,7 @@ describe("NDJSON round-trip: complex bodies", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.body).toBe(42);
+    expect(records[0]?.body).toBe(42);
   });
 
   it("boolean body round-trips", () => {
@@ -171,7 +171,7 @@ describe("NDJSON round-trip: complex bodies", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.body).toBe(false);
+    expect(records[0]?.body).toBe(false);
   });
 
   it("array body round-trips", () => {
@@ -186,7 +186,7 @@ describe("NDJSON round-trip: complex bodies", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.body).toEqual([1, "two", { three: 3 }]);
+    expect(records[0]?.body).toEqual([1, "two", { three: 3 }]);
   });
 });
 
@@ -213,13 +213,13 @@ describe("LogStore: full pipeline round-trip with all fields", () => {
     store.flush();
 
     const results = [...store.iterRecords()];
-    const decoded = results[0]!.records[0]!;
-    expect(decoded.timeUnixNano).toBe(1234567890n);
-    expect(decoded.observedTimeUnixNano).toBe(1234567891n);
-    expect(decoded.severityNumber).toBe(17);
-    expect(decoded.severityText).toBe("ERROR");
-    expect(decoded.body).toBe("request failed with status 500");
-    expect(decoded.attributes).toEqual([
+    const decoded = results[0]?.records[0];
+    expect(decoded?.timeUnixNano).toBe(1234567890n);
+    expect(decoded?.observedTimeUnixNano).toBe(1234567891n);
+    expect(decoded?.severityNumber).toBe(17);
+    expect(decoded?.severityText).toBe("ERROR");
+    expect(decoded?.body).toBe("request failed with status 500");
+    expect(decoded?.attributes).toEqual([
       { key: "url", value: "/api/users" },
       { key: "method", value: "POST" },
     ]);

--- a/packages/o11ylogsdb/test/query-edge-cases.test.ts
+++ b/packages/o11ylogsdb/test/query-edge-cases.test.ts
@@ -35,8 +35,8 @@ describe("query: raw byte scan edge cases", () => {
     const store = makeStore(records);
     const { records: hits } = query(store, { bodyContains: "🚀" });
     expect(hits).toHaveLength(2);
-    expect(hits[0]!.body).toContain("🚀");
-    expect(hits[1]!.body).toContain("🚀");
+    expect(hits[0]?.body).toContain("🚀");
+    expect(hits[1]?.body).toContain("🚀");
   });
 
   it("CJK multi-byte needle works", () => {
@@ -55,7 +55,7 @@ describe("query: raw byte scan edge cases", () => {
     const store = makeStore(records);
     const { records: hits } = query(store, { bodyContains: "ERROR" });
     expect(hits).toHaveLength(1);
-    expect(hits[0]!.body).toBe("ERROR: something broke");
+    expect(hits[0]?.body).toBe("ERROR: something broke");
   });
 
   it("needle at exact end of body matches", () => {
@@ -91,7 +91,7 @@ describe("query: raw byte scan edge cases", () => {
     const { records: hits } = query(store, { bodyContains: "match" });
     // Only the string-body record matches
     expect(hits).toHaveLength(1);
-    expect(hits[0]!.body).toBe("match me too");
+    expect(hits[0]?.body).toBe("match me too");
   });
 });
 
@@ -194,7 +194,7 @@ describe("query: time range boundary precision", () => {
     const store = makeStore(records);
     const { records: hits } = query(store, { range: { from: 200n, to: 250n } });
     expect(hits).toHaveLength(1);
-    expect(hits[0]!.body).toBe("exact");
+    expect(hits[0]?.body).toBe("exact");
   });
 
   it("range.to is exclusive", () => {
@@ -206,7 +206,7 @@ describe("query: time range boundary precision", () => {
     const store = makeStore(records);
     const { records: hits } = query(store, { range: { from: 100n, to: 200n } });
     expect(hits).toHaveLength(1);
-    expect(hits[0]!.body).toBe("before");
+    expect(hits[0]?.body).toBe("before");
   });
 
   it("chunk boundary: maxNano === range.from passes pruning", () => {
@@ -218,7 +218,7 @@ describe("query: time range boundary precision", () => {
     // range.from = 31000 (the maxNano of chunk 1)
     const { records: hits, stats } = query(store, { range: { from: 31000n, to: 32000n } });
     expect(hits).toHaveLength(1);
-    expect(hits[0]!.body).toBe("line 31");
+    expect(hits[0]?.body).toBe("line 31");
     // Both chunks should be visited (chunk1 has maxNano=31000 === range.from)
     expect(stats.chunksPruned).toBe(1); // chunk2 pruned (minNano=32000 >= to=32000)
   });

--- a/packages/o11ylogsdb/test/query-integration.test.ts
+++ b/packages/o11ylogsdb/test/query-integration.test.ts
@@ -69,8 +69,8 @@ describe("query engine: body fast path uses readRecordsFromRaw", () => {
 
     const { records: hits } = query(store, { bodyContains: "login" });
     expect(hits).toHaveLength(2);
-    expect(hits[0]!.body).toContain("login");
-    expect(hits[1]!.body).toContain("login");
+    expect(hits[0]?.body).toContain("login");
+    expect(hits[1]?.body).toContain("login");
   });
 
   it("bodyContains + limit on NDJSON store", () => {
@@ -132,7 +132,7 @@ describe("query engine: resourceEquals stream pruning", () => {
 
     const { records: hits, stats } = query(store, { resourceEquals: { service: "api" } });
     expect(hits).toHaveLength(2);
-    expect(hits[0]!.body).toBe("api log 1");
+    expect(hits[0]?.body).toBe("api log 1");
     expect(stats.streamsPruned).toBe(1);
   });
 
@@ -156,7 +156,7 @@ describe("query engine: resourceEquals stream pruning", () => {
 
     const { records: hits } = query(store, { resourceEquals: { service: "api", env: "prod" } });
     expect(hits).toHaveLength(1);
-    expect(hits[0]!.body).toBe("prod api");
+    expect(hits[0]?.body).toBe("prod api");
   });
 
   it("resourceEquals with non-matching key prunes all streams", () => {
@@ -208,7 +208,7 @@ describe("query engine: queryStream generator behavior", () => {
     const results = [...queryStream(store, {})];
     expect(results).toHaveLength(12);
     for (let i = 0; i < 12; i++) {
-      expect(results[i]!.body).toBe(`line ${i}`);
+      expect(results[i]?.body).toBe(`line ${i}`);
     }
   });
 });

--- a/packages/o11ytracesdb/src/codec-columnar.ts
+++ b/packages/o11ytracesdb/src/codec-columnar.ts
@@ -25,11 +25,6 @@ import type { KeyValue, SpanEvent, SpanLink, SpanRecord, StatusCode } from "./ty
 
 // ─── Dictionary builder ──────────────────────────────────────────────
 
-interface DictWithIndex {
-  dict: string[];
-  index: Map<string, number>;
-}
-
 // Collect attribute keys/values without intermediate array allocations
 function collectAttrKeys(spans: readonly SpanRecord[]): Iterable<string> {
   return {

--- a/packages/o11ytracesdb/src/codec-columnar.ts
+++ b/packages/o11ytracesdb/src/codec-columnar.ts
@@ -21,7 +21,7 @@
 
 import { ByteBuf, ByteReader, buildDictWithIndex, decodeAnyValue, encodeAnyValue } from "stardb";
 import type { ChunkPolicy } from "./chunk.js";
-import type { AnyValue, KeyValue, SpanEvent, SpanLink, SpanRecord, StatusCode } from "./types.js";
+import type { KeyValue, SpanEvent, SpanLink, SpanRecord, StatusCode } from "./types.js";
 
 // ─── Dictionary builder ──────────────────────────────────────────────
 

--- a/site/tsdb-engine/index.html
+++ b/site/tsdb-engine/index.html
@@ -31,18 +31,7 @@
     <main id="main-content" class="page">
 
       <!-- ─── Top Bar ─────────────────────────────────────────── -->
-      <header class="topbar">
-        <a class="brand" href="/o11ykit/"><img class="brand-mark" src="/o11ykit/logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
-        <nav class="topnav" aria-label="Primary">
-          <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
-          <a href="/o11ykit/tsdb-engine/" aria-current="page">TSDB Engine</a>
-          <a href="/o11ykit/tracesdb-engine/">TracesDB</a>
-          <a href="/o11ykit/logsdb-engine/">LogsDB</a>
-          <a href="/o11ykit/octo11y/">Octo11y</a>
-          <a href="/o11ykit/benchkit/">Benchkit</a>
-          <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>
-        </nav>
-      </header>
+      <!-- @include learn-topbar -->
 
       <!-- ─── Hero ────────────────────────────────────────────── -->
       <section class="hero grid-bg">

--- a/site/tsdb-engine/learn/_topbar.html
+++ b/site/tsdb-engine/learn/_topbar.html
@@ -1,0 +1,12 @@
+<header class="topbar panel">
+  <a class="brand" href="/o11ykit/"><img class="brand-mark" src="/o11ykit/logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
+  <nav class="topnav" aria-label="Primary">
+    <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
+    <a href="/o11ykit/tsdb-engine/" aria-current="page">TSDB Engine</a>
+    <a href="/o11ykit/tracesdb-engine/">TracesDB</a>
+    <a href="/o11ykit/logsdb-engine/">LogsDB</a>
+    <a href="/o11ykit/octo11y/">Octo11y</a>
+    <a href="/o11ykit/benchkit/">Benchkit</a>
+    <a href="https://github.com/strawgate/o11ykit" target="_blank" rel="noreferrer">GitHub</a>
+  </nav>
+</header>

--- a/site/tsdb-engine/learn/_topbar.html
+++ b/site/tsdb-engine/learn/_topbar.html
@@ -1,4 +1,4 @@
-<header class="topbar panel">
+<header class="topbar">
   <a class="brand" href="/o11ykit/"><img class="brand-mark" src="/o11ykit/logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
   <nav class="topnav" aria-label="Primary">
     <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>

--- a/site/tsdb-engine/learn/_topbar.html
+++ b/site/tsdb-engine/learn/_topbar.html
@@ -2,7 +2,7 @@
   <a class="brand" href="/o11ykit/"><img class="brand-mark" src="/o11ykit/logo.svg" width="20" height="20" alt="" aria-hidden="true" />o11ykit</a>
   <nav class="topnav" aria-label="Primary">
     <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
-    <a href="/o11ykit/tsdb-engine/" aria-current="page">TSDB Engine</a>
+    <a href="/o11ykit/tsdb-engine/" aria-current="true">TSDB Engine</a>
     <a href="/o11ykit/tracesdb-engine/">TracesDB</a>
     <a href="/o11ykit/logsdb-engine/">LogsDB</a>
     <a href="/o11ykit/octo11y/">Octo11y</a>

--- a/site/tsdb-engine/learn/alp/index.html
+++ b/site/tsdb-engine/learn/alp/index.html
@@ -14,6 +14,8 @@
     <div class="xp-ambient" aria-hidden="true"></div>
     <div class="xp-page" id="main">
 
+      <!-- @include learn-topbar -->
+
       <div id="breadcrumb-nav"></div>
 
       <div class="xp-hero">

--- a/site/tsdb-engine/learn/chunk-stats/index.html
+++ b/site/tsdb-engine/learn/chunk-stats/index.html
@@ -14,6 +14,8 @@
     <div class="xp-ambient" aria-hidden="true"></div>
     <div class="xp-page" id="main">
 
+      <!-- @include learn-topbar -->
+
       <div id="breadcrumb-nav"></div>
 
       <div class="xp-hero">

--- a/site/tsdb-engine/learn/delta-of-delta/index.html
+++ b/site/tsdb-engine/learn/delta-of-delta/index.html
@@ -14,6 +14,8 @@
     <div class="xp-ambient" aria-hidden="true"></div>
     <div class="xp-page" id="main">
 
+      <!-- @include learn-topbar -->
+
       <div id="breadcrumb-nav"></div>
 
       <div class="xp-hero">

--- a/site/tsdb-engine/learn/index.html
+++ b/site/tsdb-engine/learn/index.html
@@ -141,6 +141,8 @@
     <div class="xp-ambient" aria-hidden="true"></div>
     <div class="xp-page" id="main">
 
+      <!-- @include learn-topbar -->
+
       <nav class="xp-topbar" aria-label="Breadcrumb">
         <div class="xp-breadcrumb">
           <a href="../">TSDB Engine</a>

--- a/site/tsdb-engine/learn/query-engine/index.html
+++ b/site/tsdb-engine/learn/query-engine/index.html
@@ -14,6 +14,8 @@
     <div class="xp-ambient" aria-hidden="true"></div>
     <div class="xp-page" id="main">
 
+      <!-- @include learn-topbar -->
+
       <div id="breadcrumb-nav"></div>
 
       <div class="xp-hero">

--- a/site/tsdb-engine/learn/shared.css
+++ b/site/tsdb-engine/learn/shared.css
@@ -79,6 +79,82 @@ body {
   padding: 0 20px 64px;
 }
 
+/* ─── Site Navigation ─────────────────────────────────────────────── */
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--xp-border);
+  margin-bottom: 16px;
+}
+
+.topbar.panel {
+  background: var(--xp-surface);
+  border: 1px solid var(--xp-border);
+  border-radius: 0;
+  padding: 12px 16px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #fff;
+  font-family: var(--xp-mono);
+  font-size: 15px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.brand-mark {
+  flex-shrink: 0;
+}
+
+.topnav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.topnav a {
+  color: var(--xp-text-muted);
+  background: var(--xp-surface-raised);
+  border: 1px solid var(--xp-border-strong);
+  border-radius: 999px;
+  padding: 7px 10px;
+  font-family: var(--xp-mono);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  text-decoration: none;
+  transition:
+    color 150ms,
+    border-color 150ms,
+    background-color 150ms;
+}
+
+.topnav a:hover {
+  color: #fff;
+  border-color: var(--xp-accent);
+}
+
+.brand:focus-visible,
+.topnav a:focus-visible {
+  color: #fff;
+  border-color: var(--xp-accent);
+  outline: 2px solid var(--xp-accent-light);
+  outline-offset: 2px;
+}
+
+.topnav a[aria-current="page"] {
+  color: var(--xp-accent-light);
+  border-color: var(--xp-accent);
+  background: var(--xp-accent-glow);
+}
+
 /* ─── Top Navigation ──────────────────────────────────────────────── */
 .xp-topbar {
   display: flex;
@@ -546,6 +622,10 @@ body {
 @media (max-width: 640px) {
   .xp-page {
     padding: 0 14px 40px;
+  }
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
   }
   .xp-card {
     padding: 16px;

--- a/site/tsdb-engine/learn/shared.css
+++ b/site/tsdb-engine/learn/shared.css
@@ -85,16 +85,11 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 12px 0;
-  border-bottom: 1px solid var(--xp-border);
-  margin-bottom: 16px;
-}
-
-.topbar.panel {
   background: var(--xp-surface);
   border: 1px solid var(--xp-border);
   border-radius: 0;
   padding: 12px 16px;
+  margin-bottom: 16px;
 }
 
 .brand {

--- a/site/tsdb-engine/learn/shared.css
+++ b/site/tsdb-engine/learn/shared.css
@@ -144,7 +144,8 @@ body {
   outline-offset: 2px;
 }
 
-.topnav a[aria-current="true"], .topnav a[aria-current="page"] {
+.topnav a[aria-current="true"],
+.topnav a[aria-current="page"] {
   color: var(--xp-accent-light);
   border-color: var(--xp-accent);
   background: var(--xp-accent-glow);

--- a/site/tsdb-engine/learn/shared.css
+++ b/site/tsdb-engine/learn/shared.css
@@ -144,7 +144,7 @@ body {
   outline-offset: 2px;
 }
 
-.topnav a[aria-current="page"] {
+.topnav a[aria-current="true"], .topnav a[aria-current="page"] {
   color: var(--xp-accent-light);
   border-color: var(--xp-accent);
   background: var(--xp-accent-glow);

--- a/site/tsdb-engine/learn/string-interning/index.html
+++ b/site/tsdb-engine/learn/string-interning/index.html
@@ -14,6 +14,8 @@
     <div class="xp-ambient" aria-hidden="true"></div>
     <div class="xp-page" id="main">
 
+      <!-- @include learn-topbar -->
+
       <div id="breadcrumb-nav"></div>
 
       <div class="xp-hero">

--- a/site/tsdb-engine/learn/xor-delta/index.html
+++ b/site/tsdb-engine/learn/xor-delta/index.html
@@ -14,6 +14,8 @@
     <div class="xp-ambient" aria-hidden="true"></div>
     <div class="xp-page" id="main">
 
+      <!-- @include learn-topbar -->
+
       <div id="breadcrumb-nav"></div>
 
       <div class="xp-hero">

--- a/site/tsdb-engine/vite.config.ts
+++ b/site/tsdb-engine/vite.config.ts
@@ -1,8 +1,19 @@
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
 
+const learnTopbar = readFileSync(resolve(__dirname, "learn/_topbar.html"), "utf8");
+
 export default defineConfig({
   base: process.env.BASE_PATH ?? "/o11ykit/tsdb-engine/",
+  plugins: [
+    {
+      name: "o11ykit-learn-topbar",
+      transformIndexHtml(html) {
+        return html.replaceAll("<!-- @include learn-topbar -->", learnTopbar);
+      },
+    },
+  ],
   root: resolve(__dirname),
   resolve: {
     alias: {

--- a/site/tsdb-engine/vite.config.ts
+++ b/site/tsdb-engine/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "vite";
 const BASE_PATH = process.env.BASE_PATH ?? "/o11ykit/tsdb-engine/";
 // Derive site root by stripping the last path segment ("tsdb-engine/")
 const SITE_ROOT = BASE_PATH.replace(/[^/]+\/$/, "") || "/";
-const learnTopbarTemplate = readFileSync(resolve(__dirname, "learn/_topbar.html"), "utf8");
+let cachedTopbarTemplate = readFileSync(resolve(__dirname, "learn/_topbar.html"), "utf8");
 
 export default defineConfig({
   base: BASE_PATH,
@@ -17,13 +17,14 @@ export default defineConfig({
         server.watcher.add(topbarPath);
         server.watcher.on("change", (file) => {
           if (file === topbarPath) {
+            cachedTopbarTemplate = readFileSync(topbarPath, "utf8");
             server.moduleGraph.invalidateAll();
             server.hot.send({ type: "full-reload" });
           }
         });
       },
       transformIndexHtml(html) {
-        const learnTopbar = learnTopbarTemplate.replaceAll("/o11ykit/", SITE_ROOT);
+        const learnTopbar = cachedTopbarTemplate.replaceAll("/o11ykit/", SITE_ROOT);
         return html.replaceAll("<!-- @include learn-topbar -->", learnTopbar);
       },
     },

--- a/site/tsdb-engine/vite.config.ts
+++ b/site/tsdb-engine/vite.config.ts
@@ -2,14 +2,18 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
 
-const learnTopbar = readFileSync(resolve(__dirname, "learn/_topbar.html"), "utf8");
+const BASE_PATH = process.env.BASE_PATH ?? "/o11ykit/tsdb-engine/";
+// Derive site root by stripping the last path segment ("tsdb-engine/")
+const SITE_ROOT = BASE_PATH.replace(/[^/]+\/$/, "") || "/";
+const learnTopbarTemplate = readFileSync(resolve(__dirname, "learn/_topbar.html"), "utf8");
 
 export default defineConfig({
-  base: process.env.BASE_PATH ?? "/o11ykit/tsdb-engine/",
+  base: BASE_PATH,
   plugins: [
     {
       name: "o11ykit-learn-topbar",
       transformIndexHtml(html) {
+        const learnTopbar = learnTopbarTemplate.replaceAll("/o11ykit/", SITE_ROOT);
         return html.replaceAll("<!-- @include learn-topbar -->", learnTopbar);
       },
     },

--- a/site/tsdb-engine/vite.config.ts
+++ b/site/tsdb-engine/vite.config.ts
@@ -12,6 +12,16 @@ export default defineConfig({
   plugins: [
     {
       name: "o11ykit-learn-topbar",
+      configureServer(server) {
+        const topbarPath = resolve(__dirname, "learn/_topbar.html");
+        server.watcher.add(topbarPath);
+        server.watcher.on("change", (file) => {
+          if (file === topbarPath) {
+            server.moduleGraph.invalidateAll();
+            server.hot.send({ type: "full-reload" });
+          }
+        });
+      },
       transformIndexHtml(html) {
         const learnTopbar = learnTopbarTemplate.replaceAll("/o11ykit/", SITE_ROOT);
         return html.replaceAll("<!-- @include learn-topbar -->", learnTopbar);


### PR DESCRIPTION
## Summary
- add the shared o11ykit product nav to the TSDB learn hub and all TSDB interactive learn pages
- keep the existing TSDB breadcrumb below the global nav so local learn navigation still works
- style the nav in the TSDB learn shared stylesheet for the dark learn-page theme and mobile wrap behavior

## Validation
- make pages-build
- make lint (exits 0; existing unrelated o11ylogsdb non-null assertion warnings remain)
- playwright-cli focused TSDB learn audit: 7 routes at 1440px and 7 routes at 390px, failures=[]
- playwright-cli full generated-site audit: 20 routes at 1440px and 20 routes at 390px, failures=[]
- git diff --check