### PR TITLE
Make chart adapters first-class engine shims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Project Guidance
+
+## Chart Adapter Virtue
+
+o11ykit has a fast in-memory TSDB for metrics. Chart adapters exist to make that TSDB easy to use
+with the chart library a user already wants.
+
+The adapter goal is a thin, ergonomic shim:
+
+- Query metrics with the TSDB engine.
+- Convert the engine result into the chart library's native input shape.
+- Let the chart package render the chart.
+
+Do not add an o11ykit chart abstraction, generic chart DTO, preview-only data shape, hand-drawn chart,
+or fake adapter layer to make a gallery look more complete. That defeats the product goal. If a chart
+library cannot be rendered through its real package in the current app/runtime, do not put it in the
+gallery.
+
+## Gallery Contract
+
+The chart gallery is proof that the adapters are useful and ergonomic. Every gallery entry must:
+
+- Start from real `o11ytsdb` storage plus `ScanEngine.query(...)`.
+- Prefer the optimized `RowGroupStore`/tiered store paths for gallery and product demos. Do not use
+  `FlatStore` in the gallery unless the example is explicitly comparing storage backends.
+- Use exported `@otlpkit/adapters/*` functions for engine-to-library conversion.
+- Render with the actual chart library package named in the UI.
+- Show code that a user could adapt directly.
+- Have tests that lock the gallery to the exported adapter and native package renderer.
+
+The gallery may use deterministic sample metrics so visual comparisons are stable, but those samples
+must be appended into the TSDB and queried through the engine before adapters see them.
+
+## Adapter API Design
+
+Prefer the chart library's idioms over a shared o11ykit object model:
+
+- Tremor should receive props users can spread onto Tremor components.
+- Recharts should receive rows and `dataKey` descriptors.
+- Chart.js should receive chart configuration/data.
+- ECharts should receive option trees with dataset/encode where appropriate.
+- uPlot should receive aligned arrays and minimal options.
+- Plotly should receive traces/layout.
+
+Keep the user's happy path short, but preserve library-native escape hatches. Add update helpers only
+when they match the library's real update API.

--- a/examples/chartjs/src/main.ts
+++ b/examples/chartjs/src/main.ts
@@ -1,7 +1,7 @@
 import {
-  toChartJsHistogramConfig,
-  toChartJsLatestValuesConfig,
-  toChartJsLineConfig,
+  toChartJsViewHistogramConfig,
+  toChartJsViewLatestValuesConfig,
+  toChartJsViewLineConfig,
 } from "@otlpkit/adapters/chartjs";
 import { buildHistogramFrame, buildLatestValuesFrame, buildTimeSeriesFrame } from "@otlpkit/views";
 import Chart from "chart.js/auto";
@@ -34,9 +34,9 @@ const histogramFrame = buildHistogramFrame(sampleMetricsDocument, {
 });
 
 for (const [selector, config] of [
-  ["#time-series", toChartJsLineConfig(timeSeriesFrame)],
-  ["#latest-values", toChartJsLatestValuesConfig(latestValuesFrame)],
-  ["#histogram", toChartJsHistogramConfig(histogramFrame)],
+  ["#time-series", toChartJsViewLineConfig(timeSeriesFrame)],
+  ["#latest-values", toChartJsViewLatestValuesConfig(latestValuesFrame)],
+  ["#histogram", toChartJsViewHistogramConfig(histogramFrame)],
 ] as const) {
   const context = requireCanvas(selector).getContext("2d");
   if (!context) {

--- a/examples/demo/src/main.tsx
+++ b/examples/demo/src/main.tsx
@@ -1,9 +1,9 @@
 import {
-  toRechartsHistogramModel,
-  toRechartsLatestValuesModel,
-  toRechartsTimeSeriesModel,
+  toRechartsViewHistogramData,
+  toRechartsViewLatestValuesData,
+  toRechartsViewTimeSeriesData,
 } from "@otlpkit/adapters/recharts";
-import { toUPlotTimeSeriesModel } from "@otlpkit/adapters/uplot";
+import { toUPlotViewTimeSeriesArgs } from "@otlpkit/adapters/uplot";
 import { buildHistogramFrame, buildLatestValuesFrame, buildTimeSeriesFrame } from "@otlpkit/views";
 import type { JSX } from "react";
 import { useEffect, useRef, useState } from "react";
@@ -19,7 +19,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import uPlot, { type AlignedData, type Options } from "uplot";
+import uPlot, { type AlignedData, type Options, type Series } from "uplot";
 import "uplot/dist/uPlot.min.css";
 
 import { demoMetricsDocument } from "./demo-data.js";
@@ -54,11 +54,11 @@ const collectorPulseFrame = buildTimeSeriesFrame(demoMetricsDocument, {
   title: "Collector heartbeat",
 });
 
-const inflightModel = toRechartsTimeSeriesModel(inflightFrame);
-const retryModel = toRechartsTimeSeriesModel(retryFrame);
-const errorModel = toRechartsLatestValuesModel(errorFrame);
-const durationModel = toRechartsHistogramModel(durationFrame);
-const collectorPulseModel = toUPlotTimeSeriesModel(collectorPulseFrame);
+const inflightModel = toRechartsViewTimeSeriesData(inflightFrame);
+const retryModel = toRechartsViewTimeSeriesData(retryFrame);
+const errorModel = toRechartsViewLatestValuesData(errorFrame);
+const durationModel = toRechartsViewHistogramData(durationFrame);
+const collectorPulseModel = toUPlotViewTimeSeriesArgs(collectorPulseFrame);
 
 const routeKeys = inflightModel.series.map((series) => series.dataKey);
 const peakInflight = inflightModel.data.reduce((peak, row) => {
@@ -117,7 +117,7 @@ function UPlotPulseCard({ model }: { readonly model: typeof collectorPulseModel 
           },
         },
         axes: model.options.axes.map((axis) => ({ ...axis })),
-        series: model.options.series.map((series) => ({ ...series })),
+        series: model.options.series.map(toUPlotSeries),
       };
       plot = new uPlot(options, alignedData, element);
     };
@@ -140,6 +140,13 @@ function UPlotPulseCard({ model }: { readonly model: typeof collectorPulseModel 
       <div className="pulse-chart" ref={chartRef} />
     </div>
   );
+}
+
+function toUPlotSeries(series: (typeof collectorPulseModel.options.series)[number]): Series {
+  return {
+    label: series.label,
+    ...(series.points ? { points: { ...series.points } } : {}),
+  };
 }
 
 function MeasuredChart({

--- a/examples/echarts/src/main.ts
+++ b/examples/echarts/src/main.ts
@@ -1,7 +1,7 @@
 import {
-  toEChartsHistogramOption,
-  toEChartsLatestValuesOption,
-  toEChartsTimeSeriesOption,
+  toEChartsViewHistogramOption,
+  toEChartsViewLatestValuesOption,
+  toEChartsViewTimeSeriesOption,
 } from "@otlpkit/adapters/echarts";
 import { buildHistogramFrame, buildLatestValuesFrame, buildTimeSeriesFrame } from "@otlpkit/views";
 import { BarChart, LineChart } from "echarts/charts";
@@ -39,9 +39,9 @@ const histogramFrame = buildHistogramFrame(sampleMetricsDocument, {
 });
 
 for (const [selector, option] of [
-  ["#time-series", toEChartsTimeSeriesOption(timeSeriesFrame)],
-  ["#latest-values", toEChartsLatestValuesOption(latestValuesFrame)],
-  ["#histogram", toEChartsHistogramOption(histogramFrame)],
+  ["#time-series", toEChartsViewTimeSeriesOption(timeSeriesFrame)],
+  ["#latest-values", toEChartsViewLatestValuesOption(latestValuesFrame)],
+  ["#histogram", toEChartsViewHistogramOption(histogramFrame)],
 ] as const) {
   init(requireContainer(selector)).setOption(option);
 }

--- a/examples/recharts/src/main.tsx
+++ b/examples/recharts/src/main.tsx
@@ -1,7 +1,7 @@
 import {
-  toRechartsHistogramModel,
-  toRechartsLatestValuesModel,
-  toRechartsTimeSeriesModel,
+  toRechartsViewHistogramData,
+  toRechartsViewLatestValuesData,
+  toRechartsViewTimeSeriesData,
 } from "@otlpkit/adapters/recharts";
 import { buildHistogramFrame, buildLatestValuesFrame, buildTimeSeriesFrame } from "@otlpkit/views";
 import type { JSX } from "react";
@@ -37,9 +37,9 @@ const histogramFrame = buildHistogramFrame(sampleMetricsDocument, {
   title: "Output duration histogram",
   binCount: 6,
 });
-const timeSeriesModel = toRechartsTimeSeriesModel(frame);
-const latestValuesModel = toRechartsLatestValuesModel(latestValuesFrame);
-const histogramModel = toRechartsHistogramModel(histogramFrame);
+const timeSeriesModel = toRechartsViewTimeSeriesData(frame);
+const latestValuesModel = toRechartsViewLatestValuesData(latestValuesFrame);
+const histogramModel = toRechartsViewHistogramData(histogramFrame);
 
 function App(): JSX.Element {
   return (

--- a/examples/uplot/src/main.ts
+++ b/examples/uplot/src/main.ts
@@ -1,6 +1,6 @@
-import { toUPlotLatestValuesModel, toUPlotTimeSeriesModel } from "@otlpkit/adapters/uplot";
+import { toUPlotViewLatestValuesArgs, toUPlotViewTimeSeriesArgs } from "@otlpkit/adapters/uplot";
 import { buildLatestValuesFrame, buildTimeSeriesFrame } from "@otlpkit/views";
-import uPlot, { type AlignedData, type Options } from "uplot";
+import uPlot, { type AlignedData, type Options, type Series } from "uplot";
 import "uplot/dist/uPlot.min.css";
 
 import { sampleMetricsDocument } from "../../shared/sample.js";
@@ -25,8 +25,8 @@ const latestValuesFrame = buildLatestValuesFrame(sampleMetricsDocument, {
   title: "Latest inflight batches by output",
 });
 
-const timeSeriesModel = toUPlotTimeSeriesModel(timeSeriesFrame);
-const latestValuesModel = toUPlotLatestValuesModel(latestValuesFrame);
+const timeSeriesModel = toUPlotViewTimeSeriesArgs(timeSeriesFrame);
+const latestValuesModel = toUPlotViewLatestValuesArgs(latestValuesFrame);
 
 const timeSeriesOptions: Options = {
   width: 960,
@@ -41,7 +41,7 @@ const timeSeriesOptions: Options = {
     },
   },
   axes: timeSeriesModel.options.axes.map((axis) => ({ ...axis })),
-  series: timeSeriesModel.options.series.map((series) => ({ ...series })),
+  series: timeSeriesModel.options.series.map(toUPlotSeries),
 };
 
 const latestValuesOptions: Options = {
@@ -57,7 +57,7 @@ const latestValuesOptions: Options = {
     },
   },
   axes: latestValuesModel.options.axes.map((axis) => ({ ...axis })),
-  series: latestValuesModel.options.series.map((series) => ({ ...series })),
+  series: latestValuesModel.options.series.map(toUPlotSeries),
 };
 const latestValuesData: AlignedData = [
   [...latestValuesModel.data[0]],
@@ -66,3 +66,10 @@ const latestValuesData: AlignedData = [
 
 new uPlot(timeSeriesOptions, timeSeriesModel.data as AlignedData, requireContainer("#time-series"));
 new uPlot(latestValuesOptions, latestValuesData, requireContainer("#latest-values"));
+
+function toUPlotSeries(series: (typeof timeSeriesModel.options.series)[number]): Series {
+  return {
+    label: series.label,
+    ...(series.points ? { points: { ...series.points } } : {}),
+  };
+}

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -88,11 +88,22 @@ Those should be incremental helpers, not a second required API for everyone.
 
 ## Quick Example
 
-```ts
-import { toChartJsViewLineConfig } from "@otlpkit/adapters/chartjs";
+For metrics queried through the TSDB engine, pass the query result directly to the chart-library
+adapter:
 
-const config = toChartJsViewLineConfig(timeSeriesFrame);
+```ts
+import { toChartJsTimeSeriesConfig } from "@otlpkit/adapters/chartjs";
+import { toRechartsTimeSeriesData } from "@otlpkit/adapters/recharts";
+import { toTremorLineChartProps } from "@otlpkit/adapters/tremor";
+
+const seriesLabel = (series) => series.labels.get("host") ?? "unknown";
+
+const tremor = toTremorLineChartProps(result, { seriesLabel });
+const recharts = toRechartsTimeSeriesData(result, { seriesLabel, unit: "ms" });
+const chartjs = toChartJsTimeSeriesConfig(result, { seriesLabel });
 ```
+
+View-frame adapters are still available for applications already using `@otlpkit/views` frames:
 
 ```ts
 import { toUPlotViewTimeSeriesArgs } from "@otlpkit/adapters/uplot";
@@ -120,19 +131,7 @@ new uPlot(
 ## Engine-backed adapters
 
 Chart-library adapters accept `QueryResult`-shaped data directly and return the native shape for
-that package:
-
-```ts
-import { toChartJsTimeSeriesConfig } from "@otlpkit/adapters/chartjs";
-import { toRechartsTimeSeriesData } from "@otlpkit/adapters/recharts";
-import { toTremorLineChartProps } from "@otlpkit/adapters/tremor";
-
-const seriesLabel = (series) => series.labels.get("host") ?? "unknown";
-
-const tremor = toTremorLineChartProps(result, { seriesLabel });
-const recharts = toRechartsTimeSeriesData(result, { seriesLabel, unit: "ms" });
-const chartjs = toChartJsTimeSeriesConfig(result, { seriesLabel });
-```
+that package. The quick example above is the preferred engine-backed path.
 
 The reusable engine normalization helpers still exist in `@otlpkit/adapters/engine` for advanced
 cases where an application wants to normalize once and feed many adapters:

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -43,15 +43,14 @@ The goal is to preserve each chart library's idioms:
 ## Chart Gallery
 
 The interactive gallery at `/o11ykit/charts/` shows the same engine result across Tremor,
-Recharts, Chart.js, ECharts, uPlot, Nivo, Visx, Observable Plot, Plotly, ApexCharts, Victory,
-AG Charts, Highcharts, and Vega-Lite shapes. Package-backed entries mount the actual chart package
-in the browser; entries without package renderers are explicitly labeled as adapter shapes only.
+Recharts, Chart.js, ECharts, uPlot, Nivo, Observable Plot, Plotly, ApexCharts, Victory, AG Charts,
+Highcharts, and Vega-Lite. Every gallery entry mounts the actual chart package in the browser.
 
 The gallery uses exported engine-backed adapters for every package-backed library. Tremor and
 Recharts are the most polished component-level APIs; Chart.js, ECharts, uPlot, Nivo, Observable
-Plot, Plotly, ApexCharts, Victory, AG Charts, Highcharts, Vega-Lite, and Visx expose first-pass
-native model adapters. The gallery renders every package-backed entry with the real package; Visx is
-exported as a low-level adapter shape while its package renderer waits for a dedicated React pass.
+Plot, Plotly, ApexCharts, Victory, AG Charts, Highcharts, and Vega-Lite expose first-pass native
+model adapters. Visx remains exported as a low-level compositional adapter, but it is intentionally
+not in the gallery because it is not a native chart renderer with a React 19-clean package path.
 
 | Library | Engine-backed status | User-facing shape |
 | --- | --- | --- |
@@ -61,7 +60,7 @@ exported as a low-level adapter shape while its package renderer waits for a ded
 | ECharts | exported | dataset and encode option |
 | uPlot | exported | aligned arrays |
 | Nivo, Observable Plot, Plotly, ApexCharts, Victory, AG Charts, Highcharts, Vega-Lite | exported, package-rendered gallery | library-native models |
-| Visx | exported, adapter-shape gallery | accessors, series arrays, and scale hints |
+| Visx | exported, not gallery-mounted | low-level accessors, series arrays, and scale hints |
 
 ## Ergonomics Audit
 

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -178,9 +178,10 @@ series ids stay available in `line.meta.series`.
 Recharts adapters expose the same engine substrate as row data plus `dataKey` metadata:
 
 ```ts
-import { toEngineHistogramModel } from "@otlpkit/adapters/engine";
+import { toEngineHistogramModel, toEngineLatestValueModel } from "@otlpkit/adapters/engine";
 import {
   toRechartsEngineHistogramModel,
+  toRechartsEngineLatestValuesModel,
   toRechartsEngineScatterModel,
   toRechartsEngineTimeSeriesModel,
 } from "@otlpkit/adapters/recharts";
@@ -189,6 +190,8 @@ const model = toRechartsEngineTimeSeriesModel(wide, { unit: "ms" });
 const scatter = toRechartsEngineScatterModel(wide, { unit: "ms" });
 const buckets = toEngineHistogramModel(wide);
 const histogram = toRechartsEngineHistogramModel(buckets, { unit: "samples" });
+const latest = toEngineLatestValueModel(result);
+const donut = toRechartsEngineLatestValuesModel(latest, { unit: "ms" });
 ```
 
 ```tsx

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -1,6 +1,6 @@
 # @otlpkit/adapters
 
-Library-native adapters that project `@otlpkit/views` frames into chart-ready models.
+Library-native adapters that turn engine query results into chart-library-native inputs.
 
 The adapter rule is simple: keep the data engine shared, but make the final object feel native to
 the chart library. Tremor users should spread props. Recharts users should map `dataKey`s. uPlot
@@ -28,7 +28,7 @@ users should get aligned arrays. ECharts users should get dataset/encode options
 The goal is to preserve each chart library's idioms:
 
 - Chart.js: configuration-first datasets
-- Recharts: row-model + `dataKey` composition
+- Recharts: rows plus `dataKey` composition
 - ECharts: dataset/encode-first option trees
 - uPlot: aligned columnar arrays + minimal option scaffolding
 - Plotly: traces plus layout
@@ -44,12 +44,14 @@ The goal is to preserve each chart library's idioms:
 
 The interactive gallery at `/o11ykit/charts/` shows the same engine result across Tremor,
 Recharts, Chart.js, ECharts, uPlot, Nivo, Observable Plot, Plotly, ApexCharts, Victory, AG Charts,
-Highcharts, and Vega-Lite. Every gallery entry mounts the actual chart package in the browser.
+Highcharts, and Vega-Lite. Every gallery entry starts by appending deterministic metric samples into
+an `o11ytsdb` `RowGroupStore`, querying them with `ScanEngine`, and then mounting the actual chart
+package in the browser.
 
 The gallery uses exported engine-backed adapters for every package-backed library. Tremor and
 Recharts are the most polished component-level APIs; Chart.js, ECharts, uPlot, Nivo, Observable
 Plot, Plotly, ApexCharts, Victory, AG Charts, Highcharts, and Vega-Lite expose first-pass native
-model adapters. Visx remains exported as a low-level compositional adapter, but it is intentionally
+input adapters. Visx remains exported as a low-level compositional adapter, but it is intentionally
 not in the gallery because it is not a native chart renderer with a React 19-clean package path.
 
 | Library | Engine-backed status | User-facing shape |
@@ -59,7 +61,7 @@ not in the gallery because it is not a native chart renderer with a React 19-cle
 | Chart.js | exported | config with parsing disabled |
 | ECharts | exported | dataset and encode option |
 | uPlot | exported | aligned arrays |
-| Nivo, Observable Plot, Plotly, ApexCharts, Victory, AG Charts, Highcharts, Vega-Lite | exported, package-rendered gallery | library-native models |
+| Nivo, Observable Plot, Plotly, ApexCharts, Victory, AG Charts, Highcharts, Vega-Lite | exported, package-rendered gallery | library-native inputs |
 | Visx | exported, not gallery-mounted | low-level accessors, series arrays, and scale hints |
 
 ## Ergonomics Audit
@@ -71,15 +73,15 @@ repeated data-shaping chores without hiding the chart package's own API.
 | --- | --- | --- | --- |
 | Raw REST, SQL, Prometheus, or OTLP data | Source-specific rows, samples, or frames | timestamp conversion, pivoting, sparse joins, latest-value extraction, label naming, and one-off null policy | nothing until the user writes glue |
 | Chart-package native data | The exact props/config/spec/traces the chart package expects | source normalization and every library-specific reshaping step | chart package ergonomics only after data is already shaped |
-| o11ykit engine adapters | `QueryResult` -> engine model -> library adapter | chart selection, styling, and optional package-specific overrides | stable series ids, sorted labels, null-safe sparse points, latest-value rows, histogram buckets, and max-point trimming |
+| o11ykit engine adapters | `QueryResult` -> library adapter | chart selection, styling, and optional package-specific overrides | stable series ids, sorted labels, null-safe sparse points, latest-value rows, histogram buckets, and max-point trimming |
 
 The important design choice is that adapters do not return an o11ykit chart DTO. They return the
 library's own dialect: Tremor props, Recharts rows plus `dataKey`s, uPlot aligned arrays, Plotly
 traces, Vega-Lite specs, Observable Plot marks, AG Charts options, and so on. That keeps the happy
 path short while preserving escape hatches for each package.
 
-Most libraries are snapshot-first from the user's point of view. A single `toXxxModel(...)` API is
-the default ergonomic surface. Libraries with efficient mutation APIs can add an optional update
+Most libraries are snapshot-first from the user's point of view. A single adapter call is the
+default ergonomic surface. Libraries with efficient mutation APIs can add an optional update
 helper later: uPlot `setData`, ECharts `setOption`, Plotly `extendTraces`, ApexCharts
 `updateSeries`, AG Charts `update` / `updateDelta`, Highcharts `setData`, or Vega view changesets.
 Those should be incremental helpers, not a second required API for everyone.
@@ -87,63 +89,69 @@ Those should be incremental helpers, not a second required API for everyone.
 ## Quick Example
 
 ```ts
-import { toChartJsLineConfig } from "@otlpkit/adapters/chartjs";
+import { toChartJsViewLineConfig } from "@otlpkit/adapters/chartjs";
 
-const config = toChartJsLineConfig(timeSeriesFrame);
+const config = toChartJsViewLineConfig(timeSeriesFrame);
 ```
 
 ```ts
-import { toUPlotTimeSeriesModel } from "@otlpkit/adapters/uplot";
+import { toUPlotViewTimeSeriesArgs } from "@otlpkit/adapters/uplot";
 import uPlot from "uplot";
 
-const model = toUPlotTimeSeriesModel(timeSeriesFrame);
+const args = toUPlotViewTimeSeriesArgs(timeSeriesFrame);
 
 new uPlot(
   {
     width: 960,
     height: 480,
-    title: model.options.title,
+    title: args.options.title,
     scales: {
-      x: { time: model.options.scales.x.time },
-      y: { auto: model.options.scales.y.auto },
+      x: { time: args.options.scales.x.time },
+      y: { auto: args.options.scales.y.auto },
     },
-    axes: model.options.axes.map((axis) => ({ ...axis })),
-    series: model.options.series.map((series) => ({ ...series })),
+    axes: args.options.axes.map((axis) => ({ ...axis })),
+    series: args.options.series.map((series) => ({ ...series })),
   },
-  model.data,
+  args.data,
   element
 );
 ```
 
 ## Engine-backed adapters
 
-The engine layer converts `QueryResult`-shaped data into reusable chart models:
+Chart-library adapters accept `QueryResult`-shaped data directly and return the native shape for
+that package:
 
 ```ts
-import { toEngineWideTableModel, toEngineLatestValueModel } from "@otlpkit/adapters/engine";
+import { toChartJsTimeSeriesConfig } from "@otlpkit/adapters/chartjs";
+import { toRechartsTimeSeriesData } from "@otlpkit/adapters/recharts";
+import { toTremorLineChartProps } from "@otlpkit/adapters/tremor";
 
-const wide = toEngineWideTableModel(result, {
-  seriesLabel: (series) => series.labels.get("host") ?? "unknown",
-});
-const latest = toEngineLatestValueModel(result);
+const seriesLabel = (series) => series.labels.get("host") ?? "unknown";
+
+const tremor = toTremorLineChartProps(result, { seriesLabel });
+const recharts = toRechartsTimeSeriesData(result, { seriesLabel, unit: "ms" });
+const chartjs = toChartJsTimeSeriesConfig(result, { seriesLabel });
 ```
 
-### Choosing a model
+The reusable engine normalization helpers still exist in `@otlpkit/adapters/engine` for advanced
+cases where an application wants to normalize once and feed many adapters:
 
-- `toEngineWideTableModel(result)`: line, area, stacked area, grouped bar, and any library that
+- `toEngineWideTableModel(...)`: line, area, stacked area, grouped bar, and any library that
   wants one row per timestamp.
-- `toEngineLatestValueModel(result)`: donut, pie, bar list, KPI rows, and "current value" charts.
-- `toEngineLineSeriesModel(result)`: custom marks, canvases, or libraries that prefer one array per
+- `toEngineLatestValueModel(...)`: donut, pie, bar list, KPI rows, and "current value" charts.
+- `toEngineLineSeriesModel(...)`: custom marks, canvases, or libraries that prefer one array per
   series.
 
-All engine models canonicalize series ids from sorted labels, turn non-finite values into `null`,
-validate timestamp/value length alignment, and support `maxPoints` for dashboard previews.
+The public happy path should stay direct: `result -> published adapter -> native input`.
+The internal engine models canonicalize series ids from sorted labels, turn non-finite values into
+`null`, validate timestamp/value length alignment, and support `maxPoints` for dashboard previews.
 
 ### Adapter author checklist
 
 New engine-backed adapters should keep the same user contract:
 
-- Accept one of the engine models, not raw query results.
+- Accept raw engine query results directly; optionally also accept reusable engine models.
 - Return the library's native shape: props, rows, config, dataset, traces, or aligned arrays.
 - Preserve stable engine series ids in metadata even when the display label is shortened.
 - Keep sparse points as `null` when the chart library can represent gaps.
@@ -157,11 +165,11 @@ Tremor adapters then return native props:
 ```ts
 import { toTremorLineChartProps, toTremorDonutChartProps } from "@otlpkit/adapters/tremor";
 
-const line = toTremorLineChartProps(wide, {
-  categoryLabel: (series) => series.labels.get("service") ?? series.label,
+const line = toTremorLineChartProps(result, {
+  seriesLabel: (series) => series.labels.get("service") ?? series.label,
   connectNulls: false,
 });
-const donut = toTremorDonutChartProps(latest);
+const donut = toTremorDonutChartProps(result);
 ```
 
 ```tsx
@@ -177,26 +185,23 @@ series ids stay available in `line.meta.series`.
 Recharts adapters expose the same engine substrate as row data plus `dataKey` metadata:
 
 ```ts
-import { toEngineHistogramModel, toEngineLatestValueModel } from "@otlpkit/adapters/engine";
 import {
-  toRechartsEngineHistogramModel,
-  toRechartsEngineLatestValuesModel,
-  toRechartsEngineScatterModel,
-  toRechartsEngineTimeSeriesModel,
+  toRechartsHistogramData,
+  toRechartsLatestValuesData,
+  toRechartsScatterData,
+  toRechartsTimeSeriesData,
 } from "@otlpkit/adapters/recharts";
 
-const model = toRechartsEngineTimeSeriesModel(wide, { unit: "ms" });
-const scatter = toRechartsEngineScatterModel(wide, { unit: "ms" });
-const buckets = toEngineHistogramModel(wide);
-const histogram = toRechartsEngineHistogramModel(buckets, { unit: "samples" });
-const latest = toEngineLatestValueModel(result);
-const donut = toRechartsEngineLatestValuesModel(latest, { unit: "ms" });
+const data = toRechartsTimeSeriesData(result, { seriesLabel, unit: "ms" });
+const scatter = toRechartsScatterData(result, { seriesLabel, unit: "ms" });
+const histogram = toRechartsHistogramData(result, { seriesLabel, unit: "samples" });
+const donut = toRechartsLatestValuesData(result, { seriesLabel, unit: "ms" });
 ```
 
 ```tsx
-<LineChart data={model.data}>
-  <XAxis dataKey={model.xAxisKey} />
-  {model.series.map((series) => (
+<LineChart data={data.data}>
+  <XAxis dataKey={data.xAxisKey} />
+  {data.series.map((series) => (
     <Line key={series.id} dataKey={series.dataKey} name={series.name} />
   ))}
 </LineChart>
@@ -210,8 +215,8 @@ engine series id on each descriptor. The scatter adapter returns one flat row pe
 ### Existing view-frame adapters
 
 ```ts
-import { toUPlotLatestValuesModel } from "@otlpkit/adapters/uplot";
+import { toUPlotViewLatestValuesArgs } from "@otlpkit/adapters/uplot";
 
-const latest = toUPlotLatestValuesModel(latestValuesFrame);
+const latest = toUPlotViewLatestValuesArgs(latestValuesFrame);
 // latest.labels carries x-index -> row label mapping for tick formatting
 ```

--- a/packages/adapters/src/agcharts.ts
+++ b/packages/adapters/src/agcharts.ts
@@ -1,10 +1,17 @@
-import type { EngineLatestValueModel, EngineWideTableModel } from "./engine.js";
+import {
+  asEngineLatestValueModel,
+  asEngineWideTableModel,
+  type EngineAdapterOptions,
+  type EngineLatestValueInput,
+  type EngineWideTableInput,
+} from "./engine.js";
 import { gaugeValue, rowToRecord } from "./engine-chart-shared.js";
 
-export type AgChartsEngineChartType = "line" | "area" | "bar" | "donut" | "scatter" | "gauge";
+export type AgChartsChartType = "line" | "area" | "bar" | "donut" | "scatter" | "gauge";
 
 export interface AgChartsSeriesOptions {
   readonly type: "line" | "area" | "bar" | "donut" | "scatter";
+  readonly id?: string;
   readonly xKey?: string;
   readonly yKey?: string;
   readonly yName?: string;
@@ -12,7 +19,7 @@ export interface AgChartsSeriesOptions {
   readonly calloutLabelKey?: string;
 }
 
-export interface AgChartsEngineOptionsModel {
+export interface AgChartsOptions {
   readonly data?: readonly Record<string, number | string | null>[];
   readonly series?: readonly AgChartsSeriesOptions[];
   readonly type?: "radial-gauge";
@@ -20,20 +27,29 @@ export interface AgChartsEngineOptionsModel {
   readonly scale?: { readonly min: number; readonly max: number };
 }
 
-export interface AgChartsEngineUpdateDelta {
-  readonly data?: AgChartsEngineOptionsModel["data"];
-  readonly series?: AgChartsEngineOptionsModel["series"];
-  readonly value?: AgChartsEngineOptionsModel["value"];
+export interface AgChartsUpdateDelta {
+  readonly data?: AgChartsOptions["data"];
+  readonly series?: AgChartsOptions["series"];
+  readonly value?: AgChartsOptions["value"];
 }
 
-export function toAgChartsEngineTimeSeriesOptions(
-  model: EngineWideTableModel,
-  options: { readonly chartType?: AgChartsEngineChartType } = {}
-): AgChartsEngineOptionsModel {
+export function toAgChartsTimeSeriesOptions(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions & { readonly chartType?: AgChartsChartType } = {}
+): AgChartsOptions {
+  const wide = asEngineWideTableModel(model, options);
   const chartType = options.chartType ?? "line";
+  const seriesKeys = wide.series.map((_series, index) => `series_${index}`);
   return {
-    data: model.rows.map((row) => rowToRecord(row, model.series, "time")),
-    series: model.series.map((series) => ({
+    data: wide.rows.map((row) => {
+      const output = rowToRecord(row, [], "time");
+      for (let index = 0; index < seriesKeys.length; index++) {
+        output[seriesKeys[index] ?? `series_${index}`] = row.values[index] ?? null;
+      }
+      return output;
+    }),
+    series: wide.series.map((series, index) => ({
+      id: series.id,
       type:
         chartType === "bar"
           ? "bar"
@@ -43,15 +59,13 @@ export function toAgChartsEngineTimeSeriesOptions(
               ? "area"
               : "line",
       xKey: "time",
-      yKey: series.id,
+      yKey: seriesKeys[index] ?? `series_${index}`,
       yName: series.label,
     })),
   };
 }
 
-export function toAgChartsEngineUpdateDelta(
-  model: AgChartsEngineOptionsModel
-): AgChartsEngineUpdateDelta {
+export function toAgChartsUpdateDelta(model: AgChartsOptions): AgChartsUpdateDelta {
   return {
     ...(model.data ? { data: model.data } : {}),
     ...(model.series ? { series: model.series } : {}),
@@ -59,20 +73,21 @@ export function toAgChartsEngineUpdateDelta(
   };
 }
 
-export function toAgChartsEngineLatestValuesOptions(
-  model: EngineLatestValueModel,
-  options: { readonly chartType?: AgChartsEngineChartType } = {}
-): AgChartsEngineOptionsModel {
+export function toAgChartsLatestValuesOptions(
+  model: EngineLatestValueInput,
+  options: EngineAdapterOptions & { readonly chartType?: AgChartsChartType } = {}
+): AgChartsOptions {
+  const latest = asEngineLatestValueModel(model, options);
   const chartType = options.chartType ?? "donut";
   if (chartType === "gauge") {
     return {
       type: "radial-gauge",
-      value: gaugeValue(model),
+      value: gaugeValue(latest),
       scale: { min: 0, max: 200 },
     };
   }
   return {
-    data: model.rows.flatMap((row) =>
+    data: latest.rows.flatMap((row) =>
       row.value === null ? [] : [{ label: row.label, value: row.value }]
     ),
     series: [{ type: "donut", angleKey: "value", calloutLabelKey: "label" }],

--- a/packages/adapters/src/apexcharts.ts
+++ b/packages/adapters/src/apexcharts.ts
@@ -1,7 +1,13 @@
-import type { EngineLatestValueModel, EngineWideTableModel } from "./engine.js";
+import {
+  asEngineLatestValueModel,
+  asEngineWideTableModel,
+  type EngineAdapterOptions,
+  type EngineLatestValueInput,
+  type EngineWideTableInput,
+} from "./engine.js";
 import { gaugeValue } from "./engine-chart-shared.js";
 
-export type ApexChartsEngineChartType =
+export type ApexChartsChartType =
   | "line"
   | "area"
   | "bar"
@@ -10,12 +16,12 @@ export type ApexChartsEngineChartType =
   | "sparkline"
   | "gauge";
 
-export interface ApexChartsEngineOptions {
-  readonly chartType?: ApexChartsEngineChartType;
+export interface ApexChartsAdapterOptions extends EngineAdapterOptions {
+  readonly chartType?: ApexChartsChartType;
   readonly chartId?: string;
 }
 
-export interface ApexChartsEngineModel {
+export interface ApexChartsOptions {
   readonly chart: {
     readonly type: "line" | "bar" | "scatter" | "donut" | "radialBar";
     readonly id?: string;
@@ -28,10 +34,11 @@ export interface ApexChartsEngineModel {
   readonly fill?: { readonly opacity: number };
 }
 
-export function toApexChartsEngineTimeSeriesOptions(
-  model: EngineWideTableModel,
-  options: ApexChartsEngineOptions = {}
-): ApexChartsEngineModel {
+export function toApexChartsTimeSeriesOptions(
+  model: EngineWideTableInput,
+  options: ApexChartsAdapterOptions = {}
+): ApexChartsOptions {
+  const wide = asEngineWideTableModel(model, options);
   const chartType = options.chartType ?? "line";
   return {
     chart: {
@@ -39,9 +46,9 @@ export function toApexChartsEngineTimeSeriesOptions(
       type: chartType === "bar" ? "bar" : chartType === "scatter" ? "scatter" : "line",
       sparkline: { enabled: chartType === "sparkline" },
     },
-    series: model.series.map((series, index) => ({
+    series: wide.series.map((series, index) => ({
       name: series.label,
-      data: model.rows.map((row) => [row.t, row.values[index] ?? null]),
+      data: wide.rows.map((row) => [row.t, row.values[index] ?? null]),
     })),
     xaxis: { type: "datetime" },
     stroke: { curve: "smooth" },
@@ -49,10 +56,11 @@ export function toApexChartsEngineTimeSeriesOptions(
   };
 }
 
-export function toApexChartsEngineLatestValuesOptions(
-  model: EngineLatestValueModel,
-  options: ApexChartsEngineOptions = {}
-): ApexChartsEngineModel {
+export function toApexChartsLatestValuesOptions(
+  model: EngineLatestValueInput,
+  options: ApexChartsAdapterOptions = {}
+): ApexChartsOptions {
+  const latest = asEngineLatestValueModel(model, options);
   const chartType = options.chartType ?? "donut";
   if (chartType === "gauge") {
     return {
@@ -61,11 +69,11 @@ export function toApexChartsEngineLatestValuesOptions(
         type: "radialBar",
         sparkline: { enabled: true },
       },
-      series: [gaugeValue(model)],
+      series: [gaugeValue(latest)],
       labels: ["average"],
     };
   }
-  const rows = model.rows.filter((row) => row.value !== null);
+  const rows = latest.rows.filter((row) => row.value !== null);
   return {
     chart: { ...(options.chartId ? { id: options.chartId } : {}), type: "donut" },
     labels: rows.map((row) => row.label),
@@ -73,9 +81,9 @@ export function toApexChartsEngineLatestValuesOptions(
   };
 }
 
-export function toApexChartsEngineSeriesUpdate(model: ApexChartsEngineModel): {
-  readonly series: ApexChartsEngineModel["series"];
-  readonly labels?: ApexChartsEngineModel["labels"];
+export function toApexChartsSeriesUpdate(model: ApexChartsOptions): {
+  readonly series: ApexChartsOptions["series"];
+  readonly labels?: ApexChartsOptions["labels"];
 } {
   return {
     series: model.series,

--- a/packages/adapters/src/chartjs.ts
+++ b/packages/adapters/src/chartjs.ts
@@ -1,9 +1,17 @@
 import type { HistogramFrame, LatestValuesFrame, TimeSeriesFrame } from "@otlpkit/views";
 
 import type {
-  EngineHistogramModel,
+  EngineAdapterOptions,
+  EngineHistogramInput,
+  EngineHistogramOptions,
+  EngineLatestValueInput,
   EngineLatestValueModel,
-  EngineWideTableModel,
+  EngineWideTableInput,
+} from "./engine.js";
+import {
+  asEngineHistogramModel,
+  asEngineLatestValueModel,
+  asEngineWideTableModel,
 } from "./engine.js";
 
 export interface ChartJsPoint {
@@ -78,7 +86,7 @@ export interface ChartJsConfig {
   };
 }
 
-export type ChartJsEngineChartType =
+export type ChartJsChartType =
   | "line"
   | "area"
   | "bar"
@@ -88,24 +96,25 @@ export type ChartJsEngineChartType =
   | "sparkline"
   | "gauge";
 
-export interface ChartJsEngineOptions {
-  readonly chartType?: ChartJsEngineChartType;
+export interface ChartJsOptions extends EngineAdapterOptions, EngineHistogramOptions {
+  readonly chartType?: ChartJsChartType;
   readonly unit?: string | null;
   readonly title?: string;
   readonly spanGaps?: boolean;
 }
 
-export function toChartJsEngineTimeSeriesConfig(
-  model: EngineWideTableModel,
-  options: ChartJsEngineOptions = {}
+export function toChartJsTimeSeriesConfig(
+  model: EngineWideTableInput,
+  options: ChartJsOptions = {}
 ): ChartJsConfig {
+  const wide = asEngineWideTableModel(model, options);
   const chartType = options.chartType ?? "line";
   return {
     type: chartType === "bar" ? "bar" : chartType === "scatter" ? "line" : "line",
     data: {
-      datasets: model.series.map((series, index) => ({
+      datasets: wide.series.map((series, index) => ({
         label: series.label,
-        data: model.rows.map((row) => ({ x: row.t, y: row.values[index] ?? null })),
+        data: wide.rows.map((row) => ({ x: row.t, y: row.values[index] ?? null })),
         parsing: false,
         normalized: true,
         spanGaps: options.spanGaps ?? false,
@@ -118,7 +127,7 @@ export function toChartJsEngineTimeSeriesConfig(
     },
     options: chartJsEngineOptions({
       xType: "linear",
-      legend: chartType !== "sparkline" && model.series.length > 1,
+      legend: chartType !== "sparkline" && wide.series.length > 1,
       title: options.title ?? "",
       unit: options.unit ?? null,
       sparkline: chartType === "sparkline",
@@ -126,24 +135,26 @@ export function toChartJsEngineTimeSeriesConfig(
   };
 }
 
-export function toChartJsEngineLatestValuesConfig(
-  model: EngineLatestValueModel,
-  options: ChartJsEngineOptions = {}
+export function toChartJsLatestValuesConfig(
+  model: EngineLatestValueInput,
+  options: ChartJsOptions = {}
 ): ChartJsConfig {
+  const latest = asEngineLatestValueModel(model, options);
   const chartType = options.chartType ?? "bar";
   if (chartType === "donut" || chartType === "gauge") {
-    const value = chartType === "gauge" ? gaugeValue(model) : undefined;
+    const value = chartType === "gauge" ? gaugeValue(latest) : undefined;
     return {
       type: "doughnut",
       data: {
-        labels: chartType === "gauge" ? ["value", "remaining"] : model.rows.map((row) => row.label),
+        labels:
+          chartType === "gauge" ? ["value", "remaining"] : latest.rows.map((row) => row.label),
         datasets: [
           {
             label: options.title ?? "latest",
             data:
               chartType === "gauge"
                 ? [value, Math.max(0, 200 - (value ?? 0))]
-                : model.rows.flatMap((row) => (row.value === null ? [] : [row.value])),
+                : latest.rows.flatMap((row) => (row.value === null ? [] : [row.value])),
             backgroundColor: chartType === "gauge" ? "#4c8bf5" : "#4c8bf5",
           },
         ],
@@ -163,11 +174,11 @@ export function toChartJsEngineLatestValuesConfig(
   return {
     type: "bar",
     data: {
-      labels: model.rows.flatMap((row) => (row.value === null ? [] : [row.label])),
+      labels: latest.rows.flatMap((row) => (row.value === null ? [] : [row.label])),
       datasets: [
         {
           label: options.title ?? "latest",
-          data: model.rows.flatMap((row) => (row.value === null ? [] : [row.value])),
+          data: latest.rows.flatMap((row) => (row.value === null ? [] : [row.value])),
           backgroundColor: "#4c8bf5",
         },
       ],
@@ -181,18 +192,19 @@ export function toChartJsEngineLatestValuesConfig(
   };
 }
 
-export function toChartJsEngineHistogramConfig(
-  model: EngineHistogramModel,
-  options: ChartJsEngineOptions = {}
+export function toChartJsHistogramConfig(
+  model: EngineHistogramInput,
+  options: ChartJsOptions = {}
 ): ChartJsConfig {
+  const histogram = asEngineHistogramModel(model, options);
   return {
     type: "bar",
     data: {
-      labels: model.buckets.map((bucket) => bucket.label),
+      labels: histogram.buckets.map((bucket) => bucket.label),
       datasets: [
         {
           label: options.title ?? "samples",
-          data: model.buckets.map((bucket) => bucket.count),
+          data: histogram.buckets.map((bucket) => bucket.count),
           backgroundColor: "#0f9d58",
         },
       ],
@@ -206,7 +218,7 @@ export function toChartJsEngineHistogramConfig(
   };
 }
 
-export function toChartJsLineConfig(
+export function toChartJsViewLineConfig(
   frame: TimeSeriesFrame,
   options: {
     readonly xLabel?: string;
@@ -323,7 +335,7 @@ function gaugeValue(model: EngineLatestValueModel): number {
   return Math.round(Math.max(0, Math.min(200, average)));
 }
 
-export function toChartJsLatestValuesConfig(frame: LatestValuesFrame): ChartJsConfig {
+export function toChartJsViewLatestValuesConfig(frame: LatestValuesFrame): ChartJsConfig {
   return {
     type: "bar",
     data: {
@@ -368,7 +380,7 @@ export function toChartJsLatestValuesConfig(frame: LatestValuesFrame): ChartJsCo
   };
 }
 
-export function toChartJsHistogramConfig(frame: HistogramFrame): ChartJsConfig {
+export function toChartJsViewHistogramConfig(frame: HistogramFrame): ChartJsConfig {
   return {
     type: "bar",
     data: {

--- a/packages/adapters/src/echarts.ts
+++ b/packages/adapters/src/echarts.ts
@@ -1,9 +1,17 @@
 import type { HistogramFrame, LatestValuesFrame, TimeSeriesFrame } from "@otlpkit/views";
 
 import type {
-  EngineHistogramModel,
+  EngineAdapterOptions,
+  EngineHistogramInput,
+  EngineHistogramOptions,
+  EngineLatestValueInput,
   EngineLatestValueModel,
-  EngineWideTableModel,
+  EngineWideTableInput,
+} from "./engine.js";
+import {
+  asEngineHistogramModel,
+  asEngineLatestValueModel,
+  asEngineWideTableModel,
 } from "./engine.js";
 import { histogramRows, pivotTimeSeriesFrame } from "./shared.js";
 
@@ -46,7 +54,7 @@ export interface EChartsOption {
   }[];
 }
 
-export type EChartsEngineChartType =
+export type EChartsChartType =
   | "line"
   | "area"
   | "bar"
@@ -56,15 +64,16 @@ export type EChartsEngineChartType =
   | "sparkline"
   | "gauge";
 
-export interface EChartsEngineOptions {
-  readonly chartType?: EChartsEngineChartType;
+export interface EChartsOptions extends EngineAdapterOptions, EngineHistogramOptions {
+  readonly chartType?: EChartsChartType;
   readonly unit?: string | null;
 }
 
-export function toEChartsEngineTimeSeriesOption(
-  model: EngineWideTableModel,
-  options: EChartsEngineOptions = {}
+export function toEChartsTimeSeriesOption(
+  model: EngineWideTableInput,
+  options: EChartsOptions = {}
 ): EChartsOption {
+  const wide = asEngineWideTableModel(model, options);
   const chartType = options.chartType ?? "line";
   return {
     aria: { enabled: true },
@@ -73,10 +82,10 @@ export function toEChartsEngineTimeSeriesOption(
     dataset: [
       {
         id: "telemetry",
-        dimensions: ["time", ...model.series.map((series) => series.label)],
-        source: model.rows.map((row) => {
+        dimensions: ["time", ...wide.series.map((series) => series.label)],
+        source: wide.rows.map((row) => {
           const output: Record<string, number | string | null> = { time: row.t };
-          model.series.forEach((series, index) => {
+          wide.series.forEach((series, index) => {
             output[series.label] = row.values[index] ?? null;
           });
           return output;
@@ -85,7 +94,7 @@ export function toEChartsEngineTimeSeriesOption(
     ],
     xAxis: { type: "time" },
     yAxis: { type: "value", name: options.unit ?? "" },
-    series: model.series.map((series) => ({
+    series: wide.series.map((series) => ({
       type: chartType === "bar" ? "bar" : chartType === "scatter" ? "scatter" : "line",
       name: series.label,
       datasetId: "telemetry",
@@ -97,10 +106,11 @@ export function toEChartsEngineTimeSeriesOption(
   };
 }
 
-export function toEChartsEngineLatestValuesOption(
-  model: EngineLatestValueModel,
-  options: EChartsEngineOptions = {}
+export function toEChartsLatestValuesOption(
+  model: EngineLatestValueInput,
+  options: EChartsOptions = {}
 ): EChartsOption {
+  const latest = asEngineLatestValueModel(model, options);
   const chartType = options.chartType ?? "bar";
   if (chartType === "donut") {
     return {
@@ -116,7 +126,7 @@ export function toEChartsEngineLatestValuesOption(
           name: "latest",
           datasetId: "",
           encode: {},
-          data: model.rows.flatMap((row) =>
+          data: latest.rows.flatMap((row) =>
             row.value === null ? [] : [{ name: row.label, value: row.value }]
           ),
         },
@@ -137,7 +147,7 @@ export function toEChartsEngineLatestValuesOption(
           name: "latest",
           datasetId: "",
           encode: {},
-          data: [{ name: "average", value: gaugeValue(model) }],
+          data: [{ name: "average", value: gaugeValue(latest) }],
         },
       ],
     };
@@ -150,7 +160,7 @@ export function toEChartsEngineLatestValuesOption(
       {
         id: "latest-values",
         dimensions: ["label", "value"],
-        source: model.rows.flatMap((row) =>
+        source: latest.rows.flatMap((row) =>
           row.value === null ? [] : [{ label: row.label, value: row.value }]
         ),
       },
@@ -168,7 +178,11 @@ export function toEChartsEngineLatestValuesOption(
   };
 }
 
-export function toEChartsEngineHistogramOption(model: EngineHistogramModel): EChartsOption {
+export function toEChartsHistogramOption(
+  model: EngineHistogramInput,
+  options: EChartsOptions = {}
+): EChartsOption {
+  const histogram = asEngineHistogramModel(model, options);
   return {
     aria: { enabled: true },
     legend: { type: "scroll" },
@@ -177,7 +191,7 @@ export function toEChartsEngineHistogramOption(model: EngineHistogramModel): ECh
       {
         id: "histogram",
         dimensions: ["label", "count", "start", "end"],
-        source: model.buckets.map((bucket) => ({
+        source: histogram.buckets.map((bucket) => ({
           label: bucket.label,
           count: bucket.count,
           start: bucket.start,
@@ -198,7 +212,7 @@ export function toEChartsEngineHistogramOption(model: EngineHistogramModel): ECh
   };
 }
 
-export function toEChartsTimeSeriesOption(frame: TimeSeriesFrame): EChartsOption {
+export function toEChartsViewTimeSeriesOption(frame: TimeSeriesFrame): EChartsOption {
   const pivoted = pivotTimeSeriesFrame(frame);
 
   return {
@@ -251,7 +265,7 @@ function gaugeValue(model: EngineLatestValueModel): number {
   return Math.round(Math.max(0, Math.min(200, average)));
 }
 
-export function toEChartsLatestValuesOption(frame: LatestValuesFrame): EChartsOption {
+export function toEChartsViewLatestValuesOption(frame: LatestValuesFrame): EChartsOption {
   return {
     aria: {
       enabled: true,
@@ -294,7 +308,7 @@ export function toEChartsLatestValuesOption(frame: LatestValuesFrame): EChartsOp
   };
 }
 
-export function toEChartsHistogramOption(frame: HistogramFrame): EChartsOption {
+export function toEChartsViewHistogramOption(frame: HistogramFrame): EChartsOption {
   return {
     aria: {
       enabled: true,

--- a/packages/adapters/src/engine.ts
+++ b/packages/adapters/src/engine.ts
@@ -81,6 +81,10 @@ export interface EngineHistogramOptions {
   readonly valueFormatter?: (start: number, end: number, index: number) => string;
 }
 
+export type EngineWideTableInput = EngineWideTableModel | EngineQueryResult;
+export type EngineLatestValueInput = EngineLatestValueModel | EngineQueryResult;
+export type EngineHistogramInput = EngineHistogramModel | EngineWideTableModel | EngineQueryResult;
+
 export function toEngineLineSeriesModel(
   result: EngineQueryResult,
   options: EngineAdapterOptions = {}
@@ -157,10 +161,11 @@ export function toEngineLatestValueModel(
 }
 
 export function toEngineHistogramModel(
-  model: EngineWideTableModel,
+  model: EngineWideTableInput,
   options: EngineHistogramOptions = {}
 ): EngineHistogramModel {
-  const values = model.rows.flatMap((row) =>
+  const wide = asEngineWideTableModel(model);
+  const values = wide.rows.flatMap((row) =>
     row.values.filter((value): value is number => value !== null && Number.isFinite(value))
   );
   const bucketCount = Math.max(1, Math.floor(options.bucketCount ?? 7));
@@ -200,6 +205,47 @@ export function toEngineHistogramModel(
   }
 
   return { kind: "engine-histogram", buckets };
+}
+
+export function asEngineWideTableModel(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions = {}
+): EngineWideTableModel {
+  return isEngineWideTableModel(model) ? model : toEngineWideTableModel(model, options);
+}
+
+export function asEngineLatestValueModel(
+  model: EngineLatestValueInput,
+  options: EngineAdapterOptions = {}
+): EngineLatestValueModel {
+  return isEngineLatestValueModel(model) ? model : toEngineLatestValueModel(model, options);
+}
+
+export function asEngineHistogramModel(
+  model: EngineHistogramInput,
+  options: EngineAdapterOptions & EngineHistogramOptions = {}
+): EngineHistogramModel {
+  return isEngineHistogramModel(model)
+    ? model
+    : toEngineHistogramModel(asEngineWideTableModel(model, options), options);
+}
+
+export function isEngineWideTableModel(model: EngineWideTableInput): model is EngineWideTableModel {
+  return isObjectWithKind(model) && model.kind === "engine-wide-table";
+}
+
+export function isEngineLatestValueModel(
+  model: EngineLatestValueInput
+): model is EngineLatestValueModel {
+  return isObjectWithKind(model) && model.kind === "engine-latest-values";
+}
+
+export function isEngineHistogramModel(model: EngineHistogramInput): model is EngineHistogramModel {
+  return isObjectWithKind(model) && model.kind === "engine-histogram";
+}
+
+function isObjectWithKind(model: unknown): model is { readonly kind: unknown } {
+  return typeof model === "object" && model !== null && "kind" in model;
 }
 
 function pointsForSeries(

--- a/packages/adapters/src/highcharts.ts
+++ b/packages/adapters/src/highcharts.ts
@@ -1,11 +1,18 @@
 import type {
-  EngineHistogramModel,
-  EngineLatestValueModel,
-  EngineWideTableModel,
+  EngineAdapterOptions,
+  EngineHistogramInput,
+  EngineHistogramOptions,
+  EngineLatestValueInput,
+  EngineWideTableInput,
+} from "./engine.js";
+import {
+  asEngineHistogramModel,
+  asEngineLatestValueModel,
+  asEngineWideTableModel,
 } from "./engine.js";
 import { gaugeValue } from "./engine-chart-shared.js";
 
-export type HighchartsEngineChartType =
+export type HighchartsChartType =
   | "line"
   | "area"
   | "bar"
@@ -22,43 +29,45 @@ export interface HighchartsSeries {
   readonly data: readonly unknown[];
 }
 
-export interface HighchartsEngineOptions {
-  readonly chartType?: HighchartsEngineChartType;
+export interface HighchartsAdapterOptions extends EngineAdapterOptions, EngineHistogramOptions {
+  readonly chartType?: HighchartsChartType;
 }
 
-export interface HighchartsEngineOptionsModel {
+export interface HighchartsOptions {
   readonly chart: { readonly type: string };
   readonly xAxis?: Record<string, unknown>;
   readonly plotOptions?: Record<string, unknown>;
   readonly series: readonly HighchartsSeries[];
 }
 
-export function toHighchartsEngineTimeSeriesOptions(
-  model: EngineWideTableModel,
-  options: HighchartsEngineOptions = {}
-): HighchartsEngineOptionsModel {
+export function toHighchartsTimeSeriesOptions(
+  model: EngineWideTableInput,
+  options: HighchartsAdapterOptions = {}
+): HighchartsOptions {
+  const wide = asEngineWideTableModel(model, options);
   const chartType = options.chartType ?? "line";
   return {
     chart: { type: chartType === "bar" ? "bar" : chartType === "scatter" ? "scatter" : "line" },
     xAxis: { type: "datetime" },
-    series: model.series.map((series, index) => ({
+    series: wide.series.map((series, index) => ({
       id: series.id,
       name: series.label,
-      data: model.rows.map((row) => [row.t, row.values[index] ?? null]),
+      data: wide.rows.map((row) => [row.t, row.values[index] ?? null]),
       type: chartType === "area" ? "area" : chartType === "sparkline" ? "line" : undefined,
     })),
   };
 }
 
-export function toHighchartsEngineLatestValuesOptions(
-  model: EngineLatestValueModel,
-  options: HighchartsEngineOptions = {}
-): HighchartsEngineOptionsModel {
+export function toHighchartsLatestValuesOptions(
+  model: EngineLatestValueInput,
+  options: HighchartsAdapterOptions = {}
+): HighchartsOptions {
+  const latest = asEngineLatestValueModel(model, options);
   const chartType = options.chartType ?? "donut";
   if (chartType === "gauge") {
     return {
       chart: { type: "gauge" },
-      series: [{ name: "average", data: [gaugeValue(model)] }],
+      series: [{ name: "average", data: [gaugeValue(latest)] }],
     };
   }
   return {
@@ -66,18 +75,20 @@ export function toHighchartsEngineLatestValuesOptions(
     plotOptions: { pie: { innerSize: "55%" } },
     series: [
       {
-        data: model.rows.flatMap((row) => (row.value === null ? [] : [[row.label, row.value]])),
+        data: latest.rows.flatMap((row) => (row.value === null ? [] : [[row.label, row.value]])),
       },
     ],
   };
 }
 
-export function toHighchartsEngineHistogramOptions(
-  model: EngineHistogramModel
-): HighchartsEngineOptionsModel {
+export function toHighchartsHistogramOptions(
+  model: EngineHistogramInput,
+  options: HighchartsAdapterOptions = {}
+): HighchartsOptions {
+  const histogram = asEngineHistogramModel(model, options);
   return {
     chart: { type: "column" },
-    xAxis: { categories: model.buckets.map((bucket) => bucket.label) },
-    series: [{ name: "samples", data: model.buckets.map((bucket) => bucket.count) }],
+    xAxis: { categories: histogram.buckets.map((bucket) => bucket.label) },
+    series: [{ name: "samples", data: histogram.buckets.map((bucket) => bucket.count) }],
   };
 }

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,64 +1,57 @@
 import {
-  toAgChartsEngineLatestValuesOptions,
-  toAgChartsEngineTimeSeriesOptions,
-  toAgChartsEngineUpdateDelta,
+  toAgChartsLatestValuesOptions,
+  toAgChartsTimeSeriesOptions,
+  toAgChartsUpdateDelta,
 } from "./agcharts.js";
 import {
-  toApexChartsEngineLatestValuesOptions,
-  toApexChartsEngineSeriesUpdate,
-  toApexChartsEngineTimeSeriesOptions,
+  toApexChartsLatestValuesOptions,
+  toApexChartsSeriesUpdate,
+  toApexChartsTimeSeriesOptions,
 } from "./apexcharts.js";
 import {
-  toChartJsEngineHistogramConfig,
-  toChartJsEngineLatestValuesConfig,
-  toChartJsEngineTimeSeriesConfig,
   toChartJsHistogramConfig,
   toChartJsLatestValuesConfig,
-  toChartJsLineConfig,
+  toChartJsTimeSeriesConfig,
+  toChartJsViewHistogramConfig,
+  toChartJsViewLatestValuesConfig,
+  toChartJsViewLineConfig,
 } from "./chartjs.js";
 import {
-  toEChartsEngineHistogramOption,
-  toEChartsEngineLatestValuesOption,
-  toEChartsEngineTimeSeriesOption,
   toEChartsHistogramOption,
   toEChartsLatestValuesOption,
   toEChartsTimeSeriesOption,
+  toEChartsViewHistogramOption,
+  toEChartsViewLatestValuesOption,
+  toEChartsViewTimeSeriesOption,
 } from "./echarts.js";
 import {
-  toHighchartsEngineHistogramOptions,
-  toHighchartsEngineLatestValuesOptions,
-  toHighchartsEngineTimeSeriesOptions,
+  toHighchartsHistogramOptions,
+  toHighchartsLatestValuesOptions,
+  toHighchartsTimeSeriesOptions,
 } from "./highcharts.js";
 import {
-  toNivoEngineBarModel,
-  toNivoEngineBarProps,
-  toNivoEngineLineProps,
-  toNivoEngineLineSeries,
-  toNivoEnginePieData,
-  toNivoEnginePieProps,
-  toNivoEngineScatterSeries,
+  toNivoBarData,
+  toNivoBarProps,
+  toNivoLineProps,
+  toNivoLineSeries,
+  toNivoPieData,
+  toNivoPieProps,
+  toNivoScatterSeries,
 } from "./nivo.js";
+import { toObservablePlotHistogramOptions, toObservablePlotOptions } from "./observable.js";
 import {
-  toObservablePlotEngineHistogramModel,
-  toObservablePlotEngineModel,
-  toObservablePlotEnginePlotOptions,
-} from "./observable.js";
-import {
-  toPlotlyEngineHistogramFigure,
-  toPlotlyEngineHistogramModel,
-  toPlotlyEngineLatestValuesFigure,
-  toPlotlyEngineLatestValuesModel,
-  toPlotlyEngineTimeSeriesFigure,
-  toPlotlyEngineTimeSeriesModel,
+  toPlotlyHistogramFigure,
+  toPlotlyLatestValuesFigure,
+  toPlotlyTimeSeriesFigure,
 } from "./plotly.js";
 import {
-  toRechartsEngineHistogramModel,
-  toRechartsEngineLatestValuesModel,
-  toRechartsEngineScatterModel,
-  toRechartsEngineTimeSeriesModel,
-  toRechartsHistogramModel,
-  toRechartsLatestValuesModel,
-  toRechartsTimeSeriesModel,
+  toRechartsHistogramData,
+  toRechartsLatestValuesData,
+  toRechartsScatterData,
+  toRechartsTimeSeriesData,
+  toRechartsViewHistogramData,
+  toRechartsViewLatestValuesData,
+  toRechartsViewTimeSeriesData,
 } from "./recharts.js";
 import {
   toTremorAreaChartProps,
@@ -68,192 +61,153 @@ import {
   toTremorLineChartProps,
 } from "./tremor.js";
 import {
-  toUPlotEngineLatestValuesModel,
-  toUPlotEngineTimeSeriesModel,
-  toUPlotLatestValuesModel,
-  toUPlotTimeSeriesModel,
+  toUPlotLatestValuesArgs,
+  toUPlotTimeSeriesArgs,
+  toUPlotViewLatestValuesArgs,
+  toUPlotViewTimeSeriesArgs,
 } from "./uplot.js";
-import { toVegaLiteEngineHistogramSpec, toVegaLiteEngineSpec } from "./vegalite.js";
-import {
-  toVictoryEngineChartProps,
-  toVictoryEngineLatestData,
-  toVictoryEngineSeries,
-} from "./victory.js";
-import {
-  toVisxEngineHistogramModel,
-  toVisxEngineLatestValuesModel,
-  toVisxEngineXYChartModel,
-} from "./visx.js";
+import { toVegaLiteHistogramSpec, toVegaLiteSpec } from "./vegalite.js";
+import { toVictoryChartProps, toVictoryLatestData, toVictorySeries } from "./victory.js";
+import { toVisxHistogramModel, toVisxLatestValuesModel, toVisxXYChartModel } from "./visx.js";
 import { traceWaterfallToLaneRows } from "./waterfall.js";
 
 export const adapterModules: {
-  readonly toAgChartsEngineLatestValuesOptions: typeof toAgChartsEngineLatestValuesOptions;
-  readonly toAgChartsEngineTimeSeriesOptions: typeof toAgChartsEngineTimeSeriesOptions;
-  readonly toAgChartsEngineUpdateDelta: typeof toAgChartsEngineUpdateDelta;
-  readonly toApexChartsEngineLatestValuesOptions: typeof toApexChartsEngineLatestValuesOptions;
-  readonly toApexChartsEngineSeriesUpdate: typeof toApexChartsEngineSeriesUpdate;
-  readonly toApexChartsEngineTimeSeriesOptions: typeof toApexChartsEngineTimeSeriesOptions;
+  readonly toAgChartsLatestValuesOptions: typeof toAgChartsLatestValuesOptions;
+  readonly toAgChartsTimeSeriesOptions: typeof toAgChartsTimeSeriesOptions;
+  readonly toAgChartsUpdateDelta: typeof toAgChartsUpdateDelta;
+  readonly toApexChartsLatestValuesOptions: typeof toApexChartsLatestValuesOptions;
+  readonly toApexChartsSeriesUpdate: typeof toApexChartsSeriesUpdate;
+  readonly toApexChartsTimeSeriesOptions: typeof toApexChartsTimeSeriesOptions;
+  readonly toChartJsViewHistogramConfig: typeof toChartJsViewHistogramConfig;
   readonly toChartJsHistogramConfig: typeof toChartJsHistogramConfig;
-  readonly toChartJsEngineHistogramConfig: typeof toChartJsEngineHistogramConfig;
-  readonly toChartJsEngineLatestValuesConfig: typeof toChartJsEngineLatestValuesConfig;
-  readonly toChartJsEngineTimeSeriesConfig: typeof toChartJsEngineTimeSeriesConfig;
   readonly toChartJsLatestValuesConfig: typeof toChartJsLatestValuesConfig;
-  readonly toChartJsLineConfig: typeof toChartJsLineConfig;
-  readonly toEChartsEngineHistogramOption: typeof toEChartsEngineHistogramOption;
-  readonly toEChartsEngineLatestValuesOption: typeof toEChartsEngineLatestValuesOption;
-  readonly toEChartsEngineTimeSeriesOption: typeof toEChartsEngineTimeSeriesOption;
+  readonly toChartJsTimeSeriesConfig: typeof toChartJsTimeSeriesConfig;
+  readonly toChartJsViewLatestValuesConfig: typeof toChartJsViewLatestValuesConfig;
+  readonly toChartJsViewLineConfig: typeof toChartJsViewLineConfig;
   readonly toEChartsHistogramOption: typeof toEChartsHistogramOption;
   readonly toEChartsLatestValuesOption: typeof toEChartsLatestValuesOption;
   readonly toEChartsTimeSeriesOption: typeof toEChartsTimeSeriesOption;
-  readonly toHighchartsEngineHistogramOptions: typeof toHighchartsEngineHistogramOptions;
-  readonly toHighchartsEngineLatestValuesOptions: typeof toHighchartsEngineLatestValuesOptions;
-  readonly toHighchartsEngineTimeSeriesOptions: typeof toHighchartsEngineTimeSeriesOptions;
-  readonly toNivoEngineBarModel: typeof toNivoEngineBarModel;
-  readonly toNivoEngineBarProps: typeof toNivoEngineBarProps;
-  readonly toNivoEngineLineSeries: typeof toNivoEngineLineSeries;
-  readonly toNivoEngineLineProps: typeof toNivoEngineLineProps;
-  readonly toNivoEnginePieData: typeof toNivoEnginePieData;
-  readonly toNivoEnginePieProps: typeof toNivoEnginePieProps;
-  readonly toNivoEngineScatterSeries: typeof toNivoEngineScatterSeries;
-  readonly toObservablePlotEngineHistogramModel: typeof toObservablePlotEngineHistogramModel;
-  readonly toObservablePlotEngineModel: typeof toObservablePlotEngineModel;
-  readonly toObservablePlotEnginePlotOptions: typeof toObservablePlotEnginePlotOptions;
-  readonly toPlotlyEngineHistogramFigure: typeof toPlotlyEngineHistogramFigure;
-  readonly toPlotlyEngineHistogramModel: typeof toPlotlyEngineHistogramModel;
-  readonly toPlotlyEngineLatestValuesFigure: typeof toPlotlyEngineLatestValuesFigure;
-  readonly toPlotlyEngineLatestValuesModel: typeof toPlotlyEngineLatestValuesModel;
-  readonly toPlotlyEngineTimeSeriesFigure: typeof toPlotlyEngineTimeSeriesFigure;
-  readonly toPlotlyEngineTimeSeriesModel: typeof toPlotlyEngineTimeSeriesModel;
-  readonly toRechartsEngineLatestValuesModel: typeof toRechartsEngineLatestValuesModel;
-  readonly toRechartsEngineHistogramModel: typeof toRechartsEngineHistogramModel;
-  readonly toRechartsEngineScatterModel: typeof toRechartsEngineScatterModel;
-  readonly toRechartsEngineTimeSeriesModel: typeof toRechartsEngineTimeSeriesModel;
-  readonly toRechartsHistogramModel: typeof toRechartsHistogramModel;
-  readonly toRechartsLatestValuesModel: typeof toRechartsLatestValuesModel;
-  readonly toRechartsTimeSeriesModel: typeof toRechartsTimeSeriesModel;
+  readonly toEChartsViewHistogramOption: typeof toEChartsViewHistogramOption;
+  readonly toEChartsViewLatestValuesOption: typeof toEChartsViewLatestValuesOption;
+  readonly toEChartsViewTimeSeriesOption: typeof toEChartsViewTimeSeriesOption;
+  readonly toHighchartsHistogramOptions: typeof toHighchartsHistogramOptions;
+  readonly toHighchartsLatestValuesOptions: typeof toHighchartsLatestValuesOptions;
+  readonly toHighchartsTimeSeriesOptions: typeof toHighchartsTimeSeriesOptions;
+  readonly toNivoBarData: typeof toNivoBarData;
+  readonly toNivoBarProps: typeof toNivoBarProps;
+  readonly toNivoLineSeries: typeof toNivoLineSeries;
+  readonly toNivoLineProps: typeof toNivoLineProps;
+  readonly toNivoPieData: typeof toNivoPieData;
+  readonly toNivoPieProps: typeof toNivoPieProps;
+  readonly toNivoScatterSeries: typeof toNivoScatterSeries;
+  readonly toObservablePlotHistogramOptions: typeof toObservablePlotHistogramOptions;
+  readonly toObservablePlotOptions: typeof toObservablePlotOptions;
+  readonly toPlotlyHistogramFigure: typeof toPlotlyHistogramFigure;
+  readonly toPlotlyLatestValuesFigure: typeof toPlotlyLatestValuesFigure;
+  readonly toPlotlyTimeSeriesFigure: typeof toPlotlyTimeSeriesFigure;
+  readonly toRechartsLatestValuesData: typeof toRechartsLatestValuesData;
+  readonly toRechartsHistogramData: typeof toRechartsHistogramData;
+  readonly toRechartsScatterData: typeof toRechartsScatterData;
+  readonly toRechartsTimeSeriesData: typeof toRechartsTimeSeriesData;
+  readonly toRechartsViewHistogramData: typeof toRechartsViewHistogramData;
+  readonly toRechartsViewLatestValuesData: typeof toRechartsViewLatestValuesData;
+  readonly toRechartsViewTimeSeriesData: typeof toRechartsViewTimeSeriesData;
   readonly toTremorAreaChartProps: typeof toTremorAreaChartProps;
   readonly toTremorBarChartProps: typeof toTremorBarChartProps;
   readonly toTremorBarListProps: typeof toTremorBarListProps;
   readonly toTremorDonutChartProps: typeof toTremorDonutChartProps;
   readonly toTremorLineChartProps: typeof toTremorLineChartProps;
-  readonly toUPlotEngineLatestValuesModel: typeof toUPlotEngineLatestValuesModel;
-  readonly toUPlotEngineTimeSeriesModel: typeof toUPlotEngineTimeSeriesModel;
-  readonly toUPlotLatestValuesModel: typeof toUPlotLatestValuesModel;
-  readonly toUPlotTimeSeriesModel: typeof toUPlotTimeSeriesModel;
-  readonly toVegaLiteEngineHistogramSpec: typeof toVegaLiteEngineHistogramSpec;
-  readonly toVegaLiteEngineSpec: typeof toVegaLiteEngineSpec;
-  readonly toVictoryEngineChartProps: typeof toVictoryEngineChartProps;
-  readonly toVictoryEngineLatestData: typeof toVictoryEngineLatestData;
-  readonly toVictoryEngineSeries: typeof toVictoryEngineSeries;
-  readonly toVisxEngineHistogramModel: typeof toVisxEngineHistogramModel;
-  readonly toVisxEngineLatestValuesModel: typeof toVisxEngineLatestValuesModel;
-  readonly toVisxEngineXYChartModel: typeof toVisxEngineXYChartModel;
+  readonly toUPlotLatestValuesArgs: typeof toUPlotLatestValuesArgs;
+  readonly toUPlotTimeSeriesArgs: typeof toUPlotTimeSeriesArgs;
+  readonly toUPlotViewLatestValuesArgs: typeof toUPlotViewLatestValuesArgs;
+  readonly toUPlotViewTimeSeriesArgs: typeof toUPlotViewTimeSeriesArgs;
+  readonly toVegaLiteHistogramSpec: typeof toVegaLiteHistogramSpec;
+  readonly toVegaLiteSpec: typeof toVegaLiteSpec;
+  readonly toVictoryChartProps: typeof toVictoryChartProps;
+  readonly toVictoryLatestData: typeof toVictoryLatestData;
+  readonly toVictorySeries: typeof toVictorySeries;
+  readonly toVisxHistogramModel: typeof toVisxHistogramModel;
+  readonly toVisxLatestValuesModel: typeof toVisxLatestValuesModel;
+  readonly toVisxXYChartModel: typeof toVisxXYChartModel;
   readonly traceWaterfallToLaneRows: typeof traceWaterfallToLaneRows;
 } = {
-  toAgChartsEngineLatestValuesOptions,
-  toAgChartsEngineTimeSeriesOptions,
-  toAgChartsEngineUpdateDelta,
-  toApexChartsEngineLatestValuesOptions,
-  toApexChartsEngineSeriesUpdate,
-  toApexChartsEngineTimeSeriesOptions,
+  toAgChartsLatestValuesOptions,
+  toAgChartsTimeSeriesOptions,
+  toAgChartsUpdateDelta,
+  toApexChartsLatestValuesOptions,
+  toApexChartsSeriesUpdate,
+  toApexChartsTimeSeriesOptions,
+  toChartJsViewHistogramConfig,
   toChartJsHistogramConfig,
-  toChartJsEngineHistogramConfig,
-  toChartJsEngineLatestValuesConfig,
-  toChartJsEngineTimeSeriesConfig,
   toChartJsLatestValuesConfig,
-  toChartJsLineConfig,
-  toEChartsEngineHistogramOption,
-  toEChartsEngineLatestValuesOption,
-  toEChartsEngineTimeSeriesOption,
+  toChartJsTimeSeriesConfig,
+  toChartJsViewLatestValuesConfig,
+  toChartJsViewLineConfig,
   toEChartsHistogramOption,
   toEChartsLatestValuesOption,
   toEChartsTimeSeriesOption,
-  toHighchartsEngineHistogramOptions,
-  toHighchartsEngineLatestValuesOptions,
-  toHighchartsEngineTimeSeriesOptions,
-  toNivoEngineBarModel,
-  toNivoEngineBarProps,
-  toNivoEngineLineSeries,
-  toNivoEngineLineProps,
-  toNivoEnginePieData,
-  toNivoEnginePieProps,
-  toNivoEngineScatterSeries,
-  toObservablePlotEngineHistogramModel,
-  toObservablePlotEngineModel,
-  toObservablePlotEnginePlotOptions,
-  toPlotlyEngineHistogramFigure,
-  toPlotlyEngineHistogramModel,
-  toPlotlyEngineLatestValuesFigure,
-  toPlotlyEngineLatestValuesModel,
-  toPlotlyEngineTimeSeriesFigure,
-  toPlotlyEngineTimeSeriesModel,
-  toRechartsEngineLatestValuesModel,
-  toRechartsEngineHistogramModel,
-  toRechartsEngineScatterModel,
-  toRechartsEngineTimeSeriesModel,
-  toRechartsHistogramModel,
-  toRechartsLatestValuesModel,
-  toRechartsTimeSeriesModel,
+  toEChartsViewHistogramOption,
+  toEChartsViewLatestValuesOption,
+  toEChartsViewTimeSeriesOption,
+  toHighchartsHistogramOptions,
+  toHighchartsLatestValuesOptions,
+  toHighchartsTimeSeriesOptions,
+  toNivoBarData,
+  toNivoBarProps,
+  toNivoLineSeries,
+  toNivoLineProps,
+  toNivoPieData,
+  toNivoPieProps,
+  toNivoScatterSeries,
+  toObservablePlotHistogramOptions,
+  toObservablePlotOptions,
+  toPlotlyHistogramFigure,
+  toPlotlyLatestValuesFigure,
+  toPlotlyTimeSeriesFigure,
+  toRechartsLatestValuesData,
+  toRechartsHistogramData,
+  toRechartsScatterData,
+  toRechartsTimeSeriesData,
+  toRechartsViewHistogramData,
+  toRechartsViewLatestValuesData,
+  toRechartsViewTimeSeriesData,
   toTremorAreaChartProps,
   toTremorBarChartProps,
   toTremorBarListProps,
   toTremorDonutChartProps,
   toTremorLineChartProps,
-  toUPlotEngineLatestValuesModel,
-  toUPlotEngineTimeSeriesModel,
-  toUPlotLatestValuesModel,
-  toUPlotTimeSeriesModel,
-  toVegaLiteEngineHistogramSpec,
-  toVegaLiteEngineSpec,
-  toVictoryEngineChartProps,
-  toVictoryEngineLatestData,
-  toVictoryEngineSeries,
-  toVisxEngineHistogramModel,
-  toVisxEngineLatestValuesModel,
-  toVisxEngineXYChartModel,
+  toUPlotLatestValuesArgs,
+  toUPlotTimeSeriesArgs,
+  toUPlotViewLatestValuesArgs,
+  toUPlotViewTimeSeriesArgs,
+  toVegaLiteHistogramSpec,
+  toVegaLiteSpec,
+  toVictoryChartProps,
+  toVictoryLatestData,
+  toVictorySeries,
+  toVisxHistogramModel,
+  toVisxLatestValuesModel,
+  toVisxXYChartModel,
   traceWaterfallToLaneRows,
 };
 
 export {
-  toAgChartsEngineLatestValuesOptions,
-  toAgChartsEngineTimeSeriesOptions,
-  toAgChartsEngineUpdateDelta,
+  toAgChartsLatestValuesOptions,
+  toAgChartsTimeSeriesOptions,
+  toAgChartsUpdateDelta,
 } from "./agcharts.js";
 export {
-  toApexChartsEngineLatestValuesOptions,
-  toApexChartsEngineSeriesUpdate,
-  toApexChartsEngineTimeSeriesOptions,
+  toApexChartsLatestValuesOptions,
+  toApexChartsSeriesUpdate,
+  toApexChartsTimeSeriesOptions,
 } from "./apexcharts.js";
 export type {
-  EngineAdapterOptions,
-  EngineHistogramBucket,
-  EngineHistogramModel,
-  EngineHistogramOptions,
-  EngineLabels,
-  EngineLatestValueModel,
-  EngineLatestValueRow,
-  EngineLineSeries,
-  EngineLineSeriesModel,
-  EnginePoint,
-  EngineQueryResult,
-  EngineSeriesResult,
-  EngineTimestampUnit,
-  EngineWideRow,
-  EngineWideTableModel,
-} from "./engine.js";
-export {
-  toEngineHistogramModel,
-  toEngineLatestValueModel,
-  toEngineLineSeriesModel,
-  toEngineWideTableModel,
-} from "./engine.js";
-export type {
-  RechartsBarModel,
-  RechartsEngineScatterModel,
-  RechartsEngineTimeSeriesModel,
-  RechartsEngineTimeSeriesOptions,
+  RechartsCategoryData,
+  RechartsScatterData,
   RechartsSeriesDescriptor,
-  RechartsTimeSeriesModel,
+  RechartsTimeSeriesData,
+  RechartsTimeSeriesOptions,
+  RechartsViewTimeSeriesData,
 } from "./recharts.js";
 export type {
   TremorAreaChartProps,
@@ -266,60 +220,56 @@ export type {
   TremorXYOptions,
 } from "./tremor.js";
 export {
-  toChartJsEngineHistogramConfig,
-  toChartJsEngineLatestValuesConfig,
-  toChartJsEngineTimeSeriesConfig,
   toChartJsHistogramConfig,
   toChartJsLatestValuesConfig,
-  toChartJsLineConfig,
-  toEChartsEngineHistogramOption,
-  toEChartsEngineLatestValuesOption,
-  toEChartsEngineTimeSeriesOption,
+  toChartJsTimeSeriesConfig,
+  toChartJsViewHistogramConfig,
+  toChartJsViewLatestValuesConfig,
+  toChartJsViewLineConfig,
   toEChartsHistogramOption,
   toEChartsLatestValuesOption,
   toEChartsTimeSeriesOption,
-  toHighchartsEngineHistogramOptions,
-  toHighchartsEngineLatestValuesOptions,
-  toHighchartsEngineTimeSeriesOptions,
-  toNivoEngineBarModel,
-  toNivoEngineBarProps,
-  toNivoEngineLineProps,
-  toNivoEngineLineSeries,
-  toNivoEnginePieData,
-  toNivoEnginePieProps,
-  toNivoEngineScatterSeries,
-  toObservablePlotEngineHistogramModel,
-  toObservablePlotEngineModel,
-  toObservablePlotEnginePlotOptions,
-  toPlotlyEngineHistogramFigure,
-  toPlotlyEngineHistogramModel,
-  toPlotlyEngineLatestValuesFigure,
-  toPlotlyEngineLatestValuesModel,
-  toPlotlyEngineTimeSeriesFigure,
-  toPlotlyEngineTimeSeriesModel,
-  toRechartsEngineHistogramModel,
-  toRechartsEngineLatestValuesModel,
-  toRechartsEngineScatterModel,
-  toRechartsEngineTimeSeriesModel,
-  toRechartsHistogramModel,
-  toRechartsLatestValuesModel,
-  toRechartsTimeSeriesModel,
+  toEChartsViewHistogramOption,
+  toEChartsViewLatestValuesOption,
+  toEChartsViewTimeSeriesOption,
+  toHighchartsHistogramOptions,
+  toHighchartsLatestValuesOptions,
+  toHighchartsTimeSeriesOptions,
+  toNivoBarData,
+  toNivoBarProps,
+  toNivoLineProps,
+  toNivoLineSeries,
+  toNivoPieData,
+  toNivoPieProps,
+  toNivoScatterSeries,
+  toObservablePlotHistogramOptions,
+  toObservablePlotOptions,
+  toPlotlyHistogramFigure,
+  toPlotlyLatestValuesFigure,
+  toPlotlyTimeSeriesFigure,
+  toRechartsHistogramData,
+  toRechartsLatestValuesData,
+  toRechartsScatterData,
+  toRechartsTimeSeriesData,
+  toRechartsViewHistogramData,
+  toRechartsViewLatestValuesData,
+  toRechartsViewTimeSeriesData,
   toTremorAreaChartProps,
   toTremorBarChartProps,
   toTremorBarListProps,
   toTremorDonutChartProps,
   toTremorLineChartProps,
-  toUPlotEngineLatestValuesModel,
-  toUPlotEngineTimeSeriesModel,
-  toUPlotLatestValuesModel,
-  toUPlotTimeSeriesModel,
-  toVegaLiteEngineHistogramSpec,
-  toVegaLiteEngineSpec,
-  toVictoryEngineChartProps,
-  toVictoryEngineLatestData,
-  toVictoryEngineSeries,
-  toVisxEngineHistogramModel,
-  toVisxEngineLatestValuesModel,
-  toVisxEngineXYChartModel,
+  toUPlotLatestValuesArgs,
+  toUPlotTimeSeriesArgs,
+  toUPlotViewLatestValuesArgs,
+  toUPlotViewTimeSeriesArgs,
+  toVegaLiteHistogramSpec,
+  toVegaLiteSpec,
+  toVictoryChartProps,
+  toVictoryLatestData,
+  toVictorySeries,
+  toVisxHistogramModel,
+  toVisxLatestValuesModel,
+  toVisxXYChartModel,
   traceWaterfallToLaneRows,
 };

--- a/packages/adapters/src/nivo.ts
+++ b/packages/adapters/src/nivo.ts
@@ -1,4 +1,10 @@
-import type { EngineLatestValueModel, EngineWideTableModel } from "./engine.js";
+import {
+  asEngineLatestValueModel,
+  asEngineWideTableModel,
+  type EngineAdapterOptions,
+  type EngineLatestValueInput,
+  type EngineWideTableInput,
+} from "./engine.js";
 import { rowToRecord } from "./engine-chart-shared.js";
 
 export interface NivoPoint {
@@ -11,7 +17,7 @@ export interface NivoSeries {
   readonly data: readonly NivoPoint[];
 }
 
-export interface NivoBarModel {
+export interface NivoBarData {
   readonly data: readonly Record<string, number | null>[];
   readonly keys: readonly string[];
   readonly indexBy: string;
@@ -25,7 +31,7 @@ export interface NivoLineProps {
   readonly enablePoints: boolean;
 }
 
-export interface NivoBarProps extends NivoBarModel {
+export interface NivoBarProps extends NivoBarData {
   readonly groupMode: "grouped" | "stacked";
 }
 
@@ -42,19 +48,26 @@ export interface NivoPieDatum {
   readonly color?: string;
 }
 
-export function toNivoEngineLineSeries(model: EngineWideTableModel): readonly NivoSeries[] {
-  return model.series.map((series, index) => ({
+export function toNivoLineSeries(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions = {}
+): readonly NivoSeries[] {
+  const wide = asEngineWideTableModel(model, options);
+  return wide.series.map((series, index) => ({
     id: series.label,
-    data: model.rows.map((row) => ({ x: row.t, y: row.values[index] ?? null })),
+    data: wide.rows.map((row) => ({ x: row.t, y: row.values[index] ?? null })),
   }));
 }
 
-export function toNivoEngineLineProps(
-  model: EngineWideTableModel,
-  options: { readonly chartType?: "line" | "area" | "sparkline"; readonly stacked?: boolean } = {}
+export function toNivoLineProps(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions & {
+    readonly chartType?: "line" | "area" | "sparkline";
+    readonly stacked?: boolean;
+  } = {}
 ): NivoLineProps {
   return {
-    data: toNivoEngineLineSeries(model),
+    data: toNivoLineSeries(model, options),
     xScale: { type: "linear" },
     yScale: { type: "linear", stacked: options.stacked ?? options.chartType === "area" },
     curve: "monotoneX",
@@ -62,26 +75,33 @@ export function toNivoEngineLineProps(
   };
 }
 
-export function toNivoEngineBarModel(model: EngineWideTableModel): NivoBarModel {
+export function toNivoBarData(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions = {}
+): NivoBarData {
+  const wide = asEngineWideTableModel(model, options);
   return {
-    data: model.rows.map((row) => rowToRecord(row, model.series, "time")),
-    keys: model.series.map((series) => series.id),
+    data: wide.rows.map((row) => rowToRecord(row, wide.series, "time")),
+    keys: wide.series.map((series) => series.id),
     indexBy: "time",
   };
 }
 
-export function toNivoEngineBarProps(
-  model: EngineWideTableModel,
-  options: { readonly groupMode?: "grouped" | "stacked" } = {}
+export function toNivoBarProps(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions & { readonly groupMode?: "grouped" | "stacked" } = {}
 ): NivoBarProps {
   return {
-    ...toNivoEngineBarModel(model),
+    ...toNivoBarData(model, options),
     groupMode: options.groupMode ?? "grouped",
   };
 }
 
-export function toNivoEnginePieData(model: EngineLatestValueModel): readonly NivoPieDatum[] {
-  return model.rows.flatMap((row) =>
+export function toNivoPieData(
+  model: EngineLatestValueInput,
+  options: EngineAdapterOptions = {}
+): readonly NivoPieDatum[] {
+  return asEngineLatestValueModel(model, options).rows.flatMap((row) =>
     row.value === null
       ? []
       : [
@@ -94,14 +114,20 @@ export function toNivoEnginePieData(model: EngineLatestValueModel): readonly Niv
   );
 }
 
-export function toNivoEnginePieProps(model: EngineLatestValueModel): NivoPieProps {
+export function toNivoPieProps(
+  model: EngineLatestValueInput,
+  options: EngineAdapterOptions = {}
+): NivoPieProps {
   return {
-    data: toNivoEnginePieData(model),
+    data: toNivoPieData(model, options),
     id: "id",
     value: "value",
   };
 }
 
-export function toNivoEngineScatterSeries(model: EngineWideTableModel): readonly NivoSeries[] {
-  return toNivoEngineLineSeries(model);
+export function toNivoScatterSeries(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions = {}
+): readonly NivoSeries[] {
+  return toNivoLineSeries(model, options);
 }

--- a/packages/adapters/src/observable.ts
+++ b/packages/adapters/src/observable.ts
@@ -1,4 +1,11 @@
-import type { EngineHistogramModel, EngineWideTableModel } from "./engine.js";
+import {
+  asEngineHistogramModel,
+  asEngineWideTableModel,
+  type EngineAdapterOptions,
+  type EngineHistogramInput,
+  type EngineHistogramOptions,
+  type EngineWideTableInput,
+} from "./engine.js";
 import { tidyRows } from "./engine-chart-shared.js";
 
 export type ObservablePlotMarkName = "lineY" | "areaY" | "barY" | "dot";
@@ -10,7 +17,7 @@ export interface ObservablePlotMark {
   readonly stroke?: string;
 }
 
-export interface ObservablePlotEngineModel {
+export interface ObservablePlotOptions {
   readonly data: readonly Record<string, unknown>[];
   readonly marks: readonly ObservablePlotMark[];
   readonly options: {
@@ -20,13 +27,16 @@ export interface ObservablePlotEngineModel {
   };
 }
 
-export function toObservablePlotEngineModel(
-  model: EngineWideTableModel,
-  options: { readonly chartType?: "line" | "area" | "bar" | "scatter" | "sparkline" } = {}
-): ObservablePlotEngineModel {
+export function toObservablePlotOptions(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions & {
+    readonly chartType?: "line" | "area" | "bar" | "scatter" | "sparkline";
+  } = {}
+): ObservablePlotOptions {
+  const wide = asEngineWideTableModel(model, options);
   const chartType = options.chartType ?? "line";
   return {
-    data: tidyRows(model),
+    data: tidyRows(wide),
     marks: [
       {
         mark:
@@ -50,11 +60,13 @@ export function toObservablePlotEngineModel(
   };
 }
 
-export function toObservablePlotEngineHistogramModel(
-  model: EngineHistogramModel
-): ObservablePlotEngineModel {
+export function toObservablePlotHistogramOptions(
+  model: EngineHistogramInput,
+  options: EngineAdapterOptions & EngineHistogramOptions = {}
+): ObservablePlotOptions {
+  const histogram = asEngineHistogramModel(model, options);
   return {
-    data: model.buckets.map((bucket) => ({
+    data: histogram.buckets.map((bucket) => ({
       label: bucket.label,
       count: bucket.count,
       start: bucket.start,
@@ -64,6 +76,3 @@ export function toObservablePlotEngineHistogramModel(
     options: { x: { grid: false }, y: { grid: true } },
   };
 }
-
-export const toObservablePlotEnginePlotOptions: typeof toObservablePlotEngineModel =
-  toObservablePlotEngineModel;

--- a/packages/adapters/src/plotly.ts
+++ b/packages/adapters/src/plotly.ts
@@ -1,11 +1,18 @@
 import type {
-  EngineHistogramModel,
-  EngineLatestValueModel,
-  EngineWideTableModel,
+  EngineAdapterOptions,
+  EngineHistogramInput,
+  EngineHistogramOptions,
+  EngineLatestValueInput,
+  EngineWideTableInput,
+} from "./engine.js";
+import {
+  asEngineHistogramModel,
+  asEngineLatestValueModel,
+  asEngineWideTableModel,
 } from "./engine.js";
 import { gaugeValue } from "./engine-chart-shared.js";
 
-export type PlotlyEngineChartType =
+export type PlotlyChartType =
   | "line"
   | "area"
   | "bar"
@@ -29,7 +36,7 @@ export interface PlotlyTrace {
   readonly gauge?: Record<string, unknown>;
 }
 
-export interface PlotlyEngineModel {
+export interface PlotlyFigure {
   readonly data: readonly PlotlyTrace[];
   readonly layout: Record<string, unknown>;
   readonly config: {
@@ -38,19 +45,20 @@ export interface PlotlyEngineModel {
   };
 }
 
-export function toPlotlyEngineTimeSeriesModel(
-  model: EngineWideTableModel,
-  options: { readonly chartType?: PlotlyEngineChartType } = {}
-): PlotlyEngineModel {
+export function toPlotlyTimeSeriesFigure(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions & { readonly chartType?: PlotlyChartType } = {}
+): PlotlyFigure {
+  const wide = asEngineWideTableModel(model, options);
   const chartType = options.chartType ?? "line";
   return {
-    data: model.series.map((series, index) => ({
-      uid: series.id,
+    data: wide.series.map((series, index) => ({
+      uid: plotlyTraceUid(series.id, index),
       type: chartType === "bar" ? "bar" : "scatter",
       mode: chartType === "bar" ? undefined : chartType === "scatter" ? "markers" : "lines",
       name: series.label,
-      x: model.rows.map((row) => row.t),
-      y: model.rows.map((row) => row.values[index] ?? null),
+      x: wide.rows.map((row) => row.t),
+      y: wide.rows.map((row) => row.values[index] ?? null),
       fill: chartType === "area" ? "tozeroy" : undefined,
     })),
     layout: { xaxis: { type: "date" }, uirevision: "engine-series" },
@@ -58,19 +66,22 @@ export function toPlotlyEngineTimeSeriesModel(
   };
 }
 
-export function toPlotlyEngineLatestValuesModel(
-  model: EngineLatestValueModel,
-  options: { readonly chartType?: PlotlyEngineChartType } = {}
-): PlotlyEngineModel {
+export function toPlotlyLatestValuesFigure(
+  model: EngineLatestValueInput,
+  options: EngineAdapterOptions & { readonly chartType?: PlotlyChartType } = {}
+): PlotlyFigure {
+  const latest = asEngineLatestValueModel(model, options);
   const chartType = options.chartType ?? "donut";
   if (chartType === "gauge") {
     return {
-      data: [{ uid: "latest-gauge", type: "indicator", mode: undefined, value: gaugeValue(model) }],
+      data: [
+        { uid: "latest-gauge", type: "indicator", mode: undefined, value: gaugeValue(latest) },
+      ],
       layout: { margin: { t: 16, b: 16 }, uirevision: "engine-latest" },
       config: { responsive: true, displaylogo: false },
     };
   }
-  const rows = model.rows.filter((row) => row.value !== null);
+  const rows = latest.rows.filter((row) => row.value !== null);
   return {
     data: [
       {
@@ -85,14 +96,18 @@ export function toPlotlyEngineLatestValuesModel(
   };
 }
 
-export function toPlotlyEngineHistogramModel(model: EngineHistogramModel): PlotlyEngineModel {
+export function toPlotlyHistogramFigure(
+  model: EngineHistogramInput,
+  options: EngineAdapterOptions & EngineHistogramOptions = {}
+): PlotlyFigure {
+  const histogram = asEngineHistogramModel(model, options);
   return {
     data: [
       {
         uid: "histogram",
         type: "bar",
-        x: model.buckets.map((bucket) => bucket.label),
-        y: model.buckets.map((bucket) => bucket.count),
+        x: histogram.buckets.map((bucket) => bucket.label),
+        y: histogram.buckets.map((bucket) => bucket.count),
       },
     ],
     layout: { uirevision: "engine-histogram" },
@@ -100,9 +115,15 @@ export function toPlotlyEngineHistogramModel(model: EngineHistogramModel): Plotl
   };
 }
 
-export const toPlotlyEngineTimeSeriesFigure: typeof toPlotlyEngineTimeSeriesModel =
-  toPlotlyEngineTimeSeriesModel;
-export const toPlotlyEngineLatestValuesFigure: typeof toPlotlyEngineLatestValuesModel =
-  toPlotlyEngineLatestValuesModel;
-export const toPlotlyEngineHistogramFigure: typeof toPlotlyEngineHistogramModel =
-  toPlotlyEngineHistogramModel;
+function plotlyTraceUid(id: string, index: number): string {
+  return `engine-${index}-${stableHash(id)}`;
+}
+
+function stableHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}

--- a/packages/adapters/src/recharts.ts
+++ b/packages/adapters/src/recharts.ts
@@ -1,9 +1,17 @@
 import type { HistogramFrame, LatestValuesFrame, TimeSeriesFrame } from "@otlpkit/views";
 
 import type {
-  EngineHistogramModel,
-  EngineLatestValueModel,
+  EngineAdapterOptions,
+  EngineHistogramInput,
+  EngineHistogramOptions,
+  EngineLatestValueInput,
+  EngineWideTableInput,
   EngineWideTableModel,
+} from "./engine.js";
+import {
+  asEngineHistogramModel,
+  asEngineLatestValueModel,
+  asEngineWideTableModel,
 } from "./engine.js";
 import { histogramRows, pivotTimeSeriesFrame } from "./shared.js";
 
@@ -13,7 +21,7 @@ export interface RechartsSeriesDescriptor {
   readonly id?: string;
 }
 
-export interface RechartsTimeSeriesModel {
+export interface RechartsViewTimeSeriesData {
   readonly data: readonly Record<string, number | string | null>[];
   readonly xAxisKey: "timeMs";
   readonly tooltipKey: "isoTime";
@@ -21,7 +29,7 @@ export interface RechartsTimeSeriesModel {
   readonly series: readonly RechartsSeriesDescriptor[];
 }
 
-export interface RechartsEngineTimeSeriesModel {
+export interface RechartsTimeSeriesData {
   readonly data: readonly Record<string, number | string | null>[];
   readonly xAxisKey: string;
   readonly tooltipKey: string;
@@ -29,14 +37,14 @@ export interface RechartsEngineTimeSeriesModel {
   readonly series: readonly RechartsSeriesDescriptor[];
 }
 
-export interface RechartsBarModel {
+export interface RechartsCategoryData {
   readonly data: readonly Record<string, number | string>[];
   readonly categoryKey: string;
   readonly valueKey: string;
   readonly unit: string | null;
 }
 
-export interface RechartsEngineScatterModel {
+export interface RechartsScatterData {
   readonly data: readonly Record<string, number | string | null>[];
   readonly xAxisKey: string;
   readonly yAxisKey: string;
@@ -48,7 +56,7 @@ export interface RechartsEngineScatterModel {
   }[];
 }
 
-export function toRechartsTimeSeriesModel(frame: TimeSeriesFrame): RechartsTimeSeriesModel {
+export function toRechartsViewTimeSeriesData(frame: TimeSeriesFrame): RechartsViewTimeSeriesData {
   const pivoted = pivotTimeSeriesFrame(frame);
   return {
     data: pivoted.rows,
@@ -62,7 +70,7 @@ export function toRechartsTimeSeriesModel(frame: TimeSeriesFrame): RechartsTimeS
   };
 }
 
-export function toRechartsLatestValuesModel(frame: LatestValuesFrame): RechartsBarModel {
+export function toRechartsViewLatestValuesData(frame: LatestValuesFrame): RechartsCategoryData {
   return {
     data: frame.rows.map((row) => ({
       label: row.label,
@@ -74,7 +82,7 @@ export function toRechartsLatestValuesModel(frame: LatestValuesFrame): RechartsB
   };
 }
 
-export function toRechartsHistogramModel(frame: HistogramFrame): RechartsBarModel {
+export function toRechartsViewHistogramData(frame: HistogramFrame): RechartsCategoryData {
   return {
     data: histogramRows(frame),
     categoryKey: "label",
@@ -83,35 +91,36 @@ export function toRechartsHistogramModel(frame: HistogramFrame): RechartsBarMode
   };
 }
 
-export interface RechartsEngineTimeSeriesOptions {
+export interface RechartsTimeSeriesOptions extends EngineAdapterOptions {
   readonly xAxisKey?: string;
   readonly tooltipKey?: string;
   readonly unit?: string | null;
   readonly seriesName?: (series: EngineWideTableModel["series"][number], index: number) => string;
 }
 
-export function toRechartsEngineTimeSeriesModel(
-  model: EngineWideTableModel,
-  options: RechartsEngineTimeSeriesOptions = {}
-): RechartsEngineTimeSeriesModel {
+export function toRechartsTimeSeriesData(
+  model: EngineWideTableInput,
+  options: RechartsTimeSeriesOptions = {}
+): RechartsTimeSeriesData {
+  const wide = asEngineWideTableModel(model, options);
   const xAxisKey = options.xAxisKey ?? "time";
   const tooltipKey = options.tooltipKey ?? xAxisKey;
   const reservedKeys = new Set([xAxisKey, tooltipKey]);
-  const series = model.series.map((series, index) => ({
+  const series = wide.series.map((series, index) => ({
     id: series.id,
     dataKey: uniqueDataKey(series.id, reservedKeys),
     name: options.seriesName?.(series, index) ?? series.label,
   }));
 
   return {
-    data: model.rows.map((row) => {
+    data: wide.rows.map((row) => {
       const output: Record<string, number | string | null> = {
         [xAxisKey]: row.t,
       };
       if (tooltipKey !== xAxisKey) {
         output[tooltipKey] = row.t;
       }
-      for (let i = 0; i < model.series.length; i++) {
+      for (let i = 0; i < wide.series.length; i++) {
         const seriesMeta = series[i];
         if (!seriesMeta) continue;
         output[seriesMeta.dataKey] = row.values[i] ?? null;
@@ -125,12 +134,13 @@ export function toRechartsEngineTimeSeriesModel(
   };
 }
 
-export function toRechartsEngineLatestValuesModel(
-  model: EngineLatestValueModel,
-  options: { readonly unit?: string | null } = {}
-): RechartsBarModel {
+export function toRechartsLatestValuesData(
+  model: EngineLatestValueInput,
+  options: EngineAdapterOptions & { readonly unit?: string | null } = {}
+): RechartsCategoryData {
+  const latest = asEngineLatestValueModel(model, options);
   return {
-    data: model.rows.flatMap((row) =>
+    data: latest.rows.flatMap((row) =>
       row.value === null
         ? []
         : [
@@ -146,12 +156,13 @@ export function toRechartsEngineLatestValuesModel(
   };
 }
 
-export function toRechartsEngineHistogramModel(
-  model: EngineHistogramModel,
-  options: { readonly unit?: string | null } = {}
-): RechartsBarModel {
+export function toRechartsHistogramData(
+  model: EngineHistogramInput,
+  options: EngineAdapterOptions & EngineHistogramOptions & { readonly unit?: string | null } = {}
+): RechartsCategoryData {
+  const histogram = asEngineHistogramModel(model, options);
   return {
-    data: model.buckets.map((bucket) => ({
+    data: histogram.buckets.map((bucket) => ({
       label: bucket.label,
       count: bucket.count,
       start: bucket.start,
@@ -163,29 +174,30 @@ export function toRechartsEngineHistogramModel(
   };
 }
 
-export function toRechartsEngineScatterModel(
-  model: EngineWideTableModel,
-  options: {
+export function toRechartsScatterData(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions & {
     readonly xAxisKey?: string;
     readonly yAxisKey?: string;
     readonly seriesKey?: string;
     readonly unit?: string | null;
     readonly seriesName?: (series: EngineWideTableModel["series"][number], index: number) => string;
   } = {}
-): RechartsEngineScatterModel {
+): RechartsScatterData {
+  const wide = asEngineWideTableModel(model, options);
   const xAxisKey = options.xAxisKey ?? "time";
   const yAxisKey = options.yAxisKey ?? "value";
   const seriesKey = options.seriesKey ?? "series";
   if (xAxisKey === yAxisKey || xAxisKey === seriesKey || yAxisKey === seriesKey) {
     throw new RangeError("Recharts scatter xAxisKey, yAxisKey, and seriesKey must be distinct");
   }
-  const series = model.series.map((series, index) => ({
+  const series = wide.series.map((series, index) => ({
     id: series.id,
     name: options.seriesName?.(series, index) ?? series.label,
   }));
 
   return {
-    data: model.rows.flatMap((row) =>
+    data: wide.rows.flatMap((row) =>
       series.map((series, index) => ({
         [xAxisKey]: row.t,
         [yAxisKey]: row.values[index] ?? null,

--- a/packages/adapters/src/tremor.ts
+++ b/packages/adapters/src/tremor.ts
@@ -1,4 +1,11 @@
-import type { EngineLatestValueModel, EngineWideTableModel } from "./engine.js";
+import {
+  asEngineLatestValueModel,
+  asEngineWideTableModel,
+  type EngineAdapterOptions,
+  type EngineLatestValueInput,
+  type EngineWideTableInput,
+  type EngineWideTableModel,
+} from "./engine.js";
 
 export interface TremorSeriesDescriptor {
   readonly id: string;
@@ -6,7 +13,7 @@ export interface TremorSeriesDescriptor {
   readonly label: string;
 }
 
-export interface TremorXYOptions {
+export interface TremorXYOptions extends EngineAdapterOptions {
   readonly index?: string;
   readonly categoryLabel?: (
     series: EngineWideTableModel["series"][number],
@@ -36,7 +43,7 @@ export interface TremorBarChartProps extends TremorLineLikeProps {
   readonly type?: "default" | "stacked" | "percent";
 }
 
-export interface TremorLatestOptions {
+export interface TremorLatestOptions extends EngineAdapterOptions {
   readonly index?: string;
   readonly category?: string;
   readonly valueFormatter?: (value: number) => string;
@@ -60,47 +67,48 @@ export interface TremorBarListProps {
 }
 
 export function toTremorLineChartProps(
-  model: EngineWideTableModel,
+  model: EngineWideTableInput,
   options: TremorXYOptions = {}
 ): TremorLineLikeProps {
-  return toTremorLineLikeProps(model, options);
+  return toTremorLineLikeProps(asEngineWideTableModel(model, options), options);
 }
 
 export function toTremorAreaChartProps(
-  model: EngineWideTableModel,
+  model: EngineWideTableInput,
   options: TremorXYOptions & { readonly type?: "default" | "stacked" | "percent" } = {}
 ): TremorAreaChartProps {
   return {
-    ...toTremorLineLikeProps(model, options),
+    ...toTremorLineLikeProps(asEngineWideTableModel(model, options), options),
     ...(options.type ? { type: options.type } : {}),
   };
 }
 
 export function toTremorBarChartProps(
-  model: EngineWideTableModel,
+  model: EngineWideTableInput,
   options: TremorXYOptions & {
     readonly layout?: "vertical" | "horizontal";
     readonly type?: "default" | "stacked" | "percent";
   } = {}
 ): TremorBarChartProps {
   return {
-    ...toTremorLineLikeProps(model, options),
+    ...toTremorLineLikeProps(asEngineWideTableModel(model, options), options),
     ...(options.layout ? { layout: options.layout } : {}),
     ...(options.type ? { type: options.type } : {}),
   };
 }
 
 export function toTremorDonutChartProps(
-  model: EngineLatestValueModel,
+  model: EngineLatestValueInput,
   options: TremorLatestOptions = {}
 ): TremorDonutChartProps {
+  const latest = asEngineLatestValueModel(model, options);
   const index = options.index ?? "label";
   const category = options.category ?? "value";
   if (index === category) {
     throw new RangeError(`Tremor donut index and category keys must be distinct: ${index}`);
   }
   return {
-    data: model.rows.flatMap((row) =>
+    data: latest.rows.flatMap((row) =>
       row.value === null
         ? []
         : [
@@ -117,11 +125,15 @@ export function toTremorDonutChartProps(
 }
 
 export function toTremorBarListProps(
-  model: EngineLatestValueModel,
-  options: Pick<TremorLatestOptions, "valueFormatter"> = {}
+  model: EngineLatestValueInput,
+  options: Pick<
+    TremorLatestOptions,
+    "seriesLabel" | "timestampUnit" | "maxPoints" | "valueFormatter"
+  > = {}
 ): TremorBarListProps {
+  const latest = asEngineLatestValueModel(model, options);
   return {
-    data: model.rows.flatMap((row) =>
+    data: latest.rows.flatMap((row) =>
       row.value === null
         ? []
         : [

--- a/packages/adapters/src/uplot.ts
+++ b/packages/adapters/src/uplot.ts
@@ -1,6 +1,12 @@
 import type { LatestValuesFrame, TimeSeriesFrame } from "@otlpkit/views";
 
-import type { EngineLatestValueModel, EngineWideTableModel } from "./engine.js";
+import {
+  asEngineLatestValueModel,
+  asEngineWideTableModel,
+  type EngineAdapterOptions,
+  type EngineLatestValueInput,
+  type EngineWideTableInput,
+} from "./engine.js";
 import { pivotTimeSeriesFrame } from "./shared.js";
 
 export interface UPlotSeriesOption {
@@ -11,7 +17,7 @@ export interface UPlotSeriesOption {
   };
 }
 
-export interface UPlotTimeSeriesModel {
+export interface UPlotTimeSeriesArgs {
   readonly options: {
     readonly title: string;
     readonly scales: {
@@ -37,7 +43,7 @@ export interface UPlotTimeSeriesModel {
   readonly data: readonly (readonly (number | null)[])[];
 }
 
-export interface UPlotLatestValuesModel {
+export interface UPlotLatestValuesArgs {
   readonly options: {
     readonly title: string;
     readonly scales: {
@@ -64,16 +70,17 @@ export interface UPlotLatestValuesModel {
   readonly labels: readonly string[];
 }
 
-export interface UPlotEngineOptions {
+export interface UPlotAdapterOptions extends EngineAdapterOptions {
   readonly title?: string;
   readonly unit?: string | null;
   readonly chartType?: "line" | "area" | "sparkline";
 }
 
-export function toUPlotEngineTimeSeriesModel(
-  model: EngineWideTableModel,
-  options: UPlotEngineOptions = {}
-): UPlotTimeSeriesModel {
+export function toUPlotTimeSeriesArgs(
+  model: EngineWideTableInput,
+  options: UPlotAdapterOptions = {}
+): UPlotTimeSeriesArgs {
+  const wide = asEngineWideTableModel(model, options);
   return {
     options: {
       title: options.title ?? "",
@@ -93,7 +100,7 @@ export function toUPlotEngineTimeSeriesModel(
       ],
       series: [
         { label: "time" },
-        ...model.series.map((series) => ({
+        ...wide.series.map((series) => ({
           label: series.label,
           points: { show: false },
           fill: options.chartType === "area" ? true : undefined,
@@ -101,17 +108,17 @@ export function toUPlotEngineTimeSeriesModel(
       ],
     },
     data: [
-      model.rows.map((row) => Math.round(row.t / 1000)),
-      ...model.series.map((_series, index) => model.rows.map((row) => row.values[index] ?? null)),
+      wide.rows.map((row) => Math.round(row.t / 1000)),
+      ...wide.series.map((_series, index) => wide.rows.map((row) => row.values[index] ?? null)),
     ],
   };
 }
 
-export function toUPlotEngineLatestValuesModel(
-  model: EngineLatestValueModel,
-  options: UPlotEngineOptions = {}
-): UPlotLatestValuesModel {
-  const rows = model.rows.filter((row) => row.value !== null);
+export function toUPlotLatestValuesArgs(
+  model: EngineLatestValueInput,
+  options: UPlotAdapterOptions = {}
+): UPlotLatestValuesArgs {
+  const rows = asEngineLatestValueModel(model, options).rows.filter((row) => row.value !== null);
   return {
     options: {
       title: options.title ?? "",
@@ -142,7 +149,7 @@ export function toUPlotEngineLatestValuesModel(
   };
 }
 
-export function toUPlotTimeSeriesModel(frame: TimeSeriesFrame): UPlotTimeSeriesModel {
+export function toUPlotViewTimeSeriesArgs(frame: TimeSeriesFrame): UPlotTimeSeriesArgs {
   const pivoted = pivotTimeSeriesFrame(frame);
   const rows = pivoted.rows.filter(
     (row): row is typeof row & { readonly timeMs: number } => row.timeMs !== null
@@ -189,7 +196,7 @@ export function toUPlotTimeSeriesModel(frame: TimeSeriesFrame): UPlotTimeSeriesM
   };
 }
 
-export function toUPlotLatestValuesModel(frame: LatestValuesFrame): UPlotLatestValuesModel {
+export function toUPlotViewLatestValuesArgs(frame: LatestValuesFrame): UPlotLatestValuesArgs {
   return {
     options: {
       title: frame.title,

--- a/packages/adapters/src/vegalite.ts
+++ b/packages/adapters/src/vegalite.ts
@@ -1,26 +1,34 @@
-import type { EngineHistogramModel, EngineWideTableModel } from "./engine.js";
+import {
+  asEngineHistogramModel,
+  asEngineWideTableModel,
+  type EngineAdapterOptions,
+  type EngineHistogramInput,
+  type EngineHistogramOptions,
+  type EngineWideTableInput,
+} from "./engine.js";
 import { tidyRows } from "./engine-chart-shared.js";
 
-export type VegaLiteEngineMark = "line" | "area" | "bar" | "point";
+export type VegaLiteMark = "line" | "area" | "bar" | "point";
 
-export interface VegaLiteEngineSpec {
+export interface VegaLiteSpec {
   readonly $schema: "https://vega.github.io/schema/vega-lite/v6.json";
   readonly data: { readonly values: readonly Record<string, unknown>[] };
-  readonly mark: VegaLiteEngineMark;
+  readonly mark: VegaLiteMark;
   readonly encoding: Record<string, unknown>;
   readonly config: {
     readonly invalidValues: "filter";
   };
 }
 
-export function toVegaLiteEngineSpec(
-  model: EngineWideTableModel,
-  options: { readonly mark?: "line" | "area" | "bar" | "scatter" } = {}
-): VegaLiteEngineSpec {
+export function toVegaLiteSpec(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions & { readonly mark?: "line" | "area" | "bar" | "scatter" } = {}
+): VegaLiteSpec {
+  const wide = asEngineWideTableModel(model, options);
   const mark = options.mark === "scatter" ? "point" : (options.mark ?? "line");
   return {
     $schema: "https://vega.github.io/schema/vega-lite/v6.json",
-    data: { values: tidyRows(model).filter((row) => row.value !== null) },
+    data: { values: tidyRows(wide).filter((row) => row.value !== null) },
     mark,
     encoding: {
       x: { field: "time", type: "temporal" },
@@ -36,11 +44,15 @@ export function toVegaLiteEngineSpec(
   };
 }
 
-export function toVegaLiteEngineHistogramSpec(model: EngineHistogramModel): VegaLiteEngineSpec {
+export function toVegaLiteHistogramSpec(
+  model: EngineHistogramInput,
+  options: EngineAdapterOptions & EngineHistogramOptions = {}
+): VegaLiteSpec {
+  const histogram = asEngineHistogramModel(model, options);
   return {
     $schema: "https://vega.github.io/schema/vega-lite/v6.json",
     data: {
-      values: model.buckets.map((bucket) => ({
+      values: histogram.buckets.map((bucket) => ({
         label: bucket.label,
         count: bucket.count,
         start: bucket.start,

--- a/packages/adapters/src/victory.ts
+++ b/packages/adapters/src/victory.ts
@@ -1,4 +1,10 @@
-import type { EngineLatestValueModel, EngineWideTableModel } from "./engine.js";
+import {
+  asEngineLatestValueModel,
+  asEngineWideTableModel,
+  type EngineAdapterOptions,
+  type EngineLatestValueInput,
+  type EngineWideTableInput,
+} from "./engine.js";
 
 export interface VictoryDatum {
   readonly x: number | string;
@@ -12,21 +18,22 @@ export interface VictorySeries {
   readonly component: "VictoryLine" | "VictoryArea" | "VictoryScatter";
 }
 
-export interface VictoryChartPropsModel {
+export interface VictoryChartProps {
   readonly scale: { readonly x: "time" };
   readonly domainPadding: { readonly x: number; readonly y: number };
   readonly series: readonly VictorySeries[];
 }
 
-export function toVictoryEngineSeries(
-  model: EngineWideTableModel,
-  options: { readonly chartType?: "line" | "area" | "scatter" } = {}
+export function toVictorySeries(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions & { readonly chartType?: "line" | "area" | "scatter" } = {}
 ): readonly VictorySeries[] {
+  const wide = asEngineWideTableModel(model, options);
   const chartType = options.chartType ?? "line";
-  return model.series.map((series, index) => ({
+  return wide.series.map((series, index) => ({
     key: series.id,
     label: series.label,
-    data: model.rows.map((row) => ({ x: row.t, y: row.values[index] ?? null })),
+    data: wide.rows.map((row) => ({ x: row.t, y: row.values[index] ?? null })),
     component:
       chartType === "scatter"
         ? "VictoryScatter"
@@ -36,17 +43,22 @@ export function toVictoryEngineSeries(
   }));
 }
 
-export function toVictoryEngineChartProps(
-  model: EngineWideTableModel,
-  options: { readonly chartType?: "line" | "area" | "scatter" } = {}
-): VictoryChartPropsModel {
+export function toVictoryChartProps(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions & { readonly chartType?: "line" | "area" | "scatter" } = {}
+): VictoryChartProps {
   return {
     scale: { x: "time" },
     domainPadding: { x: 8, y: 12 },
-    series: toVictoryEngineSeries(model, options),
+    series: toVictorySeries(model, options),
   };
 }
 
-export function toVictoryEngineLatestData(model: EngineLatestValueModel): readonly VictoryDatum[] {
-  return model.rows.flatMap((row) => (row.value === null ? [] : [{ x: row.label, y: row.value }]));
+export function toVictoryLatestData(
+  model: EngineLatestValueInput,
+  options: EngineAdapterOptions = {}
+): readonly VictoryDatum[] {
+  return asEngineLatestValueModel(model, options).rows.flatMap((row) =>
+    row.value === null ? [] : [{ x: row.label, y: row.value }]
+  );
 }

--- a/packages/adapters/src/visx.ts
+++ b/packages/adapters/src/visx.ts
@@ -1,7 +1,14 @@
 import type {
-  EngineHistogramModel,
-  EngineLatestValueModel,
-  EngineWideTableModel,
+  EngineAdapterOptions,
+  EngineHistogramInput,
+  EngineHistogramOptions,
+  EngineLatestValueInput,
+  EngineWideTableInput,
+} from "./engine.js";
+import {
+  asEngineHistogramModel,
+  asEngineLatestValueModel,
+  asEngineWideTableModel,
 } from "./engine.js";
 
 export interface VisxDatum {
@@ -25,15 +32,18 @@ export interface VisxXYChartModel {
   readonly yScale: { readonly type: "linear"; readonly nice: boolean };
 }
 
-export function toVisxEngineXYChartModel(
-  model: EngineWideTableModel,
-  options: { readonly chartType?: "line" | "area" | "bar" | "scatter" | "sparkline" } = {}
+export function toVisxXYChartModel(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions & {
+    readonly chartType?: "line" | "area" | "bar" | "scatter" | "sparkline";
+  } = {}
 ): VisxXYChartModel {
+  const wide = asEngineWideTableModel(model, options);
   return {
-    data: model.series.map((series, index) => ({
+    data: wide.series.map((series, index) => ({
       key: series.id,
       label: series.label,
-      data: model.rows.map((row) => ({ x: row.t, y: row.values[index] ?? null })),
+      data: wide.rows.map((row) => ({ x: row.t, y: row.values[index] ?? null })),
     })),
     accessors: {
       xAccessor: (datum) => datum.x,
@@ -44,13 +54,17 @@ export function toVisxEngineXYChartModel(
   };
 }
 
-export function toVisxEngineLatestValuesModel(model: EngineLatestValueModel): VisxXYChartModel {
+export function toVisxLatestValuesModel(
+  model: EngineLatestValueInput,
+  options: EngineAdapterOptions = {}
+): VisxXYChartModel {
+  const latest = asEngineLatestValueModel(model, options);
   return {
     data: [
       {
         key: "latest",
         label: "latest",
-        data: model.rows.flatMap((row) =>
+        data: latest.rows.flatMap((row) =>
           row.value === null ? [] : [{ x: row.label, y: row.value }]
         ),
       },
@@ -64,13 +78,17 @@ export function toVisxEngineLatestValuesModel(model: EngineLatestValueModel): Vi
   };
 }
 
-export function toVisxEngineHistogramModel(model: EngineHistogramModel): VisxXYChartModel {
+export function toVisxHistogramModel(
+  model: EngineHistogramInput,
+  options: EngineAdapterOptions & EngineHistogramOptions = {}
+): VisxXYChartModel {
+  const histogram = asEngineHistogramModel(model, options);
   return {
     data: [
       {
         key: "histogram",
         label: "samples",
-        data: model.buckets.map((bucket) => ({ x: bucket.label, y: bucket.count })),
+        data: histogram.buckets.map((bucket) => ({ x: bucket.label, y: bucket.count })),
       },
     ],
     accessors: {

--- a/packages/adapters/test/index.test.ts
+++ b/packages/adapters/test/index.test.ts
@@ -7,54 +7,62 @@ import {
   buildTimeSeriesFrame,
   buildTraceWaterfallFrame,
 } from "../../views/src/index.js";
-import * as adapterBarrel from "../src/index.js";
 import {
-  toAgChartsEngineTimeSeriesOptions,
-  toAgChartsEngineUpdateDelta,
-  toApexChartsEngineLatestValuesOptions,
-  toApexChartsEngineSeriesUpdate,
-  toChartJsEngineHistogramConfig,
-  toChartJsEngineLatestValuesConfig,
-  toChartJsEngineTimeSeriesConfig,
-  toChartJsHistogramConfig,
-  toChartJsLatestValuesConfig,
-  toChartJsLineConfig,
-  toEChartsEngineHistogramOption,
-  toEChartsEngineLatestValuesOption,
-  toEChartsEngineTimeSeriesOption,
-  toEChartsHistogramOption,
-  toEChartsLatestValuesOption,
-  toEChartsTimeSeriesOption,
   toEngineHistogramModel,
   toEngineLatestValueModel,
   toEngineLineSeriesModel,
   toEngineWideTableModel,
-  toHighchartsEngineTimeSeriesOptions,
-  toNivoEngineBarModel,
-  toNivoEngineLineProps,
-  toNivoEnginePieProps,
-  toObservablePlotEngineModel,
-  toPlotlyEngineLatestValuesFigure,
-  toPlotlyEngineTimeSeriesModel,
-  toRechartsEngineHistogramModel,
-  toRechartsEngineLatestValuesModel,
-  toRechartsEngineScatterModel,
-  toRechartsEngineTimeSeriesModel,
-  toRechartsHistogramModel,
-  toRechartsLatestValuesModel,
-  toRechartsTimeSeriesModel,
+} from "../src/engine.js";
+import * as adapterBarrel from "../src/index.js";
+import {
+  toAgChartsLatestValuesOptions,
+  toAgChartsTimeSeriesOptions,
+  toAgChartsUpdateDelta,
+  toApexChartsLatestValuesOptions,
+  toApexChartsSeriesUpdate,
+  toApexChartsTimeSeriesOptions,
+  toChartJsHistogramConfig,
+  toChartJsLatestValuesConfig,
+  toChartJsTimeSeriesConfig,
+  toChartJsViewHistogramConfig,
+  toChartJsViewLatestValuesConfig,
+  toChartJsViewLineConfig,
+  toEChartsHistogramOption,
+  toEChartsLatestValuesOption,
+  toEChartsTimeSeriesOption,
+  toEChartsViewHistogramOption,
+  toEChartsViewLatestValuesOption,
+  toEChartsViewTimeSeriesOption,
+  toHighchartsTimeSeriesOptions,
+  toNivoBarData,
+  toNivoBarProps,
+  toNivoLineProps,
+  toNivoLineSeries,
+  toNivoPieProps,
+  toObservablePlotOptions,
+  toPlotlyHistogramFigure,
+  toPlotlyLatestValuesFigure,
+  toPlotlyTimeSeriesFigure,
+  toRechartsHistogramData,
+  toRechartsLatestValuesData,
+  toRechartsScatterData,
+  toRechartsTimeSeriesData,
+  toRechartsViewHistogramData,
+  toRechartsViewLatestValuesData,
+  toRechartsViewTimeSeriesData,
   toTremorBarChartProps,
   toTremorBarListProps,
   toTremorDonutChartProps,
   toTremorLineChartProps,
-  toUPlotEngineTimeSeriesModel,
-  toUPlotLatestValuesModel,
-  toUPlotTimeSeriesModel,
-  toVegaLiteEngineSpec,
-  toVictoryEngineChartProps,
-  toVictoryEngineSeries,
-  toVisxEngineHistogramModel,
-  toVisxEngineXYChartModel,
+  toUPlotTimeSeriesArgs,
+  toUPlotViewLatestValuesArgs,
+  toUPlotViewTimeSeriesArgs,
+  toVegaLiteSpec,
+  toVictoryChartProps,
+  toVictoryLatestData,
+  toVictorySeries,
+  toVisxHistogramModel,
+  toVisxXYChartModel,
   traceWaterfallToLaneRows,
 } from "../src/index.js";
 import { histogramRows, pivotTimeSeriesFrame } from "../src/shared.js";
@@ -97,9 +105,9 @@ describe("@otlpkit/adapters", () => {
   });
 
   it("builds native-feeling Chart.js configs", () => {
-    const line = toChartJsLineConfig(timeSeriesFrame);
-    const latest = toChartJsLatestValuesConfig(latestValuesFrame);
-    const histogram = toChartJsHistogramConfig(histogramFrame);
+    const line = toChartJsViewLineConfig(timeSeriesFrame);
+    const latest = toChartJsViewLatestValuesConfig(latestValuesFrame);
+    const histogram = toChartJsViewHistogramConfig(histogramFrame);
 
     expect(line.type).toBe("line");
     expect(line.data.datasets).toHaveLength(2);
@@ -110,9 +118,9 @@ describe("@otlpkit/adapters", () => {
   });
 
   it("builds native-feeling Recharts models", () => {
-    const timeSeries = toRechartsTimeSeriesModel(timeSeriesFrame);
-    const latest = toRechartsLatestValuesModel(latestValuesFrame);
-    const histogram = toRechartsHistogramModel(histogramFrame);
+    const timeSeries = toRechartsViewTimeSeriesData(timeSeriesFrame);
+    const latest = toRechartsViewLatestValuesData(latestValuesFrame);
+    const histogram = toRechartsViewHistogramData(histogramFrame);
 
     expect(timeSeries.xAxisKey).toBe("timeMs");
     expect(timeSeries.series).toHaveLength(2);
@@ -157,48 +165,94 @@ describe("@otlpkit/adapters", () => {
     });
     const histogram = toEngineHistogramModel(wide, { bucketCount: 3 });
 
-    expect(toChartJsEngineTimeSeriesConfig(wide).data.datasets[0]?.parsing).toBe(false);
-    expect(toChartJsEngineLatestValuesConfig(latest, { chartType: "donut" }).type).toBe("doughnut");
-    expect(toChartJsEngineHistogramConfig(histogram).data.labels).toHaveLength(3);
-    expect(toEChartsEngineTimeSeriesOption(wide).series[0]?.encode.x).toBe("time");
-    expect(toEChartsEngineLatestValuesOption(latest, { chartType: "gauge" }).series[0]?.type).toBe(
+    expect(toChartJsTimeSeriesConfig(wide).data.datasets[0]?.parsing).toBe(false);
+    expect(toChartJsLatestValuesConfig(latest, { chartType: "donut" }).type).toBe("doughnut");
+    expect(toChartJsHistogramConfig(histogram).data.labels).toHaveLength(3);
+    expect(toEChartsTimeSeriesOption(wide).series[0]?.encode.x).toBe("time");
+    expect(toEChartsLatestValuesOption(latest, { chartType: "gauge" }).series[0]?.type).toBe(
       "gauge"
     );
-    expect(toEChartsEngineHistogramOption(histogram).dataset[0]?.source).toHaveLength(3);
-    expect(toUPlotEngineTimeSeriesModel(wide).data).toHaveLength(3);
-    expect(toNivoEngineBarModel(wide).keys).toEqual(["__name__=cpu,host=a", "__name__=cpu,host=b"]);
-    expect(toNivoEngineLineProps(wide, { chartType: "sparkline" }).enablePoints).toBe(false);
-    expect(toNivoEnginePieProps(latest).value).toBe("value");
-    expect(toObservablePlotEngineModel(wide).marks[0]?.mark).toBe("lineY");
-    expect(toObservablePlotEngineModel(wide).options.color?.legend).toBe(true);
-    expect(toPlotlyEngineTimeSeriesModel(wide).data[0]?.type).toBe("scatter");
-    expect(toPlotlyEngineTimeSeriesModel(wide).data[0]?.uid).toBe("__name__=cpu,host=a");
-    expect(toPlotlyEngineLatestValuesFigure(latest).config.responsive).toBe(true);
-    expect(toRechartsEngineHistogramModel(histogram).valueKey).toBe("count");
-    expect(toRechartsEngineScatterModel(wide).series.map((series) => series.name)).toEqual([
-      "a",
-      "b",
-    ]);
-    expect(toApexChartsEngineLatestValuesOptions(latest, { chartType: "gauge" }).chart.type).toBe(
+    expect(toEChartsHistogramOption(histogram).dataset[0]?.source).toHaveLength(3);
+    expect(toUPlotTimeSeriesArgs(wide).data).toHaveLength(3);
+    expect(toNivoBarData(wide).keys).toEqual(["__name__=cpu,host=a", "__name__=cpu,host=b"]);
+    expect(toNivoLineProps(wide, { chartType: "sparkline" }).enablePoints).toBe(false);
+    expect(toNivoPieProps(latest).value).toBe("value");
+    expect(toObservablePlotOptions(wide).marks[0]?.mark).toBe("lineY");
+    expect(toObservablePlotOptions(wide).options.color?.legend).toBe(true);
+    expect(toPlotlyTimeSeriesFigure(wide).data[0]?.type).toBe("scatter");
+    expect(toPlotlyTimeSeriesFigure(wide).data[0]?.uid).toMatch(/^engine-0-[a-z0-9]+$/);
+    expect(toPlotlyTimeSeriesFigure(wide).data[0]?.name).toBe("a");
+    expect(toPlotlyLatestValuesFigure(latest).config.responsive).toBe(true);
+    expect(toRechartsHistogramData(histogram).valueKey).toBe("count");
+    expect(toRechartsScatterData(wide).series.map((series) => series.name)).toEqual(["a", "b"]);
+    expect(toApexChartsLatestValuesOptions(latest, { chartType: "gauge" }).chart.type).toBe(
       "radialBar"
     );
+    expect(toApexChartsSeriesUpdate(toApexChartsLatestValuesOptions(latest)).series).toEqual([
+      3, 30,
+    ]);
+    expect(toVictorySeries(wide, { chartType: "area" })[0]?.component).toBe("VictoryArea");
+    expect(toVictoryChartProps(wide).scale.x).toBe("time");
+    expect(toAgChartsTimeSeriesOptions(wide, { chartType: "area" }).series?.[0]?.type).toBe("area");
+    expect(toAgChartsUpdateDelta(toAgChartsTimeSeriesOptions(wide)).data).toHaveLength(3);
+    expect(toHighchartsTimeSeriesOptions(wide).chart.type).toBe("line");
+    expect(toHighchartsTimeSeriesOptions(wide).xAxis?.type).toBe("datetime");
+    expect(toVegaLiteSpec(wide, { mark: "scatter" }).mark).toBe("point");
+    expect(toVegaLiteSpec(wide).$schema).toContain("vega-lite");
+    expect(toVisxXYChartModel(wide).data[0]?.data[0]).toEqual({ x: 1, y: 1 });
+    expect(toVisxHistogramModel(histogram).xScale.type).toBe("band");
+  });
+
+  it("lets package-rendered chart adapters accept engine query results directly", () => {
+    const options = {
+      seriesLabel: (series: (typeof engineResult.series)[number]) =>
+        series.labels.get("host") ?? "unknown",
+    };
+
+    expect(toChartJsTimeSeriesConfig(engineResult, options).data.datasets[0]?.label).toBe("a");
+    expect(toChartJsLatestValuesConfig(engineResult, options).data.labels).toEqual(["a", "b"]);
     expect(
-      toApexChartsEngineSeriesUpdate(toApexChartsEngineLatestValuesOptions(latest)).series
-    ).toEqual([3, 30]);
-    expect(toVictoryEngineSeries(wide, { chartType: "area" })[0]?.component).toBe("VictoryArea");
-    expect(toVictoryEngineChartProps(wide).scale.x).toBe("time");
-    expect(toAgChartsEngineTimeSeriesOptions(wide, { chartType: "area" }).series?.[0]?.type).toBe(
-      "area"
-    );
-    expect(toAgChartsEngineUpdateDelta(toAgChartsEngineTimeSeriesOptions(wide)).data).toHaveLength(
+      toChartJsHistogramConfig(engineResult, { ...options, bucketCount: 3 }).data.labels
+    ).toHaveLength(3);
+    expect(toEChartsTimeSeriesOption(engineResult, options).dataset[0]?.source[0]?.a).toBe(1);
+    expect(toEChartsLatestValuesOption(engineResult, options).dataset[0]?.source).toEqual([
+      { label: "a", value: 3 },
+      { label: "b", value: 30 },
+    ]);
+    expect(
+      toEChartsHistogramOption(engineResult, { ...options, bucketCount: 3 }).series[0]?.type
+    ).toBe("bar");
+    expect(toUPlotTimeSeriesArgs(engineResult, options).options.series[1]?.label).toBe("a");
+    expect(toNivoLineSeries(engineResult, options)[0]?.id).toBe("a");
+    expect(toNivoBarData(engineResult, options).keys).toEqual([
+      "__name__=cpu,host=a",
+      "__name__=cpu,host=b",
+    ]);
+    expect(toNivoBarProps(engineResult, options).data[0]?.["__name__=cpu,host=a"]).toBe(1);
+    expect(toObservablePlotOptions(engineResult, options).data[0]?.series).toBe("a");
+    expect(toPlotlyTimeSeriesFigure(engineResult, options).data[0]?.name).toBe("a");
+    expect(
+      toPlotlyHistogramFigure(engineResult, { ...options, bucketCount: 3 }).data[0]?.type
+    ).toBe("bar");
+    expect(toRechartsTimeSeriesData(engineResult, options).series[0]?.name).toBe("a");
+    expect(toRechartsLatestValuesData(engineResult, options).data[1]?.value).toBe(30);
+    expect(toRechartsHistogramData(engineResult, { ...options, bucketCount: 3 }).data).toHaveLength(
       3
     );
-    expect(toHighchartsEngineTimeSeriesOptions(wide).chart.type).toBe("line");
-    expect(toHighchartsEngineTimeSeriesOptions(wide).xAxis?.type).toBe("datetime");
-    expect(toVegaLiteEngineSpec(wide, { mark: "scatter" }).mark).toBe("point");
-    expect(toVegaLiteEngineSpec(wide).$schema).toContain("vega-lite");
-    expect(toVisxEngineXYChartModel(wide).data[0]?.data[0]).toEqual({ x: 1, y: 1 });
-    expect(toVisxEngineHistogramModel(histogram).xScale.type).toBe("band");
+    expect(toApexChartsTimeSeriesOptions(engineResult, options).series[0]?.name).toBe("a");
+    expect(toApexChartsLatestValuesOptions(engineResult, options).labels).toEqual(["a", "b"]);
+    expect(toVictorySeries(engineResult, options)[0]?.label).toBe("a");
+    expect(toVictoryLatestData(engineResult, options)).toEqual([
+      { x: "a", y: 3 },
+      { x: "b", y: 30 },
+    ]);
+    expect(toAgChartsTimeSeriesOptions(engineResult, options).series?.[0]?.yName).toBe("a");
+    expect(toAgChartsLatestValuesOptions(engineResult, options).data).toEqual([
+      { label: "a", value: 3 },
+      { label: "b", value: 30 },
+    ]);
+    expect(toHighchartsTimeSeriesOptions(engineResult, options).series?.[0]?.name).toBe("a");
+    expect(toVegaLiteSpec(engineResult, options).data.values[0]?.series).toBe("a");
   });
 
   it("handles engine timestamp units, point budgets, and invalid query results", () => {
@@ -351,10 +405,10 @@ describe("@otlpkit/adapters", () => {
       seriesLabel: (series) => series.labels.get("host") ?? "unknown",
     });
     const histogram = toEngineHistogramModel(wide, { bucketCount: 3 });
-    const timeSeries = toRechartsEngineTimeSeriesModel(wide, { unit: "%" });
-    const latestValues = toRechartsEngineLatestValuesModel(latest, { unit: "%" });
-    const histogramModel = toRechartsEngineHistogramModel(histogram, { unit: "count" });
-    const scatter = toRechartsEngineScatterModel(wide, { unit: "%" });
+    const timeSeries = toRechartsTimeSeriesData(wide, { unit: "%" });
+    const latestValues = toRechartsLatestValuesData(latest, { unit: "%" });
+    const histogramModel = toRechartsHistogramData(histogram, { unit: "count" });
+    const scatter = toRechartsScatterData(wide, { unit: "%" });
 
     expect(timeSeries.xAxisKey).toBe("time");
     expect(timeSeries.series).toEqual([
@@ -408,7 +462,7 @@ describe("@otlpkit/adapters", () => {
         },
       ],
     });
-    const timeSeries = toRechartsEngineTimeSeriesModel(wide, {
+    const timeSeries = toRechartsTimeSeriesData(wide, {
       xAxisKey: "__name__=time",
       tooltipKey: "__name__=tooltip",
     });
@@ -429,13 +483,13 @@ describe("@otlpkit/adapters", () => {
     const wide = toEngineWideTableModel(engineResult);
 
     expect(() =>
-      toRechartsEngineScatterModel(wide, {
+      toRechartsScatterData(wide, {
         xAxisKey: "value",
         yAxisKey: "value",
       })
     ).toThrow(/must be distinct/);
     expect(() =>
-      toRechartsEngineScatterModel(wide, {
+      toRechartsScatterData(wide, {
         xAxisKey: "time",
         seriesKey: "time",
       })
@@ -450,11 +504,27 @@ describe("@otlpkit/adapters", () => {
       seriesLabel: (series) => series.labels.get("host") ?? "unknown",
     });
     const line = toTremorLineChartProps(wide, { connectNulls: false });
+    const directLine = toTremorLineChartProps(engineResult, {
+      connectNulls: false,
+      seriesLabel: (series) => series.labels.get("host") ?? "unknown",
+    });
     const bar = toTremorBarChartProps(wide, { layout: "horizontal", type: "stacked" });
+    const directBar = toTremorBarChartProps(engineResult, {
+      layout: "horizontal",
+      seriesLabel: (series) => series.labels.get("host") ?? "unknown",
+      type: "stacked",
+    });
     const donut = toTremorDonutChartProps(latest);
+    const directDonut = toTremorDonutChartProps(engineResult, {
+      seriesLabel: (series) => series.labels.get("host") ?? "unknown",
+    });
     const barList = toTremorBarListProps(latest);
+    const directBarList = toTremorBarListProps(engineResult, {
+      seriesLabel: (series) => series.labels.get("host") ?? "unknown",
+    });
 
     expect(line.index).toBe("time");
+    expect(directLine).toEqual(line);
     expect(line.categories).toEqual(["a", "b"]);
     expect(line.meta.series.map((series) => [series.id, series.key, series.label])).toEqual([
       ["__name__=cpu,host=a", "a", "a"],
@@ -463,12 +533,15 @@ describe("@otlpkit/adapters", () => {
     expect(line.data[1]?.a).toBeNull();
     expect(bar.layout).toBe("horizontal");
     expect(bar.type).toBe("stacked");
+    expect(directBar).toEqual(bar);
     expect(donut.index).toBe("label");
     expect(donut.category).toBe("value");
+    expect(directDonut).toEqual(donut);
     expect(barList.data).toEqual([
       { name: "a", value: 3 },
       { name: "b", value: 30 },
     ]);
+    expect(directBarList).toEqual(barList);
   });
 
   it("keeps Tremor legends readable and filters null latest values", () => {
@@ -532,8 +605,8 @@ describe("@otlpkit/adapters", () => {
   });
 
   it("builds aligned uPlot models", () => {
-    const timeSeries = toUPlotTimeSeriesModel(timeSeriesFrame);
-    const latest = toUPlotLatestValuesModel(latestValuesFrame);
+    const timeSeries = toUPlotViewTimeSeriesArgs(timeSeriesFrame);
+    const latest = toUPlotViewLatestValuesArgs(latestValuesFrame);
 
     expect(timeSeries.options.scales.x.time).toBe(true);
     expect(timeSeries.data).toHaveLength(timeSeriesFrame.series.length + 1);
@@ -544,9 +617,9 @@ describe("@otlpkit/adapters", () => {
   });
 
   it("builds dataset-first ECharts options", () => {
-    const timeSeries = toEChartsTimeSeriesOption(timeSeriesFrame);
-    const latest = toEChartsLatestValuesOption(latestValuesFrame);
-    const histogram = toEChartsHistogramOption(histogramFrame);
+    const timeSeries = toEChartsViewTimeSeriesOption(timeSeriesFrame);
+    const latest = toEChartsViewLatestValuesOption(latestValuesFrame);
+    const histogram = toEChartsViewHistogramOption(histogramFrame);
 
     expect(timeSeries.dataset[0]?.id).toBe("telemetry");
     expect(timeSeries.series[0]?.encode.x).toBe("timeMs");
@@ -614,18 +687,20 @@ describe("@otlpkit/adapters", () => {
       ],
     };
 
-    expect(typeof adapterBarrel.adapterModules.toChartJsLineConfig).toBe("function");
-    expect(typeof adapterBarrel.adapterModules.toAgChartsEngineTimeSeriesOptions).toBe("function");
-    expect(typeof adapterBarrel.adapterModules.toVegaLiteEngineSpec).toBe("function");
-    expect(typeof adapterBarrel.adapterModules.toVisxEngineXYChartModel).toBe("function");
-    expect(toChartJsLineConfig(sparseFrame).data.datasets[0]?.data[0]).toEqual({ x: 0, y: 1 });
-    expect(toChartJsLineConfig(sparseFrame).options.scales.y.title.text).toBe("");
-    expect(toEChartsTimeSeriesOption(sparseFrame).yAxis.name).toBe("");
-    expect(toChartJsLatestValuesConfig(sparseLatest).options.scales.y.title.text).toBe("");
-    expect(toEChartsLatestValuesOption(sparseLatest).yAxis.name).toBe("");
-    expect(toRechartsTimeSeriesModel(sparseFrame).data[0]?.timeMs).toBeNull();
-    expect(toUPlotTimeSeriesModel(sparseFrame).data[0]).toHaveLength(1);
-    expect(toUPlotLatestValuesModel(sparseLatest).options.axes[1].label).toBe("");
+    expect(typeof adapterBarrel.adapterModules.toChartJsViewLineConfig).toBe("function");
+    expect(typeof adapterBarrel.adapterModules.toAgChartsTimeSeriesOptions).toBe("function");
+    expect(typeof adapterBarrel.adapterModules.toVegaLiteSpec).toBe("function");
+    expect(typeof adapterBarrel.adapterModules.toVisxXYChartModel).toBe("function");
+    expect("toEngineWideTableModel" in adapterBarrel.adapterModules).toBe(false);
+    expect("toEngineWideTableModel" in adapterBarrel).toBe(false);
+    expect(toChartJsViewLineConfig(sparseFrame).data.datasets[0]?.data[0]).toEqual({ x: 0, y: 1 });
+    expect(toChartJsViewLineConfig(sparseFrame).options.scales.y.title.text).toBe("");
+    expect(toEChartsViewTimeSeriesOption(sparseFrame).yAxis.name).toBe("");
+    expect(toChartJsViewLatestValuesConfig(sparseLatest).options.scales.y.title.text).toBe("");
+    expect(toEChartsViewLatestValuesOption(sparseLatest).yAxis.name).toBe("");
+    expect(toRechartsViewTimeSeriesData(sparseFrame).data[0]?.timeMs).toBeNull();
+    expect(toUPlotViewTimeSeriesArgs(sparseFrame).data[0]).toHaveLength(1);
+    expect(toUPlotViewLatestValuesArgs(sparseLatest).options.axes[1].label).toBe("");
     expect(pivotTimeSeriesFrame(sparseFrame).rows).toHaveLength(2);
     expect(histogramRows(histogramFrame)[0]?.count).toBeGreaterThanOrEqual(0);
   });

--- a/site/charts/PLAN.md
+++ b/site/charts/PLAN.md
@@ -18,8 +18,9 @@ The gallery should make the adapter story obvious:
 
 ```ts
 const result = engine.query(store, query);
-const wide = toEngineWideTableModel(result);
-const props = toTremorLineChartProps(wide);
+const props = toTremorLineChartProps(result, {
+  seriesLabel: (series) => series.labels.get("service") ?? series.label,
+});
 ```
 
 Then:
@@ -40,7 +41,9 @@ Use one generated TSDB dataset across every page:
   - latest by route
   - histogram-ish bucket output for non-TS charts where useful
 
-Keep the data fixed enough that every library page is visually comparable.
+Keep the data fixed enough that every library page is visually comparable. The generated samples
+must still be appended into an `o11ytsdb` `RowGroupStore` and queried with `ScanEngine`; the gallery
+should never pass hand-built query-result lookalikes directly to adapters.
 
 ## Site Structure
 

--- a/site/charts/PLAN.md
+++ b/site/charts/PLAN.md
@@ -63,8 +63,6 @@ site/charts/
     index.html
   nivo/
     index.html
-  visx/
-    index.html
   observable-plot/
     index.html
   plotly/
@@ -81,7 +79,6 @@ site/charts/
 | ECharts | yes | yes | yes | pie | yes | `setOption` plan, append spike | second wave |
 | uPlot | yes | no native area focus | latest recipe | no | no | live controller + `setData` | second wave |
 | Nivo | yes | yes | yes | pie | recipe | React data updates | third wave |
-| Visx | yes | yes | yes | recipe | recipe | caller state updates | third wave |
 | Observable Plot | yes | area mark | bar mark | no | bin transform | rebuild plot | third wave |
 | Plotly | yes | filled scatter | bar | pie | histogram | `extendTraces` patch | third wave |
 
@@ -109,7 +106,7 @@ Each library page should include:
 
 - Added `/o11ykit/charts/` overview page.
 - Linked it from the home nav.
-- Included support matrix, canonical snippets, adapter-shaped output previews, and deterministic gallery data.
+- Included support matrix, canonical snippets, native package previews, and deterministic gallery data.
 
 ### Phase 2: Tremor + Recharts Live Examples
 
@@ -125,7 +122,7 @@ Each library page should include:
 
 ### Phase 4: Ecosystem Libraries
 
-- Nivo, Visx, Observable Plot, Plotly pages.
+- Nivo, Observable Plot, Plotly pages.
 - Keep modules lazily loaded so the gallery shell does not pay every chart library cost.
 
 ## Validation

--- a/site/charts/PLAN.md
+++ b/site/charts/PLAN.md
@@ -76,7 +76,7 @@ site/charts/
 | Library | Time series | Area | Bar/latest | Donut/pie | Histogram | Live/update | Demo stance |
 |---|---:|---:|---:|---:|---:|---|---|
 | Tremor | yes | yes | yes | yes | recipe | React data updates | first wave |
-| Recharts | yes | yes | yes | pie via recipe | yes | React data updates | first wave |
+| Recharts | yes | yes | yes | donut | yes | React data updates | first wave |
 | Chart.js | yes | yes | yes | doughnut | yes | controller + `update('none')` | second wave |
 | ECharts | yes | yes | yes | pie | yes | `setOption` plan, append spike | second wave |
 | uPlot | yes | no native area focus | latest recipe | no | no | live controller + `setData` | second wave |
@@ -115,7 +115,7 @@ Each library page should include:
 
 - Add React/Vite example pages or iframe from workspace examples.
 - Show line, area, bar, donut/barlist for Tremor.
-- Show line, area, bar, composed chart for Recharts.
+- Show line, area, bar, donut, histogram, and scatter chart for Recharts.
 
 ### Phase 3: Existing Adapter Libraries
 

--- a/site/charts/index.html
+++ b/site/charts/index.html
@@ -54,14 +54,14 @@
           </div>
           <div class="hero-terminal" aria-label="Adapter flow code sample">
             <pre><span class="code-comment">// Query once. Render anywhere.</span>
+const engine = new ScanEngine();
 const result = engine.query(store, query);
-const wide = toEngineWideTableModel(result);
 
-const tremor = toTremorLineChartProps(wide);
+const tremor = toTremorLineChartProps(result);
 const recharts =
-  toRechartsEngineTimeSeriesModel(wide);
-// Planned adapters keep
-// the same engine input.</pre>
+  toRechartsTimeSeriesData(result);
+// Every gallery chart starts from
+// this TSDB engine result.</pre>
           </div>
         </div>
       </section>
@@ -72,7 +72,7 @@ const recharts =
           <span class="stat-label">chart libraries</span>
         </div>
         <div class="stat">
-          <span class="stat-value">9</span>
+          <span class="stat-value">10</span>
           <span class="stat-label">chart shapes</span>
         </div>
         <div class="stat">
@@ -87,12 +87,14 @@ const recharts =
 
       <section id="gallery" class="gallery-shell">
         <div class="gallery-toolbar" aria-label="Gallery controls">
-          <div>
+          <div class="library-picker">
             <p class="t-eyebrow">library</p>
             <div id="libraryButtons" class="segmented-control"></div>
           </div>
-          <div id="librarySummary" class="library-summary"></div>
-          <div class="live-controls" aria-label="Live update controls">
+        </div>
+
+        <div class="gallery-controls-row" aria-label="Live update controls">
+          <div class="live-controls">
             <label class="refresh-rate-label" for="refreshRate">Refresh rate</label>
             <select id="refreshRate" class="refresh-rate-select" aria-label="Refresh rate"></select>
             <button id="liveToggle" class="live-toggle" type="button" aria-pressed="false">
@@ -110,30 +112,30 @@ const recharts =
       <section id="adapter-docs" class="adapter-docs">
         <div class="section-inner">
           <p class="t-eyebrow">user docs</p>
-          <h2 class="t-h2" style="margin:8px 0 8px">Start with the chart shape.</h2>
+          <h2 class="t-h2" style="margin:8px 0 8px">What the adapter gives you.</h2>
           <p class="t-body" style="max-width:72ch;margin:0 0 28px">
-            The engine model is the stable part. Pick the model that matches the chart you are
-            rendering, then use the library adapter to get the object that chart library expects.
-            The most polished adapters today are Tremor and Recharts. Chart.js, ECharts, uPlot,
-            Nivo, Observable Plot, Plotly, ApexCharts, Victory, AG Charts, Highcharts, and Vega-Lite
-            also expose real engine-backed adapter exports. Use the Show code button on any chart
-            card to inspect that adapter output beside the package-rendered chart.
+            Query the TSDB engine once, then pass the result directly to the adapter for the chart
+            library you already use. The adapter returns native package input: Tremor props,
+            Recharts rows and keys, Chart.js configs, ECharts options, Plotly figures, uPlot aligned
+            arrays, Vega-Lite specs, and the equivalent shape for each supported library. Use the
+            Show code button on any card to compare the query, adapter call, returned input, and
+            native render code.
           </p>
           <div class="adapter-doc-grid">
             <article class="adapter-doc">
-              <h3>Time series</h3>
-              <p>Use `toEngineWideTableModel` for line, area, and grouped bar charts.</p>
-              <code>rows: [{ t, values[] }]</code>
+              <h3>Direct result in</h3>
+              <p>Pass the engine query result into the adapter. No wide table or gallery DTO step.</p>
+              <code>result -> published adapter -> native input</code>
             </article>
             <article class="adapter-doc">
-              <h3>Latest values</h3>
-              <p>Use `toEngineLatestValueModel` for donut charts, pie charts, and bar lists.</p>
-              <code>rows: [{ label, value }]</code>
+              <h3>Native input out</h3>
+              <p>Feed the returned object to the chart package exactly where that package expects it.</p>
+              <code>new Chart(canvas, config)</code>
             </article>
             <article class="adapter-doc">
-              <h3>Custom marks</h3>
-              <p>Use `toEngineLineSeriesModel` when the library wants one point array per series.</p>
-              <code>series: [{ id, points[] }]</code>
+              <h3>Live updates stay yours</h3>
+              <p>Reuse the chart instance and call the library's normal update path with new adapter output.</p>
+              <code>chart.update("none")</code>
             </article>
           </div>
         </div>
@@ -142,37 +144,37 @@ const recharts =
       <section id="ergonomics-audit" class="adapter-docs">
         <div class="section-inner">
           <p class="t-eyebrow">ergonomics audit</p>
-          <h2 class="t-h2" style="margin:8px 0 8px">Compared with raw data sources.</h2>
+          <h2 class="t-h2" style="margin:8px 0 8px">What you still control.</h2>
           <p class="t-body" style="max-width:76ch;margin:0 0 28px">
-            Raw APIs make chart users solve transport, time alignment, grouping, sparse values, and
-            chart-library shape differences at the same time. The engine splits that work: queries
-            produce typed series once, engine models normalize dashboard data once, and adapters
-            return the package-native object a chart user already recognizes.
+            The adapters handle the repetitive conversion work: aligned timestamps, latest values,
+            histogram buckets, labels, sparse values, and package-specific field names. You keep
+            control over presentation, colors, tooltips, axes, and the update strategy each chart
+            library recommends.
           </p>
           <div class="ergonomics-grid">
             <article class="ergonomics-card">
-              <h3>Raw source data</h3>
+              <h3>Labels and nulls</h3>
               <p>
-                Users hand-roll timestamp conversion, joins, latest-value extraction, null
-                handling, and label naming before they can even start writing chart code.
+                Supply a `seriesLabel` callback and let the adapter preserve sparse samples as the
+                null or missing-value shape that library expects.
               </p>
-              <code>fetch() -> reshape -> chart config</code>
+              <code>seriesLabel: (series) => ...</code>
             </article>
             <article class="ergonomics-card">
-              <h3>Chart-native data</h3>
+              <h3>Styling remains native</h3>
               <p>
-                The chart package feels good once the data is shaped, but every package wants a
-                different shape: props, rows, traces, specs, options, marks, or aligned arrays.
+                The adapter gives you the data-bearing object. You can still merge in normal chart
+                package options for themes, legends, grids, cursors, and interaction.
               </p>
-              <code>rows | props | traces | spec | marks</code>
+              <code>{ ...option, grid, tooltip }</code>
             </article>
             <article class="ergonomics-card">
-              <h3>Engine adapters</h3>
+              <h3>Updates are package updates</h3>
               <p>
-                Users keep one query and one set of engine transforms, then pick the adapter that
-                speaks their chart library's dialect without learning an o11ykit-only chart DTO.
+                For live data, append into the same store, query the sliding window, convert again,
+                then call the chart library's own update API.
               </p>
-              <code>engine model -> library-native output</code>
+              <code>result -> adapter -> chart.update()</code>
             </article>
           </div>
         </div>
@@ -183,10 +185,9 @@ const recharts =
           <p class="t-eyebrow">why it feels good</p>
           <h2 class="t-h2" style="margin:8px 0 8px">Each adapter speaks the library's dialect.</h2>
           <p class="t-body" style="max-width:72ch;margin:0 0 28px">
-            The shared engine model handles timestamps, sparse rows, nulls, labels, and latest
-            values. Library adapters stay thin and lovable: a Tremor user gets props, a Recharts
-            user gets rows and data keys, uPlot gets aligned arrays, and ECharts gets
-            dataset/encode.
+            The public exports are named for the thing the library wants, not for an o11ykit
+            intermediate model. A Tremor user gets props, a Recharts user gets rows and data keys,
+            uPlot gets aligned arrays, ECharts gets options, and Plotly gets a figure.
           </p>
           <div id="libraryCards" class="library-card-grid"></div>
         </div>
@@ -197,8 +198,9 @@ const recharts =
           <p class="t-eyebrow">coverage</p>
           <h2 class="t-h2" style="margin:8px 0 8px">Chart shape by chart shape.</h2>
           <p class="t-body" style="max-width:72ch;margin:0 0 28px">
-            First-class does not mean every adapter exposes the same API. It means every chart type
-            has the smallest useful bridge from engine output to that library's natural runtime.
+            A checked cell means this gallery has a published adapter call and a native package
+            render path for that chart shape. Recipe cells are intentional examples that can be built
+            from the exported primitives without adding gallery-only drawing.
           </p>
           <div class="coverage-table-wrap">
             <table id="coverageTable" class="coverage-table"></table>

--- a/site/charts/index.html
+++ b/site/charts/index.html
@@ -68,11 +68,11 @@ const recharts =
 
       <section class="gallery-stats" aria-label="Gallery scope">
         <div class="stat">
-          <span class="stat-value">13</span>
+          <span id="libraryCount" class="stat-value">0</span>
           <span class="stat-label">chart libraries</span>
         </div>
         <div class="stat">
-          <span class="stat-value">10</span>
+          <span id="chartShapeCount" class="stat-value">0</span>
           <span class="stat-label">chart shapes</span>
         </div>
         <div class="stat">

--- a/site/charts/index.html
+++ b/site/charts/index.html
@@ -43,8 +43,8 @@
             <p class="hero-sub">
               The engine returns typed time-series results. The adapters turn that into the thing
               each chart library actually wants: props, rows, configs, datasets, aligned arrays, or
-              traces. Switch libraries below; exported adapters render with the actual chart
-              package, and adapter-shape-only entries are labeled clearly.
+              traces. Switch libraries below; every gallery entry renders through the actual chart
+              package it represents.
             </p>
             <div class="hero-actions charts-actions">
               <a class="stamp-fill" href="#gallery">Open Gallery</a>
@@ -68,7 +68,7 @@ const recharts =
 
       <section class="gallery-stats" aria-label="Gallery scope">
         <div class="stat">
-          <span class="stat-value">14</span>
+          <span class="stat-value">13</span>
           <span class="stat-label">chart libraries</span>
         </div>
         <div class="stat">

--- a/site/charts/js/gallery-app.js
+++ b/site/charts/js/gallery-app.js
@@ -10,11 +10,7 @@ import {
   getLiveRefreshRate,
   LIVE_REFRESH_RATES,
 } from "./gallery-live.js";
-import {
-  destroyNativeCharts,
-  hasPackageRenderer,
-  renderNativeCharts,
-} from "./gallery-renderers.js";
+import { destroyNativeCharts, renderNativeCharts } from "./gallery-renderers.js";
 
 const COLOR_SCALE = ["#2563eb", "#059669", "#dc2626", "#7c3aed", "#d97706", "#0891b2"];
 const state = {
@@ -97,7 +93,7 @@ function renderLibrarySummary(gallery) {
       <strong>${gallery.library.name}</strong>
       <span>${gallery.charts.length} charts</span>
       <span>${gallery.library.primaryApi}</span>
-      <span>${hasPackageRenderer(gallery.library.id) ? "package renderer" : "adapter shape"}</span>
+      <span>native package renderer</span>
     </div>
   `;
 }

--- a/site/charts/js/gallery-app.js
+++ b/site/charts/js/gallery-app.js
@@ -3,7 +3,7 @@ import {
   createLibraryGalleryState,
   getSupportedChart,
   LIBRARIES,
-  serializableAdapterModel,
+  serializableAdapterOutput,
 } from "./gallery-data.js";
 import {
   DEFAULT_LIVE_REFRESH_RATE_ID,
@@ -12,7 +12,6 @@ import {
 } from "./gallery-live.js";
 import { destroyNativeCharts, renderNativeCharts } from "./gallery-renderers.js";
 
-const COLOR_SCALE = ["#2563eb", "#059669", "#dc2626", "#7c3aed", "#d97706", "#0891b2"];
 const state = {
   library: "tremor",
   expandedChart: null,
@@ -24,12 +23,12 @@ const state = {
   raf: null,
   renderBusy: false,
   renderQueued: false,
+  lastLayoutWidth: "",
   lastLayoutKey: "",
 };
 
 const elements = {
   libraryButtons: document.querySelector("#libraryButtons"),
-  librarySummary: document.querySelector("#librarySummary"),
   liveToggle: document.querySelector("#liveToggle"),
   liveToggleLabel: document.querySelector("#liveToggleLabel"),
   refreshRate: document.querySelector("#refreshRate"),
@@ -45,6 +44,7 @@ function init() {
   renderLibraryButtons();
   renderLibraryCards();
   renderCoverageTable();
+  observeGallerySize();
   elements.liveToggle.addEventListener("click", toggleLive);
   elements.refreshRate.addEventListener("change", () => {
     state.liveRateId = elements.refreshRate.value;
@@ -54,13 +54,26 @@ function init() {
   void render();
 }
 
+function observeGallerySize() {
+  if (!("ResizeObserver" in window)) return;
+  const observer = new ResizeObserver((entries) => {
+    const entry = entries[0];
+    if (!entry) return;
+    const { width } = entry.contentRect;
+    const nextKey = `${Math.round(width)}`;
+    if (nextKey === state.lastLayoutWidth) return;
+    state.lastLayoutWidth = nextKey;
+    scheduleRender();
+  });
+  observer.observe(elements.chartGallery);
+}
+
 async function render() {
   const gallery = createLibraryGalleryState(state.library, state.liveStep);
   if (state.expandedChart && !gallery.library.charts.includes(state.expandedChart)) {
     state.expandedChart = null;
   }
   const layoutKey = `${gallery.library.id}:${gallery.charts.join(",")}:${state.expandedChart ?? ""}:${state.tab}`;
-  renderLibrarySummary(gallery);
   if (layoutKey !== state.lastLayoutKey) {
     state.lastLayoutKey = layoutKey;
     renderLibraryButtons();
@@ -73,7 +86,10 @@ async function render() {
 function renderLibraryButtons() {
   elements.libraryButtons.innerHTML = LIBRARIES.map(
     (library) =>
-      `<button type="button" class="${library.id === state.library ? "is-active" : ""}" data-library="${library.id}">${library.name}</button>`
+      `<button type="button" class="${library.id === state.library ? "is-active" : ""}" data-library="${library.id}">
+        ${renderLibraryLogo(library)}
+        <span>${library.name}</span>
+      </button>`
   ).join("");
   elements.libraryButtons.querySelectorAll("button").forEach((button) => {
     button.addEventListener("click", () => {
@@ -84,18 +100,6 @@ function renderLibraryButtons() {
       void render();
     });
   });
-}
-
-function renderLibrarySummary(gallery) {
-  elements.librarySummary.innerHTML = `
-    <p class="t-eyebrow">rendering</p>
-    <div class="library-summary-line" aria-label="${gallery.library.name} rendering details">
-      <strong>${gallery.library.name}</strong>
-      <span>${gallery.charts.length} charts</span>
-      <span>${gallery.library.primaryApi}</span>
-      <span>native package renderer</span>
-    </div>
-  `;
 }
 
 async function renderChartGallery(gallery) {
@@ -112,7 +116,12 @@ async function renderChartGallery(gallery) {
               <span class="chart-card-kicker">${chart.library.primaryApi}</span>
               <strong>${chartLabel(chart.chartType)}</strong>
             </span>
-            <span class="chart-card-meta">${adapterSummary(chart.adapterModel)}</span>
+            <span class="chart-card-tools">
+              <span class="chart-card-meta">${adapterOutputSummary(chart.adapterOutput)}</span>
+              <button type="button" class="chart-code-button" data-chart="${chart.chartType}" aria-expanded="${selected}">
+                ${selected ? "Hide code" : "Show code"}
+              </button>
+            </span>
           </span>
           <span class="chart-card-frame">
             <span
@@ -123,12 +132,6 @@ async function renderChartGallery(gallery) {
               role="img"
               aria-label="${chart.library.name} ${chartLabel(chart.chartType)} chart"
             ></span>
-          </span>
-          <span class="mini-legend">${renderLegend(chart)}</span>
-          <span class="chart-card-actions">
-            <button type="button" class="chart-code-button" data-chart="${chart.chartType}" aria-expanded="${selected}">
-              ${selected ? "Hide code" : "Show code"}
-            </button>
           </span>
           ${selected ? renderInlineCode(chart) : ""}
         </article>
@@ -160,9 +163,7 @@ async function updateChartGallery(gallery) {
       ?.closest(".chart-card");
     if (!card) continue;
     const meta = card.querySelector(".chart-card-meta");
-    if (meta) setTextIfChanged(meta, adapterSummary(chart.adapterModel));
-    const legend = card.querySelector(".mini-legend");
-    if (legend) setHtmlIfChanged(legend, renderLegend(chart));
+    if (meta) setTextIfChanged(meta, adapterOutputSummary(chart.adapterOutput));
     if (chart.chartType === state.expandedChart) {
       const code = card.querySelector(".card-code-block");
       if (code) setTextIfChanged(code, codeFor(chart));
@@ -171,19 +172,8 @@ async function updateChartGallery(gallery) {
   await renderNativeCharts(gallery.charts, elements.chartGallery);
 }
 
-function renderLegend(gallery) {
-  const rows =
-    gallery.chartType === "histogram" ? gallery.histogram.buckets.slice(0, 4) : gallery.wide.series;
-  return rows
-    .map((row, index) => {
-      const label = row.label ?? row.id;
-      return `<span class="legend-item"><span class="legend-swatch" style="background:${COLOR_SCALE[index % COLOR_SCALE.length]}"></span>${escapeHtml(label)}</span>`;
-    })
-    .join("");
-}
-
 function renderInlineCode(gallery) {
-  const tabs = ["query", "adapter", "library", "output"]
+  const tabs = ["query", "adapter", "input", "render"]
     .map(
       (tab) => `
         <button
@@ -191,7 +181,7 @@ function renderInlineCode(gallery) {
           class="card-code-tab ${state.tab === tab ? "is-active" : ""}"
           data-chart="${gallery.chartType}"
           data-tab="${tab}"
-        >${tab}</button>
+        >${codeTabLabel(tab)}</button>
       `
     )
     .join("");
@@ -199,7 +189,7 @@ function renderInlineCode(gallery) {
     <div class="chart-card-code">
       <div class="chart-card-code-heading">
         <span>
-          <span class="chart-card-kicker">${gallery.library.primaryApi} adapter</span>
+          <span class="chart-card-kicker">published adapter -> native input</span>
           <strong>${gallery.library.name} ${chartLabel(gallery.chartType)}</strong>
         </span>
       </div>
@@ -213,10 +203,16 @@ function renderInlineCode(gallery) {
 
 function codeFor(gallery) {
   const code =
-    state.tab === "output"
-      ? JSON.stringify(serializableAdapterModel(gallery.adapterModel), null, 2)
-      : gallery.snippets[state.tab];
+    state.tab === "input"
+      ? JSON.stringify(serializableAdapterOutput(gallery.adapterOutput), null, 2)
+      : gallery.snippets[state.tab === "render" ? "library" : state.tab];
   return code;
+}
+
+function codeTabLabel(tab) {
+  if (tab === "adapter") return "adapter call";
+  if (tab === "input") return "native input";
+  return tab;
 }
 
 function renderLibraryCards() {
@@ -237,6 +233,12 @@ function renderLibraryCards() {
       </article>
     `
   ).join("");
+}
+
+function renderLibraryLogo(library) {
+  const fallback = `<span class="library-mark" aria-hidden="true">${escapeHtml(library.mark)}</span>`;
+  if (!library.logoUrl) return fallback;
+  return `<img class="library-logo" src="${escapeHtml(library.logoUrl)}" alt="" aria-hidden="true" loading="lazy" referrerpolicy="no-referrer" onerror="this.hidden=true;this.nextElementSibling.hidden=false" />${fallback}`;
 }
 
 function renderCoverageTable() {
@@ -325,8 +327,8 @@ function chartLabel(chartType) {
   return CHART_TYPES.find((chart) => chart.id === chartType)?.label ?? chartType;
 }
 
-function adapterSummary(model) {
-  const output = serializableAdapterModel(model);
+function adapterOutputSummary(input) {
+  const output = serializableAdapterOutput(input);
   if (output.chart?.type) return `chart.type=${output.chart.type}`;
   if (output.type) return `type=${output.type}`;
   if (output.mark) return `mark=${output.mark}`;
@@ -339,12 +341,6 @@ function adapterSummary(model) {
 function setTextIfChanged(element, next) {
   if (element.textContent !== next) {
     element.textContent = next;
-  }
-}
-
-function setHtmlIfChanged(element, next) {
-  if (element.innerHTML !== next) {
-    element.innerHTML = next;
   }
 }
 

--- a/site/charts/js/gallery-app.js
+++ b/site/charts/js/gallery-app.js
@@ -35,11 +35,14 @@ const elements = {
   chartGallery: document.querySelector("#chartGallery"),
   libraryCards: document.querySelector("#libraryCards"),
   coverageTable: document.querySelector("#coverageTable"),
+  libraryCount: document.querySelector("#libraryCount"),
+  chartShapeCount: document.querySelector("#chartShapeCount"),
 };
 
 init();
 
 function init() {
+  renderGalleryStats();
   renderRefreshRates();
   renderLibraryButtons();
   renderLibraryCards();
@@ -52,6 +55,11 @@ function init() {
     if (state.live) restartLiveTimer();
   });
   void render();
+}
+
+function renderGalleryStats() {
+  elements.libraryCount.textContent = String(LIBRARIES.length);
+  elements.chartShapeCount.textContent = String(CHART_TYPES.length);
 }
 
 function observeGallerySize() {

--- a/site/charts/js/gallery-data.js
+++ b/site/charts/js/gallery-data.js
@@ -1,46 +1,47 @@
 import {
-  toAgChartsEngineLatestValuesOptions,
-  toAgChartsEngineTimeSeriesOptions,
+  toAgChartsLatestValuesOptions,
+  toAgChartsTimeSeriesOptions,
 } from "../../../packages/adapters/src/agcharts.ts";
 import {
-  toApexChartsEngineLatestValuesOptions,
-  toApexChartsEngineTimeSeriesOptions,
+  toApexChartsLatestValuesOptions,
+  toApexChartsTimeSeriesOptions,
 } from "../../../packages/adapters/src/apexcharts.ts";
 import {
-  toChartJsEngineHistogramConfig,
-  toChartJsEngineLatestValuesConfig,
-  toChartJsEngineTimeSeriesConfig,
+  toChartJsHistogramConfig,
+  toChartJsLatestValuesConfig,
+  toChartJsTimeSeriesConfig,
 } from "../../../packages/adapters/src/chartjs.ts";
 import {
-  toEChartsEngineHistogramOption,
-  toEChartsEngineLatestValuesOption,
-  toEChartsEngineTimeSeriesOption,
+  toEChartsHistogramOption,
+  toEChartsLatestValuesOption,
+  toEChartsTimeSeriesOption,
 } from "../../../packages/adapters/src/echarts.ts";
 import { toEngineHistogramModel as toAdapterEngineHistogramModel } from "../../../packages/adapters/src/engine.ts";
 import {
-  toHighchartsEngineHistogramOptions,
-  toHighchartsEngineLatestValuesOptions,
-  toHighchartsEngineTimeSeriesOptions,
+  toHighchartsHistogramOptions,
+  toHighchartsLatestValuesOptions,
+  toHighchartsTimeSeriesOptions,
 } from "../../../packages/adapters/src/highcharts.ts";
 import {
-  toNivoEngineBarModel,
-  toNivoEngineLineSeries,
-  toNivoEnginePieData,
-  toNivoEngineScatterSeries,
+  toNivoBarData,
+  toNivoLineSeries,
+  toNivoPieData,
+  toNivoScatterSeries,
 } from "../../../packages/adapters/src/nivo.ts";
 import {
-  toObservablePlotEngineHistogramModel,
-  toObservablePlotEngineModel,
+  toObservablePlotHistogramOptions,
+  toObservablePlotOptions,
 } from "../../../packages/adapters/src/observable.ts";
 import {
-  toPlotlyEngineHistogramModel,
-  toPlotlyEngineLatestValuesModel,
-  toPlotlyEngineTimeSeriesModel,
+  toPlotlyHistogramFigure,
+  toPlotlyLatestValuesFigure,
+  toPlotlyTimeSeriesFigure,
 } from "../../../packages/adapters/src/plotly.ts";
 import {
-  toRechartsEngineHistogramModel,
-  toRechartsEngineLatestValuesModel,
-  toRechartsEngineScatterModel,
+  toRechartsHistogramData,
+  toRechartsLatestValuesData,
+  toRechartsScatterData,
+  toRechartsTimeSeriesData,
 } from "../../../packages/adapters/src/recharts.ts";
 import {
   toTremorAreaChartProps,
@@ -49,21 +50,21 @@ import {
   toTremorDonutChartProps,
   toTremorLineChartProps,
 } from "../../../packages/adapters/src/tremor.ts";
-import { toUPlotEngineTimeSeriesModel } from "../../../packages/adapters/src/uplot.ts";
+import { toUPlotTimeSeriesArgs } from "../../../packages/adapters/src/uplot.ts";
 import {
-  toVegaLiteEngineHistogramSpec,
-  toVegaLiteEngineSpec,
+  toVegaLiteHistogramSpec,
+  toVegaLiteSpec,
 } from "../../../packages/adapters/src/vegalite.ts";
-import {
-  toVictoryEngineLatestData,
-  toVictoryEngineSeries,
-} from "../../../packages/adapters/src/victory.ts";
+import { toVictoryLatestData, toVictorySeries } from "../../../packages/adapters/src/victory.ts";
+import { ScanEngine } from "../../../packages/o11ytsdb/src/query.ts";
+import { RowGroupStore } from "../../../packages/o11ytsdb/src/row-group-store.ts";
 
 export const CHART_TYPES = [
   { id: "line", label: "Line" },
   { id: "area", label: "Area" },
   { id: "bar", label: "Bar" },
   { id: "donut", label: "Donut" },
+  { id: "latestBar", label: "Latest bars" },
   { id: "histogram", label: "Histogram" },
   { id: "barList", label: "Bar list" },
   { id: "scatter", label: "Scatter" },
@@ -75,6 +76,8 @@ export const LIBRARIES = [
   {
     id: "tremor",
     name: "Tremor",
+    mark: "T",
+    logoUrl: "https://www.tremor.so/favicon.ico",
     primaryApi: "props",
     updateModel: "React data updates",
     status: "implemented",
@@ -85,36 +88,63 @@ export const LIBRARIES = [
   {
     id: "recharts",
     name: "Recharts",
+    mark: "R",
+    logoUrl: "https://github.com/recharts.png?size=64",
     primaryApi: "rows + dataKey",
     updateModel: "React data updates",
     status: "implemented",
     package: "@otlpkit/adapters/recharts",
-    charts: ["line", "area", "bar", "donut", "histogram", "scatter"],
+    charts: ["line", "area", "bar", "donut", "latestBar", "histogram", "scatter"],
     note: "Keep Recharts ergonomic: rows for data, descriptors for Line/Area/Bar dataKey wiring.",
   },
   {
     id: "chartjs",
     name: "Chart.js",
+    mark: "C",
+    logoUrl: "https://cdn.simpleicons.org/chartdotjs/11110F",
     primaryApi: "configuration",
     updateModel: "controller.update('none')",
     status: "exported",
     package: "@otlpkit/adapters/chartjs",
-    charts: ["line", "area", "bar", "donut", "histogram", "scatter", "sparkline", "gauge"],
+    charts: [
+      "line",
+      "area",
+      "bar",
+      "donut",
+      "latestBar",
+      "histogram",
+      "scatter",
+      "sparkline",
+      "gauge",
+    ],
     note: "Produce chart configs with parsing disabled so large time-series stay cheap to update.",
   },
   {
     id: "echarts",
     name: "ECharts",
+    mark: "E",
+    logoUrl: "https://cdn.simpleicons.org/apacheecharts/11110F",
     primaryApi: "dataset + encode",
     updateModel: "setOption",
     status: "exported",
     package: "@otlpkit/adapters/echarts",
-    charts: ["line", "area", "bar", "donut", "histogram", "scatter", "sparkline", "gauge"],
+    charts: [
+      "line",
+      "area",
+      "bar",
+      "donut",
+      "latestBar",
+      "histogram",
+      "scatter",
+      "sparkline",
+      "gauge",
+    ],
     note: "Use dataset source and encode fields so ECharts keeps transforms and tooltips native.",
   },
   {
     id: "uplot",
     name: "uPlot",
+    mark: "u",
     primaryApi: "aligned arrays",
     updateModel: "setData",
     status: "exported",
@@ -125,6 +155,7 @@ export const LIBRARIES = [
   {
     id: "nivo",
     name: "Nivo",
+    mark: "N",
     primaryApi: "series objects",
     updateModel: "React data updates",
     status: "exported",
@@ -135,16 +166,20 @@ export const LIBRARIES = [
   {
     id: "observable",
     name: "Observable Plot",
+    mark: "OP",
+    logoUrl: "https://cdn.simpleicons.org/observable/11110F",
     primaryApi: "marks",
     updateModel: "plot rebuild",
     status: "exported",
     package: "@otlpkit/adapters/observable",
     charts: ["line", "area", "bar", "histogram", "scatter", "sparkline"],
-    note: "Flatten wide rows into tidy records and return Plot marks users can drop into Plot.plot.",
+    note: "Turn engine results into tidy records and return Plot marks users can drop into Plot.plot.",
   },
   {
     id: "plotly",
     name: "Plotly",
+    mark: "P",
+    logoUrl: "https://cdn.simpleicons.org/plotly/11110F",
     primaryApi: "traces",
     updateModel: "extendTraces",
     status: "exported",
@@ -155,6 +190,8 @@ export const LIBRARIES = [
   {
     id: "apexcharts",
     name: "ApexCharts",
+    mark: "A",
+    logoUrl: "https://apexcharts.com/favicon.ico",
     primaryApi: "options + series",
     updateModel: "updateSeries",
     status: "exported",
@@ -165,6 +202,8 @@ export const LIBRARIES = [
   {
     id: "victory",
     name: "Victory",
+    mark: "V",
+    logoUrl: "https://formidable.com/open-source/victory/favicon.ico",
     primaryApi: "components + data",
     updateModel: "React data updates",
     status: "exported",
@@ -175,16 +214,20 @@ export const LIBRARIES = [
   {
     id: "agcharts",
     name: "AG Charts",
+    mark: "AG",
+    logoUrl: "https://github.com/ag-grid.png?size=64",
     primaryApi: "options",
     updateModel: "update options",
     status: "exported",
     package: "@otlpkit/adapters/agcharts",
-    charts: ["line", "area", "bar", "donut", "scatter", "gauge"],
+    charts: ["line", "area", "bar", "donut", "scatter"],
     note: "Project engine rows into AG Charts options with explicit keys and series definitions.",
   },
   {
     id: "highcharts",
     name: "Highcharts",
+    mark: "H",
+    logoUrl: "https://github.com/highcharts.png?size=64",
     primaryApi: "options + series",
     updateModel: "setData",
     status: "exported",
@@ -195,6 +238,8 @@ export const LIBRARIES = [
   {
     id: "vegalite",
     name: "Vega-Lite",
+    mark: "VL",
+    logoUrl: "https://cdn.simpleicons.org/vega/11110F",
     primaryApi: "spec",
     updateModel: "view changeset",
     status: "exported",
@@ -206,6 +251,56 @@ export const LIBRARIES = [
 
 const NS_PER_MS = 1_000_000n;
 const COLORS = ["#2563eb", "#059669", "#dc2626", "#7c3aed", "#d97706", "#0891b2"];
+const GALLERY_METRIC = "http.server.duration";
+const GALLERY_STEP_MS = 30_000;
+const GALLERY_POINTS = 18;
+const GALLERY_START_MS = 1_714_200_000_000;
+const GALLERY_SERIES = [
+  { service: "checkout", route: "/cart", status: "2xx", base: 74, phase: 0.2 },
+  { service: "checkout", route: "/pay", status: "5xx", base: 108, phase: 1.8 },
+  { service: "api", route: "/search", status: "2xx", base: 62, phase: 2.4 },
+  { service: "worker", route: "/jobs", status: "2xx", base: 88, phase: 3.1 },
+];
+const galleryEngine = new ScanEngine();
+let galleryMetricState;
+
+const galleryValuesCodec = {
+  name: "f64-plain",
+  encodeValues(values) {
+    const out = new Uint8Array(4 + values.byteLength);
+    new DataView(out.buffer).setUint32(0, values.length, true);
+    out.set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), 4);
+    return out;
+  },
+  decodeValues(buf) {
+    if (buf.byteLength < 4) return new Float64Array(0);
+    const n = new DataView(buf.buffer, buf.byteOffset, buf.byteLength).getUint32(0, true);
+    const raw = buf.subarray(4);
+    const bytes = raw.byteLength - (raw.byteLength % 8);
+    const copy = raw.slice(0, bytes);
+    return new Float64Array(
+      copy.buffer,
+      copy.byteOffset,
+      Math.min(n, Math.floor(bytes / 8))
+    ).slice();
+  },
+  decodeValuesRange(buf, startIndex, endIndex) {
+    if (buf.byteLength < 4 || endIndex <= startIndex) return new Float64Array(0);
+    const n = new DataView(buf.buffer, buf.byteOffset, buf.byteLength).getUint32(0, true);
+    const raw = buf.subarray(4);
+    const clampedStart = Math.max(0, Math.min(startIndex, n));
+    const clampedEnd = Math.max(clampedStart, Math.min(endIndex, n));
+    const byteStart = clampedStart * 8;
+    const byteEnd = clampedEnd * 8;
+    const bytes = Math.max(
+      0,
+      Math.min(raw.byteLength, byteEnd) - Math.min(raw.byteLength, byteStart)
+    );
+    if (bytes === 0) return new Float64Array(0);
+    const copy = raw.slice(byteStart, byteStart + bytes);
+    return new Float64Array(copy.buffer, copy.byteOffset, Math.floor(bytes / 8)).slice();
+  },
+};
 
 export function getLibrary(id) {
   return LIBRARIES.find((library) => library.id === id) ?? LIBRARIES[0];
@@ -217,89 +312,74 @@ export function getSupportedChart(libraryId, chartType) {
 }
 
 export function createEngineResult(liveStep = 0) {
-  const services = [
-    { service: "checkout", route: "/cart", status: "2xx", base: 74, phase: 0.2 },
-    { service: "checkout", route: "/pay", status: "5xx", base: 108, phase: 1.8 },
-    { service: "api", route: "/search", status: "2xx", base: 62, phase: 2.4 },
-    { service: "worker", route: "/jobs", status: "2xx", base: 88, phase: 3.1 },
-  ];
-  const startMs = 1_714_200_000_000 + liveStep * 30_000;
-  const points = 18;
+  const { store, query } = createGalleryMetricStore(liveStep);
+  return galleryEngine.query(store, query);
+}
 
+export function createGalleryMetricStore(liveStep = 0) {
+  const state = getGalleryMetricState();
+  const startSample = Math.max(0, Math.floor(liveStep));
+  const endSample = startSample + GALLERY_POINTS - 1;
+  appendGallerySamplesThrough(state, endSample);
+
+  const startNs = BigInt(GALLERY_START_MS + startSample * GALLERY_STEP_MS) * NS_PER_MS;
+  const endNs = BigInt(GALLERY_START_MS + endSample * GALLERY_STEP_MS) * NS_PER_MS;
   return {
-    series: services.map((series, seriesIndex) => {
-      const timestamps = new BigInt64Array(points);
-      const values = new Float64Array(points);
-      for (let i = 0; i < points; i++) {
-        const sampleIndex = liveStep + i;
-        timestamps[i] = BigInt(startMs + i * 30_000) * NS_PER_MS;
-        const wave = Math.sin(sampleIndex * 0.68 + series.phase) * 13;
-        const secondary = Math.cos((sampleIndex + seriesIndex) * 0.37) * 6;
-        const incidentWave = Math.max(0, 44 - Math.abs((sampleIndex % 44) - 24) * 6);
-        const incident = series.status === "5xx" ? incidentWave : 0;
-        values[i] = Math.max(4, Math.round((series.base + wave + secondary + incident) * 10) / 10);
-      }
-      return {
-        labels: new Map([
-          ["__name__", "http.server.duration"],
+    store: state.store,
+    startNs,
+    endNs,
+    query: {
+      metric: GALLERY_METRIC,
+      start: startNs,
+      end: endNs,
+      maxPoints: GALLERY_POINTS,
+    },
+  };
+}
+
+function getGalleryMetricState() {
+  if (galleryMetricState) return galleryMetricState;
+
+  const store = new RowGroupStore(galleryValuesCodec, 64, () => 0, 32, "chart-gallery-rowgroup");
+  galleryMetricState = {
+    store,
+    appendedThroughSample: -1,
+    seriesIds: GALLERY_SERIES.map((series) =>
+      store.getOrCreateSeries(
+        new Map([
+          ["__name__", GALLERY_METRIC],
           ["service", series.service],
           ["route", series.route],
           ["status_class", series.status],
+        ])
+      )
+    ),
+  };
+  return galleryMetricState;
+}
+
+function appendGallerySamplesThrough(state, endSample) {
+  for (let sampleIndex = state.appendedThroughSample + 1; sampleIndex <= endSample; sampleIndex++) {
+    const timestamp = BigInt(GALLERY_START_MS + sampleIndex * GALLERY_STEP_MS) * NS_PER_MS;
+    state.store.append(
+      new BigInt64Array([timestamp]),
+      state.seriesIds.map((id, seriesIndex) => ({
+        id,
+        values: new Float64Array([
+          sampleValue(GALLERY_SERIES[seriesIndex], seriesIndex, sampleIndex),
         ]),
-        timestamps,
-        values,
-      };
-    }),
-  };
+      }))
+    );
+    state.appendedThroughSample = sampleIndex;
+  }
 }
 
-export function toEngineWideTableModel(result) {
-  const rowsByTime = new Map();
-  const series = result.series.map((seriesResult, index) => ({
-    id: seriesId(seriesResult, index),
-    label: seriesLabel(seriesResult, index),
-    labels: seriesResult.labels,
-  }));
-
-  result.series.forEach((seriesResult, seriesIndex) => {
-    for (let i = 0; i < seriesResult.timestamps.length; i++) {
-      const t = Number(seriesResult.timestamps[i] / NS_PER_MS);
-      const row = rowsByTime.get(t) ?? new Array(result.series.length).fill(null);
-      row[seriesIndex] = Number.isFinite(seriesResult.values[i]) ? seriesResult.values[i] : null;
-      rowsByTime.set(t, row);
-    }
-  });
-
-  return {
-    kind: "engine-wide-table",
-    columns: ["t", ...series.map((entry) => entry.label)],
-    series,
-    rows: [...rowsByTime.entries()]
-      .sort(([left], [right]) => left - right)
-      .map(([t, values]) => ({
-        t,
-        values,
-      })),
-  };
-}
-
-export function toEngineLatestValueModel(result) {
-  return {
-    kind: "engine-latest-values",
-    rows: result.series.map((seriesResult, index) => {
-      const last = seriesResult.values.length - 1;
-      return {
-        id: seriesId(seriesResult, index),
-        label: seriesLabel(seriesResult, index),
-        labels: seriesResult.labels,
-        t: last >= 0 ? Number(seriesResult.timestamps[last] / NS_PER_MS) : null,
-        value:
-          last >= 0 && Number.isFinite(seriesResult.values[last])
-            ? seriesResult.values[last]
-            : null,
-      };
-    }),
-  };
+function sampleValue(series, seriesIndex, sampleIndex) {
+  const wave = Math.sin(sampleIndex * 0.68 + series.phase) * 13;
+  const secondary = Math.cos((sampleIndex + seriesIndex) * 0.37) * 6;
+  const incidentWave = Math.max(0, 44 - Math.abs((sampleIndex % 44) - 24) * 6);
+  const incident = series.status === "5xx" ? incidentWave : 0;
+  return Math.max(4, Math.round((series.base + wave + secondary + incident) * 10) / 10);
 }
 
 export function createGalleryState(libraryId = "tremor", chartType = "line", liveStep = 0) {
@@ -311,91 +391,93 @@ export function createGalleryState(libraryId = "tremor", chartType = "line", liv
 export function createLibraryGalleryState(libraryId = "tremor", liveStep = 0) {
   const library = getLibrary(libraryId);
   const result = createEngineResult(liveStep);
-  const wide = toEngineWideTableModel(result);
-  const latest = toEngineLatestValueModel(result);
-  const histogram = toAdapterEngineHistogramModel(wide);
+  const seriesLegend = result.series.map((series, index) => ({
+    id: seriesLabel(series, index),
+    label: seriesLabel(series, index),
+  }));
+  const histogram = toAdapterEngineHistogramModel(result, { seriesLabel });
 
   return {
     library,
     result,
-    wide,
-    latest,
+    seriesLegend,
     histogram,
     charts: library.charts.map((chartType) => ({
       library,
       chartType,
       result,
-      wide,
-      latest,
+      seriesLegend,
       histogram,
-      adapterModel: toAdapterModel(library, chartType, wide, latest, histogram),
+      adapterOutput: createAdapterOutput(library, chartType, result),
       snippets: snippetsFor(library, chartType),
     })),
   };
 }
 
-export function toAdapterModel(library, chartType, wide, latest, histogram) {
+export function createAdapterOutput(library, chartType, result) {
   switch (library.id) {
     case "tremor":
-      return tremorModel(chartType, wide, latest);
+      return tremorModel(chartType, result);
     case "recharts":
-      return rechartsModel(chartType, wide, latest, histogram);
+      return rechartsModel(chartType, result);
     case "chartjs":
       return chartType === "histogram"
-        ? toChartJsEngineHistogramConfig(histogram)
-        : chartType === "donut" || chartType === "gauge"
-          ? toChartJsEngineLatestValuesConfig(latest, { chartType })
-          : toChartJsEngineTimeSeriesConfig(wide, { chartType });
+        ? toChartJsHistogramConfig(result)
+        : chartType === "donut" || chartType === "gauge" || chartType === "latestBar"
+          ? toChartJsLatestValuesConfig(result, {
+              chartType: chartType === "latestBar" ? "bar" : chartType,
+              seriesLabel,
+            })
+          : toChartJsTimeSeriesConfig(result, { chartType, seriesLabel });
     case "echarts":
       return chartType === "histogram"
-        ? toEChartsEngineHistogramOption(histogram)
-        : chartType === "donut" || chartType === "gauge"
-          ? toEChartsEngineLatestValuesOption(latest, { chartType })
-          : toEChartsEngineTimeSeriesOption(wide, { chartType });
+        ? toEChartsHistogramOption(result)
+        : chartType === "donut" || chartType === "gauge" || chartType === "latestBar"
+          ? toEChartsLatestValuesOption(result, {
+              chartType: chartType === "latestBar" ? "bar" : chartType,
+              seriesLabel,
+            })
+          : toEChartsTimeSeriesOption(result, { chartType, seriesLabel });
     case "uplot":
-      return toUPlotEngineTimeSeriesModel(wide, { chartType });
+      return toUPlotTimeSeriesArgs(result, { chartType, seriesLabel });
     case "nivo":
-      return nivoModel(chartType, wide, latest);
+      return nivoModel(chartType, result);
     case "observable":
       return chartType === "histogram"
-        ? toObservablePlotEngineHistogramModel(histogram)
-        : toObservablePlotEngineModel(wide, { chartType });
+        ? toObservablePlotHistogramOptions(result)
+        : toObservablePlotOptions(result, { chartType, seriesLabel });
     case "plotly":
       return chartType === "histogram"
-        ? toPlotlyEngineHistogramModel(histogram)
+        ? toPlotlyHistogramFigure(result)
         : chartType === "donut" || chartType === "gauge"
-          ? toPlotlyEngineLatestValuesModel(latest, { chartType })
-          : toPlotlyEngineTimeSeriesModel(wide, { chartType });
+          ? toPlotlyLatestValuesFigure(result, { chartType, seriesLabel })
+          : toPlotlyTimeSeriesFigure(result, { chartType, seriesLabel });
     case "apexcharts":
       return chartType === "donut" || chartType === "gauge"
-        ? toApexChartsEngineLatestValuesOptions(latest, { chartType })
-        : toApexChartsEngineTimeSeriesOptions(wide, { chartType });
+        ? toApexChartsLatestValuesOptions(result, { chartType, seriesLabel })
+        : toApexChartsTimeSeriesOptions(result, { chartType, seriesLabel });
     case "victory":
-      return victoryModel(chartType, wide, latest);
+      return victoryModel(chartType, result);
     case "agcharts":
       return chartType === "donut" || chartType === "gauge"
-        ? toAgChartsEngineLatestValuesOptions(latest, { chartType })
-        : toAgChartsEngineTimeSeriesOptions(wide, { chartType });
+        ? toAgChartsLatestValuesOptions(result, { chartType, seriesLabel })
+        : toAgChartsTimeSeriesOptions(result, { chartType, seriesLabel });
     case "highcharts":
       return chartType === "histogram"
-        ? toHighchartsEngineHistogramOptions(histogram)
+        ? toHighchartsHistogramOptions(result)
         : chartType === "donut" || chartType === "gauge"
-          ? toHighchartsEngineLatestValuesOptions(latest, { chartType })
-          : toHighchartsEngineTimeSeriesOptions(wide, { chartType });
+          ? toHighchartsLatestValuesOptions(result, { chartType, seriesLabel })
+          : toHighchartsTimeSeriesOptions(result, { chartType, seriesLabel });
     case "vegalite":
       return chartType === "histogram"
-        ? toVegaLiteEngineHistogramSpec(histogram)
-        : toVegaLiteEngineSpec(wide, { mark: chartType });
+        ? toVegaLiteHistogramSpec(result)
+        : toVegaLiteSpec(result, { mark: chartType, seriesLabel });
     default:
-      return { data: wide.rows };
+      return { data: result.series };
   }
 }
 
-export function toHistogramModel(wide) {
-  return toAdapterEngineHistogramModel(wide);
-}
-
-export function serializableAdapterModel(model) {
+export function serializableAdapterOutput(model) {
   return JSON.parse(
     JSON.stringify(model, (_key, value) => {
       if (value instanceof Map) return Object.fromEntries(value.entries());
@@ -406,77 +488,79 @@ export function serializableAdapterModel(model) {
   );
 }
 
-function tremorModel(chartType, wide, latest) {
+function tremorModel(chartType, result) {
   if (chartType === "donut") {
-    return toTremorDonutChartProps(latest);
+    return toTremorDonutChartProps(result, { seriesLabel });
   }
   if (chartType === "barList") {
-    return toTremorBarListProps(latest);
+    return toTremorBarListProps(result, { seriesLabel });
   }
-  if (chartType === "area") return toTremorAreaChartProps(wide, { type: "default" });
-  if (chartType === "bar") return toTremorBarChartProps(wide, { layout: "vertical" });
-  return toTremorLineChartProps(wide);
+  if (chartType === "area") return toTremorAreaChartProps(result, { seriesLabel, type: "default" });
+  if (chartType === "bar")
+    return toTremorBarChartProps(result, { layout: "vertical", seriesLabel });
+  return toTremorLineChartProps(result, { seriesLabel });
 }
 
-function rechartsModel(chartType, wide, latest, histogram) {
-  if (chartType === "donut") {
-    return toRechartsEngineLatestValuesModel(latest);
+function rechartsModel(chartType, result) {
+  if (chartType === "donut" || chartType === "latestBar") {
+    return toRechartsLatestValuesData(result, { seriesLabel });
   }
   if (chartType === "histogram") {
-    return toRechartsEngineHistogramModel(histogram);
+    return toRechartsHistogramData(result);
   }
   if (chartType === "scatter") {
-    return toRechartsEngineScatterModel(wide);
+    return toRechartsScatterData(result, { seriesLabel });
   }
-  return {
-    data: wide.rows.map((row) => rowToRecord(row, wide.series, "time")),
-    xAxisKey: "time",
-    tooltipKey: "time",
-    series: wide.series.map((series) => ({
-      id: series.id,
-      dataKey: series.id,
-      name: series.label,
-    })),
-    ...(chartType === "bar"
-      ? { latest: latest.rows.map((row) => ({ label: row.label, value: row.value })) }
-      : {}),
-  };
+  return toRechartsTimeSeriesData(result, { seriesLabel });
 }
 
-function nivoModel(chartType, wide, latest) {
+function nivoModel(chartType, result) {
   if (chartType === "donut") {
-    return toNivoEnginePieData(latest).map((row, index) => ({
+    return toNivoPieData(result, { seriesLabel }).map((row, index) => ({
       ...row,
       color: COLORS[index % COLORS.length],
     }));
   }
   if (chartType === "bar") {
-    return toNivoEngineBarModel(wide);
+    return toNivoBarData(result, { seriesLabel });
   }
   if (chartType === "scatter") {
-    return toNivoEngineScatterSeries(wide);
+    return toNivoScatterSeries(result, { seriesLabel });
   }
-  return toNivoEngineLineSeries(wide);
+  return toNivoLineSeries(result, { seriesLabel });
 }
 
-function victoryModel(chartType, wide, latest) {
+function victoryModel(chartType, result) {
   if (chartType === "donut") {
-    return toVictoryEngineLatestData(latest);
+    return toVictoryLatestData(result, { seriesLabel });
   }
   if (chartType === "bar") {
-    return toVictoryEngineLatestData(latest);
+    return toVictoryLatestData(result, { seriesLabel });
   }
-  return toVictoryEngineSeries(wide, { chartType });
+  return toVictorySeries(result, { chartType, seriesLabel });
 }
 
 function snippetsFor(library, chartType) {
   const componentName = componentFor(library.id, chartType);
   return {
-    query: `const result = engine.query(store, {
+    query: `import { RowGroupStore, ScanEngine } from "o11ytsdb";
+
+const store = new RowGroupStore(valuesCodec, 640, () => 0, 32, "dashboard");
+const id = store.getOrCreateSeries(new Map([
+  ["__name__", "http.server.duration"],
+  ["service", "checkout"],
+  ["route", "/cart"],
+  ["status_class", "2xx"],
+]));
+
+store.append(timestamps, [{ id, values }]);
+
+const engine = new ScanEngine();
+const result = engine.query(store, {
   metric: "http.server.duration",
   start,
   end,
-  groupBy: ["service", "route", "status_class"],
+  maxPoints: 300,
 });`,
     adapter: adapterSnippet(library.id, chartType),
     library: librarySnippet(library.id, chartType, componentName),
@@ -492,305 +576,172 @@ function adapterSnippet(libraryId, chartType) {
           ? "toTremorBarListProps"
           : `toTremor${capitalize(chartType)}ChartProps`;
     return `import {
-  toEngineLatestValueModel,
-  toEngineWideTableModel,
-} from "@otlpkit/adapters/engine";
-import {
   ${fn},
 } from "@otlpkit/adapters/tremor";
 
-const wide = toEngineWideTableModel(result, {
+const props = ${fn}(result, {
   seriesLabel: (s) => s.labels.get("service") ?? "service",
-});
-const latest = toEngineLatestValueModel(result);
-const props = ${fn}(${chartType === "donut" || chartType === "barList" ? "latest" : "wide"});`;
+});`;
   }
   if (libraryId === "recharts") {
-    if (chartType === "donut") {
-      return `import {
-  toEngineLatestValueModel,
-} from "@otlpkit/adapters/engine";
-import {
-  toRechartsEngineLatestValuesModel,
-} from "@otlpkit/adapters/recharts";
+    const fn =
+      chartType === "donut" || chartType === "latestBar"
+        ? "toRechartsLatestValuesData"
+        : chartType === "histogram"
+          ? "toRechartsHistogramData"
+          : chartType === "scatter"
+            ? "toRechartsScatterData"
+            : "toRechartsTimeSeriesData";
+    return `import { ${fn} } from "@otlpkit/adapters/recharts";
 
-const latest = toEngineLatestValueModel(result);
-const model = toRechartsEngineLatestValuesModel(latest, {
-  unit: "ms",
-});`;
-    }
-    if (chartType === "histogram") {
-      return `import {
-  toEngineHistogramModel,
-  toEngineWideTableModel,
-} from "@otlpkit/adapters/engine";
-import {
-  toRechartsEngineHistogramModel,
-} from "@otlpkit/adapters/recharts";
-
-const wide = toEngineWideTableModel(result);
-const histogram = toEngineHistogramModel(wide);
-const model = toRechartsEngineHistogramModel(histogram, {
-  unit: "samples",
-});`;
-    }
-    if (chartType === "scatter") {
-      return `import {
-  toEngineWideTableModel,
-} from "@otlpkit/adapters/engine";
-import {
-  toRechartsEngineScatterModel,
-} from "@otlpkit/adapters/recharts";
-
-const wide = toEngineWideTableModel(result);
-const model = toRechartsEngineScatterModel(wide, {
-  unit: "ms",
-});`;
-    }
-    return `import {
-  toEngineWideTableModel,
-} from "@otlpkit/adapters/engine";
-import {
-  toRechartsEngineTimeSeriesModel,
-} from "@otlpkit/adapters/recharts";
-
-const wide = toEngineWideTableModel(result);
-const model = toRechartsEngineTimeSeriesModel(wide, {
-  unit: "ms",
+const data = ${fn}(result, {
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
+  unit: "${chartType === "histogram" ? "samples" : "ms"}",
 });`;
   }
   if (libraryId === "uplot") {
-    return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toUPlotEngineTimeSeriesModel } from "@otlpkit/adapters/uplot";
+    return `import { toUPlotTimeSeriesArgs } from "@otlpkit/adapters/uplot";
 
-const wide = toEngineWideTableModel(result);
-const model = toUPlotEngineTimeSeriesModel(wide, {
+const args = toUPlotTimeSeriesArgs(result, {
   chartType: "${chartType}",
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
 });`;
   }
   if (libraryId === "echarts") {
-    if (chartType === "histogram") {
-      return `import {
-  toEngineHistogramModel,
-  toEngineWideTableModel,
-} from "@otlpkit/adapters/engine";
-import { toEChartsEngineHistogramOption } from "@otlpkit/adapters/echarts";
+    const fn =
+      chartType === "histogram"
+        ? "toEChartsHistogramOption"
+        : chartType === "donut" || chartType === "gauge" || chartType === "latestBar"
+          ? "toEChartsLatestValuesOption"
+          : "toEChartsTimeSeriesOption";
+    return `import { ${fn} } from "@otlpkit/adapters/echarts";
 
-const wide = toEngineWideTableModel(result);
-const histogram = toEngineHistogramModel(wide);
-const option = toEChartsEngineHistogramOption(histogram);`;
-    }
-    if (chartType === "donut" || chartType === "gauge") {
-      return `import { toEngineLatestValueModel } from "@otlpkit/adapters/engine";
-import { toEChartsEngineLatestValuesOption } from "@otlpkit/adapters/echarts";
-
-const latest = toEngineLatestValueModel(result);
-const option = toEChartsEngineLatestValuesOption(latest, {
-  chartType: "${chartType}",
-});`;
-    }
-    return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toEChartsEngineTimeSeriesOption } from "@otlpkit/adapters/echarts";
-
-const wide = toEngineWideTableModel(result);
-const option = toEChartsEngineTimeSeriesOption(wide, {
-  chartType: "${chartType}",
+const option = ${fn}(result, {
+  chartType: "${chartType === "latestBar" ? "bar" : chartType}",
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
 });`;
   }
   if (libraryId === "chartjs") {
-    if (chartType === "histogram") {
-      return `import {
-  toEngineHistogramModel,
-  toEngineWideTableModel,
-} from "@otlpkit/adapters/engine";
-import { toChartJsEngineHistogramConfig } from "@otlpkit/adapters/chartjs";
+    const fn =
+      chartType === "histogram"
+        ? "toChartJsHistogramConfig"
+        : chartType === "donut" || chartType === "gauge" || chartType === "latestBar"
+          ? "toChartJsLatestValuesConfig"
+          : "toChartJsTimeSeriesConfig";
+    return `import { ${fn} } from "@otlpkit/adapters/chartjs";
 
-const wide = toEngineWideTableModel(result);
-const histogram = toEngineHistogramModel(wide);
-const config = toChartJsEngineHistogramConfig(histogram);`;
-    }
-    if (chartType === "donut" || chartType === "gauge") {
-      return `import { toEngineLatestValueModel } from "@otlpkit/adapters/engine";
-import { toChartJsEngineLatestValuesConfig } from "@otlpkit/adapters/chartjs";
-
-const latest = toEngineLatestValueModel(result);
-const config = toChartJsEngineLatestValuesConfig(latest, {
-  chartType: "${chartType}",
-});`;
-    }
-    return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toChartJsEngineTimeSeriesConfig } from "@otlpkit/adapters/chartjs";
-
-const wide = toEngineWideTableModel(result);
-const config = toChartJsEngineTimeSeriesConfig(wide, {
-  chartType: "${chartType}",
+const config = ${fn}(result, {
+  chartType: "${chartType === "latestBar" ? "bar" : chartType}",
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
 });`;
   }
   if (libraryId === "plotly") {
-    if (chartType === "histogram") {
-      return `import {
-  toEngineHistogramModel,
-  toEngineWideTableModel,
-} from "@otlpkit/adapters/engine";
-import { toPlotlyEngineHistogramModel } from "@otlpkit/adapters/plotly";
+    const fn =
+      chartType === "histogram"
+        ? "toPlotlyHistogramFigure"
+        : chartType === "donut" || chartType === "gauge"
+          ? "toPlotlyLatestValuesFigure"
+          : "toPlotlyTimeSeriesFigure";
+    return `import { ${fn} } from "@otlpkit/adapters/plotly";
 
-const wide = toEngineWideTableModel(result);
-const histogram = toEngineHistogramModel(wide);
-const traces = toPlotlyEngineHistogramModel(histogram);`;
-    }
-    if (chartType === "donut" || chartType === "gauge") {
-      return `import { toEngineLatestValueModel } from "@otlpkit/adapters/engine";
-import { toPlotlyEngineLatestValuesModel } from "@otlpkit/adapters/plotly";
-
-const latest = toEngineLatestValueModel(result);
-const traces = toPlotlyEngineLatestValuesModel(latest, {
+const figure = ${fn}(result, {
   chartType: "${chartType}",
-});`;
-    }
-    return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toPlotlyEngineTimeSeriesModel } from "@otlpkit/adapters/plotly";
-
-const wide = toEngineWideTableModel(result);
-const traces = toPlotlyEngineTimeSeriesModel(wide, {
-  chartType: "${chartType}",
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
 });`;
   }
   if (libraryId === "apexcharts") {
-    if (chartType === "donut" || chartType === "gauge") {
-      return `import { toEngineLatestValueModel } from "@otlpkit/adapters/engine";
-import { toApexChartsEngineLatestValuesOptions } from "@otlpkit/adapters/apexcharts";
+    const fn =
+      chartType === "donut" || chartType === "gauge"
+        ? "toApexChartsLatestValuesOptions"
+        : "toApexChartsTimeSeriesOptions";
+    return `import { ${fn} } from "@otlpkit/adapters/apexcharts";
 
-const latest = toEngineLatestValueModel(result);
-const options = toApexChartsEngineLatestValuesOptions(latest, {
+const options = ${fn}(result, {
   chartType: "${chartType}",
-});`;
-    }
-    return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toApexChartsEngineTimeSeriesOptions } from "@otlpkit/adapters/apexcharts";
-
-const wide = toEngineWideTableModel(result);
-const options = toApexChartsEngineTimeSeriesOptions(wide, {
-  chartType: "${chartType}",
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
 });`;
   }
   if (libraryId === "victory") {
-    if (chartType === "donut" || chartType === "bar") {
-      return `import { toEngineLatestValueModel } from "@otlpkit/adapters/engine";
-import { toVictoryEngineLatestData } from "@otlpkit/adapters/victory";
+    const fn =
+      chartType === "donut" || chartType === "bar" ? "toVictoryLatestData" : "toVictorySeries";
+    return `import { ${fn} } from "@otlpkit/adapters/victory";
 
-const latest = toEngineLatestValueModel(result);
-const data = toVictoryEngineLatestData(latest);`;
-    }
-    return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toVictoryEngineSeries } from "@otlpkit/adapters/victory";
-
-const wide = toEngineWideTableModel(result);
-const series = toVictoryEngineSeries(wide, {
+const data = ${fn}(result, {
   chartType: "${chartType}",
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
 });`;
   }
   if (libraryId === "agcharts") {
-    if (chartType === "donut" || chartType === "gauge") {
-      return `import { toEngineLatestValueModel } from "@otlpkit/adapters/engine";
-import { toAgChartsEngineLatestValuesOptions } from "@otlpkit/adapters/agcharts";
+    const fn =
+      chartType === "donut" || chartType === "gauge"
+        ? "toAgChartsLatestValuesOptions"
+        : "toAgChartsTimeSeriesOptions";
+    return `import { ${fn} } from "@otlpkit/adapters/agcharts";
 
-const latest = toEngineLatestValueModel(result);
-const options = toAgChartsEngineLatestValuesOptions(latest, {
+const options = ${fn}(result, {
   chartType: "${chartType}",
-});`;
-    }
-    return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toAgChartsEngineTimeSeriesOptions } from "@otlpkit/adapters/agcharts";
-
-const wide = toEngineWideTableModel(result);
-const options = toAgChartsEngineTimeSeriesOptions(wide, {
-  chartType: "${chartType}",
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
 });`;
   }
   if (libraryId === "highcharts") {
-    if (chartType === "histogram") {
-      return `import {
-  toEngineHistogramModel,
-  toEngineWideTableModel,
-} from "@otlpkit/adapters/engine";
-import { toHighchartsEngineHistogramOptions } from "@otlpkit/adapters/highcharts";
+    const fn =
+      chartType === "histogram"
+        ? "toHighchartsHistogramOptions"
+        : chartType === "donut" || chartType === "gauge"
+          ? "toHighchartsLatestValuesOptions"
+          : "toHighchartsTimeSeriesOptions";
+    return `import { ${fn} } from "@otlpkit/adapters/highcharts";
 
-const wide = toEngineWideTableModel(result);
-const histogram = toEngineHistogramModel(wide);
-const options = toHighchartsEngineHistogramOptions(histogram);`;
-    }
-    if (chartType === "donut" || chartType === "gauge") {
-      return `import { toEngineLatestValueModel } from "@otlpkit/adapters/engine";
-import { toHighchartsEngineLatestValuesOptions } from "@otlpkit/adapters/highcharts";
-
-const latest = toEngineLatestValueModel(result);
-const options = toHighchartsEngineLatestValuesOptions(latest, {
+const options = ${fn}(result, {
   chartType: "${chartType}",
-});`;
-    }
-    return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toHighchartsEngineTimeSeriesOptions } from "@otlpkit/adapters/highcharts";
-
-const wide = toEngineWideTableModel(result);
-const options = toHighchartsEngineTimeSeriesOptions(wide, {
-  chartType: "${chartType}",
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
 });`;
   }
   if (libraryId === "vegalite") {
-    if (chartType === "histogram") {
-      return `import {
-  toEngineHistogramModel,
-  toEngineWideTableModel,
-} from "@otlpkit/adapters/engine";
-import { toVegaLiteEngineHistogramSpec } from "@otlpkit/adapters/vegalite";
+    const fn = chartType === "histogram" ? "toVegaLiteHistogramSpec" : "toVegaLiteSpec";
+    return `import { ${fn} } from "@otlpkit/adapters/vegalite";
 
-const wide = toEngineWideTableModel(result);
-const histogram = toEngineHistogramModel(wide);
-const spec = toVegaLiteEngineHistogramSpec(histogram);`;
-    }
-    return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toVegaLiteEngineSpec } from "@otlpkit/adapters/vegalite";
-
-const wide = toEngineWideTableModel(result);
-const spec = toVegaLiteEngineSpec(wide, {
+const spec = ${fn}(result, {
   mark: "${chartType}",
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
 });`;
   }
   if (libraryId === "observable") {
-    return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toObservablePlotEngineModel } from "@otlpkit/adapters/observable";
+    const fn =
+      chartType === "histogram" ? "toObservablePlotHistogramOptions" : "toObservablePlotOptions";
+    return `import { ${fn} } from "@otlpkit/adapters/observable";
 
-const wide = toEngineWideTableModel(result);
-const plot = toObservablePlotEngineModel(wide, {
+const options = ${fn}(result, {
   chartType: "${chartType}",
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
 });`;
   }
   if (libraryId === "nivo" && chartType === "donut") {
-    return `import { toEngineLatestValueModel } from "@otlpkit/adapters/engine";
-import { toNivoEnginePieData } from "@otlpkit/adapters/nivo";
+    return `import { toNivoPieData } from "@otlpkit/adapters/nivo";
 
-const latest = toEngineLatestValueModel(result);
-const data = toNivoEnginePieData(latest);`;
+const data = toNivoPieData(result, {
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
+});`;
   }
   if (libraryId === "nivo" && chartType === "bar") {
-    return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toNivoEngineBarModel } from "@otlpkit/adapters/nivo";
+    return `import { toNivoBarData } from "@otlpkit/adapters/nivo";
 
-const wide = toEngineWideTableModel(result);
-const data = toNivoEngineBarModel(wide);`;
+const data = toNivoBarData(result, {
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
+});`;
   }
   if (libraryId === "nivo" && chartType === "scatter") {
-    return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toNivoEngineScatterSeries } from "@otlpkit/adapters/nivo";
+    return `import { toNivoScatterSeries } from "@otlpkit/adapters/nivo";
 
-const wide = toEngineWideTableModel(result);
-const data = toNivoEngineScatterSeries(wide);`;
+const data = toNivoScatterSeries(result, {
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
+});`;
   }
-  return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toNivoEngineLineSeries } from "@otlpkit/adapters/nivo";
+  return `import { toNivoLineSeries } from "@otlpkit/adapters/nivo";
 
-const wide = toEngineWideTableModel(result);
-const data = toNivoEngineLineSeries(wide);`;
+const data = toNivoLineSeries(result, {
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
+});`;
 }
 
 function librarySnippet(libraryId, chartType, componentName) {
@@ -799,35 +750,35 @@ function librarySnippet(libraryId, chartType, componentName) {
     if (chartType === "donut") {
       return `<PieChart>
   <Pie
-    data={model.data}
-    dataKey={model.valueKey}
-    nameKey={model.categoryKey}
+    data={data.data}
+    dataKey={data.valueKey}
+    nameKey={data.categoryKey}
     innerRadius={48}
   />
 </PieChart>`;
     }
     if (chartType === "histogram") {
-      return `<BarChart data={model.data}>
-  <XAxis dataKey={model.categoryKey} />
-  <Bar dataKey={model.valueKey} />
+      return `<BarChart data={data.data}>
+  <XAxis dataKey={data.categoryKey} />
+  <Bar dataKey={data.valueKey} />
 </BarChart>`;
     }
     if (chartType === "scatter") {
       return `<ScatterChart>
-  <XAxis dataKey={model.xAxisKey} type="number" />
-  <YAxis dataKey={model.yAxisKey} />
-  {model.series.map((s) => (
+  <XAxis dataKey={data.xAxisKey} type="number" />
+  <YAxis dataKey={data.yAxisKey} />
+  {data.series.map((s) => (
     <Scatter
       key={s.id}
       name={s.name}
-      data={model.data.filter((row) => row[model.seriesKey] === s.name)}
+      data={data.data.filter((row) => row[data.seriesKey] === s.name)}
     />
   ))}
 </ScatterChart>`;
     }
-    return `<${componentName} data={model.data}>
-  <XAxis dataKey={model.xAxisKey} />
-  {model.series.map((s) => <Line key={s.id} dataKey={s.dataKey} name={s.name} />)}
+    return `<${componentName} data={data.data}>
+  <XAxis dataKey={data.xAxisKey} />
+  {data.series.map((s) => <Line key={s.id} dataKey={s.dataKey} name={s.name} />)}
 </${componentName}>`;
   }
   if (libraryId === "chartjs")
@@ -852,14 +803,14 @@ view.view.change("telemetry", changeset).run();`;
     return `const chart = echarts.init(node);
 chart.setOption(option);`;
   if (libraryId === "uplot")
-    return `const plot = new uPlot(model.options, model.data, node);
-plot.setData(nextModel.data);`;
+    return `const plot = new uPlot(args.options, args.data, node);
+plot.setData(nextArgs.data);`;
   if (libraryId === "nivo") return `<${componentName} data={data} animate={false} />`;
   if (libraryId === "observable")
     return `Plot.plot({
-  marks: plot.marks.map((mark) => Plot[mark.mark](plot.data, mark)),
+  marks: options.marks.map((mark) => Plot[mark.mark](options.data, mark)),
 });`;
-  return `Plotly.react(node, traces.data, traces.layout);
+  return `Plotly.react(node, figure.data, figure.layout);
 Plotly.extendTraces(node, nextPatch, [0, 1, 2]);`;
 }
 
@@ -889,19 +840,6 @@ function componentFor(libraryId, chartType) {
   return names[libraryId]?.[chartType] ?? "Chart";
 }
 
-function rowToRecord(row, series, timeKey) {
-  const output = { [timeKey]: row.t };
-  row.values.forEach((value, index) => {
-    output[series[index].id] = value;
-  });
-  return output;
-}
-
-function seriesId(series, index) {
-  const parts = sortedLabelEntries(series.labels).map(([key, value]) => `${key}=${value}`);
-  return parts.length > 0 ? parts.join(",") : `series-${index}`;
-}
-
 function seriesLabel(series, index) {
   const service = series.labels.get("service") ?? `series-${index}`;
   const route = series.labels.get("route");
@@ -911,8 +849,4 @@ function seriesLabel(series, index) {
 
 function capitalize(value) {
   return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
-}
-
-function sortedLabelEntries(labels) {
-  return [...labels.entries()].sort(([left], [right]) => left.localeCompare(right));
 }

--- a/site/charts/js/gallery-data.js
+++ b/site/charts/js/gallery-data.js
@@ -58,11 +58,6 @@ import {
   toVictoryEngineLatestData,
   toVictoryEngineSeries,
 } from "../../../packages/adapters/src/victory.ts";
-import {
-  toVisxEngineHistogramModel,
-  toVisxEngineLatestValuesModel,
-  toVisxEngineXYChartModel,
-} from "../../../packages/adapters/src/visx.ts";
 
 export const CHART_TYPES = [
   { id: "line", label: "Line" },
@@ -136,16 +131,6 @@ export const LIBRARIES = [
     package: "@otlpkit/adapters/nivo",
     charts: ["line", "area", "bar", "donut", "scatter"],
     note: "Map engine series into Nivo's nested data while keeping labels and colors predictable.",
-  },
-  {
-    id: "visx",
-    name: "Visx",
-    primaryApi: "accessors + arrays",
-    updateModel: "caller state updates",
-    status: "exported",
-    package: "@otlpkit/adapters/visx",
-    charts: ["line", "area", "bar", "histogram", "scatter", "sparkline"],
-    note: "Expose arrays and accessors, because Visx users compose marks rather than consume configs.",
   },
   {
     id: "observable",
@@ -371,8 +356,6 @@ export function toAdapterModel(library, chartType, wide, latest, histogram) {
       return toUPlotEngineTimeSeriesModel(wide, { chartType });
     case "nivo":
       return nivoModel(chartType, wide, latest);
-    case "visx":
-      return visxModel(chartType, wide, latest, histogram);
     case "observable":
       return chartType === "histogram"
         ? toObservablePlotEngineHistogramModel(histogram)
@@ -476,13 +459,6 @@ function nivoModel(chartType, wide, latest) {
   return toNivoEngineLineSeries(wide);
 }
 
-function visxModel(chartType, wide, latest, histogram) {
-  if (chartType === "histogram") return toVisxEngineHistogramModel(histogram);
-  if (chartType === "bar") return toVisxEngineLatestValuesModel(latest);
-  if (chartType === "scatter") return toVisxEngineXYChartModel(wide, { chartType: "scatter" });
-  return toVisxEngineXYChartModel(wide, { chartType });
-}
-
 function victoryModel(chartType, wide, latest) {
   if (chartType === "donut") {
     return toVictoryEngineLatestData(latest);
@@ -508,7 +484,6 @@ function snippetsFor(library, chartType) {
 }
 
 function adapterSnippet(libraryId, chartType) {
-  // Exported libraries show copy-ready imports; Visx is exported but still adapter-shape-only here.
   if (libraryId === "tremor") {
     const fn =
       chartType === "donut"
@@ -790,15 +765,6 @@ const plot = toObservablePlotEngineModel(wide, {
   chartType: "${chartType}",
 });`;
   }
-  if (libraryId === "visx") {
-    return `import { toEngineWideTableModel } from "@otlpkit/adapters/engine";
-import { toVisxEngineXYChartModel } from "@otlpkit/adapters/visx";
-
-const wide = toEngineWideTableModel(result);
-const model = toVisxEngineXYChartModel(wide, {
-  chartType: "${chartType}",
-});`;
-  }
   if (libraryId === "nivo" && chartType === "donut") {
     return `import { toEngineLatestValueModel } from "@otlpkit/adapters/engine";
 import { toNivoEnginePieData } from "@otlpkit/adapters/nivo";
@@ -889,10 +855,6 @@ chart.setOption(option);`;
     return `const plot = new uPlot(model.options, model.data, node);
 plot.setData(nextModel.data);`;
   if (libraryId === "nivo") return `<${componentName} data={data} animate={false} />`;
-  if (libraryId === "visx")
-    return `{model.series.map((series) => (
-  <LinePath key={series.key} data={series.points} x={x} y={y} />
-))}`;
   if (libraryId === "observable")
     return `Plot.plot({
   marks: plot.marks.map((mark) => Plot[mark.mark](plot.data, mark)),

--- a/site/charts/js/gallery-data.js
+++ b/site/charts/js/gallery-data.js
@@ -39,6 +39,7 @@ import {
 } from "../../../packages/adapters/src/plotly.ts";
 import {
   toRechartsEngineHistogramModel,
+  toRechartsEngineLatestValuesModel,
   toRechartsEngineScatterModel,
 } from "../../../packages/adapters/src/recharts.ts";
 import {
@@ -93,7 +94,7 @@ export const LIBRARIES = [
     updateModel: "React data updates",
     status: "implemented",
     package: "@otlpkit/adapters/recharts",
-    charts: ["line", "area", "bar", "histogram", "scatter"],
+    charts: ["line", "area", "bar", "donut", "histogram", "scatter"],
     note: "Keep Recharts ergonomic: rows for data, descriptors for Line/Area/Bar dataKey wiring.",
   },
   {
@@ -173,7 +174,7 @@ export const LIBRARIES = [
     updateModel: "updateSeries",
     status: "exported",
     package: "@otlpkit/adapters/apexcharts",
-    charts: ["line", "area", "bar", "donut", "scatter", "sparkline", "gauge"],
+    charts: ["line", "area", "bar", "donut", "histogram", "scatter", "sparkline", "gauge"],
     note: "Return compact options plus series arrays, including sparkline and radial gauge shapes.",
   },
   {
@@ -203,7 +204,7 @@ export const LIBRARIES = [
     updateModel: "setData",
     status: "exported",
     package: "@otlpkit/adapters/highcharts",
-    charts: ["line", "area", "bar", "donut", "scatter", "sparkline", "gauge"],
+    charts: ["line", "area", "bar", "donut", "histogram", "scatter", "sparkline", "gauge"],
     note: "Return Highcharts-style options while preserving stable engine ids for updates.",
   },
   {
@@ -435,6 +436,9 @@ function tremorModel(chartType, wide, latest) {
 }
 
 function rechartsModel(chartType, wide, latest, histogram) {
+  if (chartType === "donut") {
+    return toRechartsEngineLatestValuesModel(latest);
+  }
   if (chartType === "histogram") {
     return toRechartsEngineHistogramModel(histogram);
   }
@@ -527,6 +531,19 @@ const latest = toEngineLatestValueModel(result);
 const props = ${fn}(${chartType === "donut" || chartType === "barList" ? "latest" : "wide"});`;
   }
   if (libraryId === "recharts") {
+    if (chartType === "donut") {
+      return `import {
+  toEngineLatestValueModel,
+} from "@otlpkit/adapters/engine";
+import {
+  toRechartsEngineLatestValuesModel,
+} from "@otlpkit/adapters/recharts";
+
+const latest = toEngineLatestValueModel(result);
+const model = toRechartsEngineLatestValuesModel(latest, {
+  unit: "ms",
+});`;
+    }
     if (chartType === "histogram") {
       return `import {
   toEngineHistogramModel,
@@ -810,9 +827,38 @@ const wide = toEngineWideTableModel(result);
 const data = toNivoEngineLineSeries(wide);`;
 }
 
-function librarySnippet(libraryId, _chartType, componentName) {
+function librarySnippet(libraryId, chartType, componentName) {
   if (libraryId === "tremor") return `<${componentName} {...props} />`;
   if (libraryId === "recharts") {
+    if (chartType === "donut") {
+      return `<PieChart>
+  <Pie
+    data={model.data}
+    dataKey={model.valueKey}
+    nameKey={model.categoryKey}
+    innerRadius={48}
+  />
+</PieChart>`;
+    }
+    if (chartType === "histogram") {
+      return `<BarChart data={model.data}>
+  <XAxis dataKey={model.categoryKey} />
+  <Bar dataKey={model.valueKey} />
+</BarChart>`;
+    }
+    if (chartType === "scatter") {
+      return `<ScatterChart>
+  <XAxis dataKey={model.xAxisKey} type="number" />
+  <YAxis dataKey={model.yAxisKey} />
+  {model.series.map((s) => (
+    <Scatter
+      key={s.id}
+      name={s.name}
+      data={model.data.filter((row) => row[model.seriesKey] === s.name)}
+    />
+  ))}
+</ScatterChart>`;
+    }
     return `<${componentName} data={model.data}>
   <XAxis dataKey={model.xAxisKey} />
   {model.series.map((s) => <Line key={s.id} dataKey={s.dataKey} name={s.name} />)}

--- a/site/charts/js/gallery-data.js
+++ b/site/charts/js/gallery-data.js
@@ -196,7 +196,7 @@ export const LIBRARIES = [
     updateModel: "updateSeries",
     status: "exported",
     package: "@otlpkit/adapters/apexcharts",
-    charts: ["line", "area", "bar", "donut", "histogram", "scatter", "sparkline", "gauge"],
+    charts: ["line", "area", "bar", "donut", "scatter", "sparkline", "gauge"],
     note: "Return compact options plus series arrays, including sparkline and radial gauge shapes.",
   },
   {
@@ -503,15 +503,15 @@ function tremorModel(chartType, result) {
 
 function rechartsModel(chartType, result) {
   if (chartType === "donut" || chartType === "latestBar") {
-    return toRechartsLatestValuesData(result, { seriesLabel });
+    return toRechartsLatestValuesData(result, { seriesLabel, unit: "ms" });
   }
   if (chartType === "histogram") {
-    return toRechartsHistogramData(result);
+    return toRechartsHistogramData(result, { seriesLabel, unit: "samples" });
   }
   if (chartType === "scatter") {
-    return toRechartsScatterData(result, { seriesLabel });
+    return toRechartsScatterData(result, { seriesLabel, unit: "ms" });
   }
-  return toRechartsTimeSeriesData(result, { seriesLabel });
+  return toRechartsTimeSeriesData(result, { seriesLabel, unit: "ms" });
 }
 
 function nivoModel(chartType, result) {

--- a/site/charts/js/gallery-renderers.js
+++ b/site/charts/js/gallery-renderers.js
@@ -987,7 +987,7 @@ function isCurrentRender(target, generation) {
   return generation === renderGeneration && target.isConnected;
 }
 
-function renderPlaceholder(target, chart, message, title = "adapter shape") {
+function renderPlaceholder(target, chart, message, title = "renderer") {
   target.innerHTML = `<div class="chart-render-placeholder">
     <strong>${escapeHtml(chart.library.name)} ${escapeHtml(title)}</strong>
     <span>${escapeHtml(message)}</span>
@@ -1013,6 +1013,9 @@ function timeValuesForChart(chart) {
   const model = chart.adapterModel;
   if (model?.data?.datasets?.[0]?.data) {
     return model.data.datasets[0].data.map((point) => point.x);
+  }
+  if (Array.isArray(model?.data?.[0]?.data)) {
+    return model.data[0].data.map((point) => point.x).filter((value) => value !== undefined);
   }
   if (model?.dataset?.[0]?.source) {
     return model.dataset[0].source.map((row) => row.time).filter((value) => value !== undefined);

--- a/site/charts/js/gallery-renderers.js
+++ b/site/charts/js/gallery-renderers.js
@@ -236,14 +236,14 @@ async function renderTremor(target, chart, generation) {
   } = await loadTremorRuntime();
   if (!isCurrentRender(target, generation)) return undefined;
 
-  const model = chart.adapterModel;
+  const model = chart.adapterOutput;
   const common = {
     className: "native-react-chart",
     showAnimation: false,
   };
   const xyProps = {
     ...common,
-    showLegend: false,
+    showLegend: true,
     showXAxis: false,
     showYAxis: false,
     minValue: VALUE_DOMAIN.min,
@@ -271,7 +271,7 @@ async function renderRecharts(target, chart, generation) {
   if (!isCurrentRender(target, generation)) return undefined;
 
   const { React } = runtime;
-  const model = chart.adapterModel;
+  const model = chart.adapterOutput;
   const timeRange = timeRangeForChart(chart);
   if (chart.chartType === "donut") {
     return renderReact(
@@ -296,13 +296,14 @@ async function renderRecharts(target, chart, generation) {
               fill: COLORS[index % COLORS.length],
             })
           ),
-          React.createElement(runtime.Tooltip, null)
+          React.createElement(runtime.Tooltip, null),
+          React.createElement(runtime.Legend, { iconSize: 8, wrapperStyle: legendStyle() })
         )
       ),
       runtime.createRoot
     );
   }
-  if (chart.chartType === "histogram") {
+  if (chart.chartType === "histogram" || chart.chartType === "latestBar") {
     return renderReact(
       target,
       React.createElement(
@@ -318,6 +319,7 @@ async function renderRecharts(target, chart, generation) {
             domain: [VALUE_DOMAIN.min, VALUE_DOMAIN.max],
           }),
           React.createElement(runtime.Tooltip, null),
+          React.createElement(runtime.Legend, { wrapperStyle: legendStyle() }),
           React.createElement(runtime.Bar, {
             dataKey: model.valueKey,
             fill: COLORS[0],
@@ -364,6 +366,7 @@ async function renderRecharts(target, chart, generation) {
           domain: [VALUE_DOMAIN.min, VALUE_DOMAIN.max],
         }),
         React.createElement(runtime.Tooltip, null),
+        React.createElement(runtime.Legend, { wrapperStyle: legendStyle() }),
         model.series.map((series, index) =>
           React.createElement(SeriesComponent, {
             key: series.id,
@@ -384,7 +387,7 @@ async function renderRecharts(target, chart, generation) {
 
 function renderRechartsScatter(target, chart, runtime) {
   const { React } = runtime;
-  const model = chart.adapterModel;
+  const model = chart.adapterOutput;
   const timeRange = timeRangeForChart(chart);
   const seriesNames = [...new Set(model.data.map((row) => row.series))];
   return renderReact(
@@ -408,6 +411,7 @@ function renderRechartsScatter(target, chart, runtime) {
           domain: [VALUE_DOMAIN.min, VALUE_DOMAIN.max],
         }),
         React.createElement(runtime.Tooltip, null),
+        React.createElement(runtime.Legend, { wrapperStyle: legendStyle() }),
         seriesNames.map((series, index) =>
           React.createElement(runtime.Scatter, {
             key: series,
@@ -428,9 +432,9 @@ async function renderChartJs(target, chart, generation) {
 
   const timeRange = timeRangeForChart(chart);
   const config = {
-    ...chart.adapterModel,
+    ...chart.adapterOutput,
     options: {
-      ...chart.adapterModel.options,
+      ...chart.adapterOutput.options,
       responsive: true,
       maintainAspectRatio: false,
       plugins: {
@@ -438,13 +442,14 @@ async function renderChartJs(target, chart, generation) {
         tooltip: { enabled: true },
       },
       scales: {
-        ...(chart.adapterModel.options?.scales ?? {}),
+        ...(chart.adapterOutput.options?.scales ?? {}),
         x: {
-          ...(chart.adapterModel.options?.scales?.x ?? {}),
+          ...(chart.adapterOutput.options?.scales?.x ?? {}),
           ...(timeRange ?? {}),
+          ticks: { display: false },
         },
         y: {
-          ...(chart.adapterModel.options?.scales?.y ?? {}),
+          ...(chart.adapterOutput.options?.scales?.y ?? {}),
           min: VALUE_DOMAIN.min,
           max: VALUE_DOMAIN.max,
         },
@@ -456,6 +461,7 @@ async function renderChartJs(target, chart, generation) {
     state.chartJs.config.type = config.type;
     state.chartJs.data = config.data;
     state.chartJs.options = config.options;
+    state.chartJs.resize();
     state.chartJs.update("none");
     return state.dispose;
   }
@@ -474,6 +480,7 @@ async function renderECharts(target, chart, generation) {
   const option = echartsOptionFor(chart);
   const state = stateFor(target);
   if (state.echarts) {
+    state.echarts.resize();
     state.echarts.setOption(option, { notMerge: false, lazyUpdate: true });
     return state.dispose;
   }
@@ -489,15 +496,16 @@ async function renderUPlot(target, chart, generation) {
   const uPlot = await loadUPlotRuntime();
   if (!isCurrentRender(target, generation)) return undefined;
 
-  const model = chart.adapterModel;
+  const model = chart.adapterOutput;
+  const width = Math.max(260, target.clientWidth || 320);
+  const height = Math.max(180, target.clientHeight || 220);
   const state = stateFor(target);
   if (state.uplot) {
+    state.uplot.setSize({ width, height });
     state.uplot.setData(model.data);
     return state.dispose;
   }
   target.replaceChildren();
-  const width = Math.max(260, target.clientWidth || 320);
-  const height = Math.max(180, target.clientHeight || 220);
   const options = {
     ...model.options,
     width,
@@ -537,11 +545,12 @@ async function renderPlotly(target, chart, generation) {
   const Plotly = await loadPlotlyRuntime();
   if (!isCurrentRender(target, generation)) return undefined;
 
-  const model = chart.adapterModel;
+  const model = chart.adapterOutput;
   const timeRange = timeRangeForChart(chart);
   const layout = {
     ...model.layout,
     autosize: true,
+    width: Math.max(260, target.clientWidth || 320),
     height: target.clientHeight || 220,
     margin: { l: 36, r: 12, t: 12, b: 28, ...(model.layout?.margin ?? {}) },
     paper_bgcolor: "rgba(0,0,0,0)",
@@ -578,7 +587,7 @@ async function renderApexCharts(target, chart, generation) {
   const ApexCharts = await loadApexChartsRuntime();
   if (!isCurrentRender(target, generation)) return undefined;
 
-  const model = chart.adapterModel;
+  const model = chart.adapterOutput;
   const timeRange = timeRangeForChart(chart);
   const options = {
     ...model,
@@ -587,6 +596,9 @@ async function renderApexCharts(target, chart, generation) {
       type: chart.chartType === "area" ? "area" : model.chart?.type,
       animations: { enabled: false },
       height: target.clientHeight || 220,
+      parentHeightOffset: 0,
+      redrawOnParentResize: false,
+      redrawOnWindowResize: false,
       toolbar: { show: false },
       sparkline: {
         enabled: chart.chartType === "sparkline" || model.chart?.sparkline?.enabled === true,
@@ -608,7 +620,7 @@ async function renderApexCharts(target, chart, generation) {
   };
   const state = stateFor(target);
   if (state.apex) {
-    await state.apex.updateOptions(options, false, false);
+    await state.apex.updateOptions(options, false, false, false);
     return state.dispose;
   }
   target.replaceChildren();
@@ -623,7 +635,7 @@ async function renderHighcharts(target, chart, generation) {
   const Highcharts = await loadHighchartsRuntime();
   if (!isCurrentRender(target, generation)) return undefined;
 
-  const model = chart.adapterModel;
+  const model = chart.adapterOutput;
   const timeRange = timeRangeForChart(chart);
   const options = {
     ...model,
@@ -658,6 +670,7 @@ async function renderHighcharts(target, chart, generation) {
   };
   const state = stateFor(target);
   if (state.highcharts) {
+    state.highcharts.setSize(target.clientWidth || null, target.clientHeight || null, false);
     state.highcharts.update(options, true, false);
     return state.dispose;
   }
@@ -672,11 +685,12 @@ async function renderVegaLite(target, chart, generation) {
   const vegaEmbed = await loadVegaLiteRuntime();
   if (!isCurrentRender(target, generation)) return undefined;
 
-  const model = chart.adapterModel;
+  const model = chart.adapterOutput;
   const spec = {
     ...model,
-    width: "container",
+    width: Math.max(260, target.clientWidth || 320),
     height: Math.max(180, target.clientHeight || 220),
+    autosize: { type: "fit", contains: "padding" },
     background: "transparent",
     config: {
       ...(model.config ?? {}),
@@ -712,6 +726,8 @@ async function renderNivo(target, chart, generation) {
     colors: COLORS,
     margin:
       chart.chartType === "donut" ? { top: 16, right: 16, bottom: 16, left: 16 } : chartMargin(),
+    enableGridX: chart.chartType !== "donut",
+    enableGridY: chart.chartType !== "donut",
     theme: nivoTheme(),
   };
   if (chart.chartType === "donut") {
@@ -719,7 +735,7 @@ async function renderNivo(target, chart, generation) {
       target,
       React.createElement(runtime.ResponsivePie, {
         ...common,
-        data: chart.adapterModel,
+        data: chart.adapterOutput,
         innerRadius: 0.58,
         enableArcLabels: false,
         enableArcLinkLabels: false,
@@ -732,13 +748,14 @@ async function renderNivo(target, chart, generation) {
       target,
       React.createElement(runtime.ResponsiveBar, {
         ...common,
-        data: chart.adapterModel.data,
-        keys: chart.adapterModel.keys,
-        indexBy: chart.adapterModel.indexBy,
+        data: chart.adapterOutput.data,
+        keys: chart.adapterOutput.keys,
+        indexBy: chart.adapterOutput.indexBy,
         groupMode: "grouped",
         enableLabel: false,
-        axisBottom: null,
+        axisBottom: { tickSize: 0, tickPadding: 6, format: () => "" },
         axisLeft: { tickSize: 0, tickPadding: 6 },
+        isInteractive: false,
       }),
       runtime.createRoot
     );
@@ -748,14 +765,15 @@ async function renderNivo(target, chart, generation) {
       target,
       React.createElement(runtime.ResponsiveScatterPlot, {
         ...common,
-        data: chart.adapterModel,
+        data: chart.adapterOutput,
         xScale: {
           type: "linear",
           ...(timeRange ? { min: timeRange.min, max: timeRange.max } : {}),
         },
         yScale: { type: "linear", min: VALUE_DOMAIN.min, max: VALUE_DOMAIN.max },
-        axisBottom: null,
+        axisBottom: { tickSize: 0, tickPadding: 6, format: () => "" },
         axisLeft: { tickSize: 0, tickPadding: 6 },
+        isInteractive: false,
         nodeSize: 8,
       }),
       runtime.createRoot
@@ -765,16 +783,17 @@ async function renderNivo(target, chart, generation) {
     target,
     React.createElement(runtime.ResponsiveLine, {
       ...common,
-      data: chart.adapterModel,
+      data: chart.adapterOutput,
       enableArea: chart.chartType === "area",
       enablePoints: false,
-      useMesh: true,
+      useMesh: false,
+      isInteractive: false,
       xScale: {
         type: "linear",
         ...(timeRange ? { min: timeRange.min, max: timeRange.max } : {}),
       },
       yScale: { type: "linear", stacked: false, min: VALUE_DOMAIN.min, max: VALUE_DOMAIN.max },
-      axisBottom: null,
+      axisBottom: { tickSize: 0, tickPadding: 6, format: () => "" },
       axisLeft: { tickSize: 0, tickPadding: 6 },
     }),
     runtime.createRoot
@@ -785,7 +804,7 @@ async function renderObservablePlot(target, chart, generation) {
   const Plot = await loadObservablePlotRuntime();
   if (!isCurrentRender(target, generation)) return undefined;
 
-  const model = chart.adapterModel;
+  const model = chart.adapterOutput;
   const timeRange = timeRangeForChart(chart);
   const marks = model.marks.map((mark) => observableMark(Plot, model.data, mark));
   const state = stateFor(target);
@@ -808,7 +827,6 @@ async function renderObservablePlot(target, chart, generation) {
     color: model.options.color,
     marks,
   });
-  state.observablePlot?.remove();
   target.replaceChildren(plot);
   state.observablePlot = plot;
   state.dispose = () => plot.remove();
@@ -831,7 +849,7 @@ async function renderVictory(target, chart, generation) {
       target,
       React.createElement(runtime.VictoryPie, {
         ...dimensions,
-        data: chart.adapterModel,
+        data: chart.adapterOutput,
         colorScale: COLORS,
         innerRadius: 54,
         labels: () => null,
@@ -853,7 +871,7 @@ async function renderVictory(target, chart, generation) {
         React.createElement(runtime.VictoryAxis, { tickFormat: () => "" }),
         React.createElement(runtime.VictoryAxis, { dependentAxis: true }),
         React.createElement(runtime.VictoryBar, {
-          data: chart.adapterModel,
+          data: chart.adapterOutput,
           style: { data: { fill: COLORS[0] } },
         })
       ),
@@ -871,7 +889,7 @@ async function renderVictory(target, chart, generation) {
       },
       React.createElement(runtime.VictoryAxis, { tickFormat: () => "" }),
       React.createElement(runtime.VictoryAxis, { dependentAxis: true }),
-      chart.adapterModel.map((series, index) => {
+      chart.adapterOutput.map((series, index) => {
         const style = {
           data: {
             stroke: COLORS[index % COLORS.length],
@@ -910,7 +928,7 @@ async function renderAgCharts(target, chart, generation) {
   const AgCharts = await loadAgChartsRuntime();
   if (!isCurrentRender(target, generation)) return undefined;
 
-  const model = chart.adapterModel;
+  const model = chart.adapterOutput;
   const baseOptions = {
     ...model,
     container: target,
@@ -921,10 +939,19 @@ async function renderAgCharts(target, chart, generation) {
     axes:
       chart.chartType === "gauge" || chart.chartType === "donut"
         ? undefined
-        : [
-            { type: chart.chartType === "bar" ? "category" : "number", position: "bottom" },
-            { type: "number", position: "left", min: VALUE_DOMAIN.min, max: VALUE_DOMAIN.max },
-          ],
+        : {
+            x: {
+              type: chart.chartType === "bar" ? "category" : "number",
+              position: "bottom",
+              label: { enabled: false },
+            },
+            y: {
+              type: "number",
+              position: "left",
+              min: VALUE_DOMAIN.min,
+              max: VALUE_DOMAIN.max,
+            },
+          },
     theme: {
       palette: { fills: COLORS, strokes: COLORS },
       overrides: { common: { axes: { number: { gridLine: { enabled: true } } } } },
@@ -933,9 +960,9 @@ async function renderAgCharts(target, chart, generation) {
   const state = stateFor(target);
   if (state.ag) {
     if (typeof state.ag.update === "function") {
-      state.ag.update(baseOptions);
+      await state.ag.update(baseOptions);
     } else if (typeof state.ag.updateDelta === "function") {
-      state.ag.updateDelta(baseOptions);
+      await state.ag.updateDelta(baseOptions);
     }
     return state.dispose;
   }
@@ -958,7 +985,7 @@ function renderReact(target, element, createRoot) {
 }
 
 function echartsOptionFor(chart) {
-  const model = chart.adapterModel;
+  const model = chart.adapterOutput;
   if (chart.chartType === "donut" || chart.chartType === "gauge") {
     return { ...model, animation: false, tooltip: { trigger: "item" } };
   }
@@ -970,7 +997,8 @@ function echartsOptionFor(chart) {
     legend: { show: chart.chartType !== "sparkline", type: "scroll", bottom: 0 },
     tooltip: { trigger: "axis" },
     xAxis: {
-      type: chart.chartType === "histogram" ? "category" : "time",
+      type:
+        chart.chartType === "histogram" || chart.chartType === "latestBar" ? "category" : "time",
       show: chart.chartType !== "sparkline",
       ...(timeRange ?? {}),
     },
@@ -1010,7 +1038,7 @@ function timeRangeForChart(chart) {
 }
 
 function timeValuesForChart(chart) {
-  const model = chart.adapterModel;
+  const model = chart.adapterOutput;
   if (model?.data?.datasets?.[0]?.data) {
     return model.data.datasets[0].data.map((point) => point.x);
   }
@@ -1050,6 +1078,14 @@ function chartMargin() {
 
 function responsiveContainerProps() {
   return { width: "100%", height: "100%", minWidth: 1, minHeight: 1 };
+}
+
+function legendStyle() {
+  return {
+    fontFamily: "var(--mono)",
+    fontSize: 11,
+    lineHeight: "16px",
+  };
 }
 
 function nivoTheme() {

--- a/site/charts/js/gallery-renderers.js
+++ b/site/charts/js/gallery-renderers.js
@@ -1040,28 +1040,37 @@ function timeRangeForChart(chart) {
 function timeValuesForChart(chart) {
   const model = chart.adapterOutput;
   if (model?.data?.datasets?.[0]?.data) {
-    return model.data.datasets[0].data.map((point) => point.x);
+    return model.data.datasets[0].data.map(pointXValue).filter((value) => value !== undefined);
   }
   if (Array.isArray(model?.data?.[0]?.data)) {
-    return model.data[0].data.map((point) => point.x).filter((value) => value !== undefined);
+    return model.data[0].data.map(pointXValue).filter((value) => value !== undefined);
   }
   if (model?.dataset?.[0]?.source) {
-    return model.dataset[0].source.map((row) => row.time).filter((value) => value !== undefined);
+    return model.dataset[0].source.map(rowTimeValue).filter((value) => value !== undefined);
   }
   if (Array.isArray(model?.data?.[0])) return model.data[0];
   if (Array.isArray(model?.data?.[0]?.x)) return model.data[0].x;
   if (Array.isArray(model?.series?.[0]?.data)) {
-    return model.series[0].data
-      .map((point) => (Array.isArray(point) ? point[0] : point?.x))
-      .filter((value) => value !== undefined);
+    return model.series[0].data.map(pointXValue).filter((value) => value !== undefined);
   }
   if (Array.isArray(model?.data)) {
-    return model.data.map((row) => row.time ?? row.x).filter((value) => value !== undefined);
+    return model.data.map(rowTimeValue).filter((value) => value !== undefined);
   }
   if (Array.isArray(model?.[0]?.data)) {
-    return model[0].data.map((point) => point.x).filter((value) => value !== undefined);
+    return model[0].data.map(pointXValue).filter((value) => value !== undefined);
   }
   return [];
+}
+
+function pointXValue(point) {
+  if (Array.isArray(point)) return point[0];
+  if (point && typeof point === "object") return point.x;
+  return undefined;
+}
+
+function rowTimeValue(row) {
+  if (!row || typeof row !== "object") return undefined;
+  return row.time ?? row.x;
 }
 
 function victoryDomainFor(chart) {

--- a/site/charts/js/stardb-browser.ts
+++ b/site/charts/js/stardb-browser.ts
@@ -1,0 +1,2 @@
+export { lowerBound, upperBound } from "../../../packages/stardb/src/binary-search.ts";
+export { Interner } from "../../../packages/stardb/src/interner.ts";

--- a/site/charts/styles.css
+++ b/site/charts/styles.css
@@ -22,8 +22,6 @@
 }
 
 .charts-hero-inner > *,
-.preview-panel,
-.code-panel,
 .hero-terminal {
   min-width: 0;
 }
@@ -80,38 +78,27 @@
   max-width: var(--max-w);
   margin: 0 auto;
   padding: 28px var(--gutter);
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.55fr) auto;
-  gap: 20px;
-  align-items: end;
+  display: block;
 }
 
-.library-summary {
+.gallery-toolbar .t-eyebrow {
+  display: inline-flex;
+  margin: 0 0 18px;
+  padding: 12px 16px;
+  border: 1px solid var(--ink);
+  border-radius: 0;
+  background: var(--ink);
+  color: var(--paper);
+  font-size: 13px;
+}
+
+.library-picker {
   min-width: 0;
 }
 
-.library-summary-line {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  align-items: center;
-}
-
-.library-summary-line strong,
-.library-summary-line span {
-  color: var(--ink-2);
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.library-summary-line strong {
-  color: var(--ink);
-}
-
 .segmented-control {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
   gap: 8px;
 }
 
@@ -121,7 +108,7 @@
 .refresh-rate-select {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   min-height: 36px;
   padding: 8px 12px;
   border: 1px solid var(--rule);
@@ -132,6 +119,36 @@
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
+}
+
+.segmented-control button {
+  gap: 10px;
+  min-height: 54px;
+  padding: 10px 14px;
+  font-size: 14px;
+}
+
+.library-mark {
+  display: inline-grid;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid currentcolor;
+  border-radius: 50%;
+  font-size: 11px;
+  line-height: 1;
+}
+
+.library-logo {
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  object-fit: contain;
+}
+
+.library-logo:not([hidden]) + .library-mark {
+  display: none;
 }
 
 .segmented-control button:hover,
@@ -165,7 +182,13 @@
   grid-template-columns: auto auto;
   gap: 8px;
   align-items: end;
-  justify-content: end;
+  justify-content: start;
+}
+
+.gallery-controls-row {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter) 18px;
 }
 
 .refresh-rate-label {
@@ -212,12 +235,6 @@
   align-items: start;
 }
 
-.preview-panel,
-.code-panel {
-  border: 1px solid var(--ink);
-  background: var(--paper);
-}
-
 .chart-card-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -226,7 +243,7 @@
 
 .chart-card {
   display: grid;
-  grid-template-rows: auto minmax(220px, auto) auto auto;
+  grid-template-rows: auto minmax(220px, auto) auto;
   gap: 0;
   min-width: 0;
   min-height: 0;
@@ -253,7 +270,7 @@
   display: flex;
   justify-content: space-between;
   gap: 12px;
-  padding: 16px;
+  padding: 14px 16px;
   border-bottom: 1px solid var(--rule);
 }
 
@@ -283,11 +300,16 @@
 
 .chart-card-meta {
   max-width: 18ch;
-  align-self: start;
   overflow: hidden;
   text-align: right;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.chart-card-tools {
+  display: grid;
+  gap: 8px;
+  justify-items: end;
 }
 
 .chart-card-pill {
@@ -301,18 +323,18 @@
 }
 
 .chart-card-frame {
+  height: 244px;
   min-height: 220px;
   padding: 12px;
-  background:
-    linear-gradient(var(--chart-grid) 1px, transparent 1px),
-    linear-gradient(90deg, var(--chart-grid) 1px, transparent 1px);
-  background-size: 38px 38px;
+  overflow: hidden;
+  background: var(--paper);
 }
 
 .chart-card-render {
   display: block;
   width: 100%;
   height: 220px;
+  max-height: 220px;
   min-width: 0;
   overflow: hidden;
 }
@@ -325,6 +347,16 @@
 .native-react-chart {
   width: 100%;
   height: 220px;
+}
+
+.chart-card-render .apexcharts-canvas,
+.chart-card-render .apexcharts-svg,
+.chart-card-render .vega-embed,
+.chart-card-render .vega-embed > svg {
+  width: 100%;
+  max-width: 100%;
+  max-height: 220px;
+  overflow: hidden;
 }
 
 .chart-card-render .w-full {
@@ -435,113 +467,9 @@
   line-height: 1.45;
 }
 
-.chart-card-preview {
-  display: block;
-  width: 100%;
-  height: 220px;
-  overflow: visible;
-}
-
-.panel-heading {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 22px;
-  border-bottom: 1px solid var(--rule);
-}
-
-.update-pill {
-  max-width: 180px;
-  padding: 6px 10px;
-  border: 1px solid var(--rule);
-  border-radius: var(--radius-sm);
-  color: var(--ink-2);
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 600;
-  text-align: right;
-}
-
-.chart-frame {
-  min-height: 420px;
-  padding: 18px;
-  border-bottom: 1px solid var(--rule);
-  background:
-    linear-gradient(var(--chart-grid) 1px, transparent 1px),
-    linear-gradient(90deg, var(--chart-grid) 1px, transparent 1px);
-  background-size: 48px 48px;
-}
-
-.chart-preview {
-  display: block;
-  width: 100%;
-  height: 420px;
-  overflow: visible;
-}
-
-.chart-axis {
-  stroke: var(--ink);
-  stroke-width: 1;
-}
-
-.chart-grid-line {
-  stroke: rgba(17, 17, 15, 0.12);
-  stroke-width: 1;
-}
-
-.chart-label {
-  fill: var(--ink-3);
-  font-family: var(--mono);
-  font-size: 11px;
-}
-
-.legend {
-  min-height: 58px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px 14px;
-  padding: 16px 22px;
-}
-
-.legend-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  color: var(--ink-2);
-  font-family: var(--mono);
-  font-size: 12px;
-}
-
-.legend-swatch {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-}
-
-.mini-legend {
-  min-height: 62px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 10px;
-  padding: 12px 16px;
-  border-top: 1px solid var(--rule);
-}
-
-.mini-legend .legend-item {
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.chart-card-actions {
-  padding: 0 16px 16px;
-}
-
 .chart-code-button {
-  width: 100%;
-  min-height: 36px;
+  min-height: 30px;
+  padding: 6px 10px;
   border: 1px solid var(--ink);
   border-radius: var(--radius-sm);
   background: var(--paper);
@@ -627,22 +555,6 @@
   font-size: 11px;
   line-height: 1.55;
   white-space: pre;
-}
-
-.code-panel {
-  min-width: 0;
-}
-
-.code-panel-heading {
-  padding: 18px 18px 0;
-}
-
-.code-tabs {
-  display: flex;
-  gap: 8px;
-  padding: 14px;
-  border-bottom: 1px solid var(--rule);
-  overflow-x: auto;
 }
 
 .gallery-code {
@@ -819,14 +731,9 @@
 @media (max-width: 980px) {
   .charts-hero-inner,
   .gallery-grid,
-  .gallery-toolbar,
   .adapter-doc-grid,
   .ergonomics-grid {
     grid-template-columns: 1fr;
-  }
-
-  .gallery-toolbar {
-    align-items: stretch;
   }
 
   .live-controls {
@@ -849,6 +756,7 @@
 @media (max-width: 640px) {
   .charts-hero,
   .gallery-toolbar,
+  .gallery-controls-row,
   .gallery-grid {
     padding-left: 18px;
     padding-right: 18px;
@@ -865,15 +773,6 @@
 
   .gallery-stats .stat:last-child {
     border-bottom: none;
-  }
-
-  .chart-frame {
-    min-height: 300px;
-    padding: 10px;
-  }
-
-  .chart-preview {
-    height: 300px;
   }
 
   .chart-card-grid {

--- a/site/charts/test/gallery-content.test.js
+++ b/site/charts/test/gallery-content.test.js
@@ -16,6 +16,8 @@ describe("chart gallery content", () => {
     expect(html).toContain("Show code button");
     expect(html).toContain("native render code");
     expect(html).toContain('id="refreshRate"');
+    expect(html).toContain('id="libraryCount"');
+    expect(html).toContain('id="chartShapeCount"');
     expect(html).toContain("Refresh rate");
     expect(html).not.toContain('id="librarySummary"');
     expect(html).toContain("What you still control");

--- a/site/charts/test/gallery-content.test.js
+++ b/site/charts/test/gallery-content.test.js
@@ -5,19 +5,38 @@ describe("chart gallery content", () => {
   it("keeps user docs honest about shipped adapters", async () => {
     const html = await readFile(new URL("../index.html", import.meta.url), "utf8");
 
-    expect(html).toContain("most polished adapters today are Tremor and Recharts");
-    expect(html).toContain("toEngineWideTableModel");
-    expect(html).toContain("toEngineLatestValueModel");
-    expect(html).toContain("toEngineLineSeriesModel");
+    expect(html).toContain("What the adapter gives you");
+    expect(html).toContain("toTremorLineChartProps(result)");
+    expect(html).toContain("toRechartsTimeSeriesData(result)");
+    expect(html).not.toContain("toEngineWideTableModel(result)");
+    expect(html).not.toContain("toEngineLatestValueModel(result)");
+    expect(html).toContain("new ScanEngine");
+    expect(html).not.toContain("new FlatStore");
+    expect(html).toContain("Every gallery chart starts from");
     expect(html).toContain("Show code button");
-    expect(html).toContain("package-rendered chart");
+    expect(html).toContain("native render code");
     expect(html).toContain('id="refreshRate"');
     expect(html).toContain("Refresh rate");
-    expect(html).toContain("Compared with raw data sources");
-    expect(html).toContain("engine model -> library-native output");
+    expect(html).not.toContain('id="librarySummary"');
+    expect(html).toContain("What you still control");
+    expect(html).toContain("result -> published adapter -> native input");
     expect(html).toContain('id="chartGallery"');
     expect(html).not.toContain('id="chartButtons"');
     expect(html).not.toContain('id="codeBlock"');
     expect(html).not.toContain("toEChartsOption(wide)");
+    expect(html.toLowerCase()).not.toContain("adapter-shape");
+    expect(html.toLowerCase()).not.toContain("fake");
+  });
+
+  it("does not draw gallery-only graph lines behind native charts", async () => {
+    const css = await readFile(new URL("../styles.css", import.meta.url), "utf8");
+
+    expect(css).toContain(".chart-card-frame");
+    expect(css).toContain("background: var(--paper)");
+    expect(css).not.toContain(".chart-grid-line");
+    expect(css).not.toContain(".chart-preview");
+    expect(css).not.toContain(".chart-axis");
+    expect(css).not.toContain(".mini-legend");
+    expect(css).not.toContain("linear-gradient(var(--chart-grid)");
   });
 });

--- a/site/charts/test/gallery-data.test.js
+++ b/site/charts/test/gallery-data.test.js
@@ -99,6 +99,10 @@ describe("chart gallery data", () => {
         }),
       ]),
     });
+    expect(createGalleryState("recharts", "donut").adapterModel).toMatchObject({
+      categoryKey: "label",
+      valueKey: "value",
+    });
     expect(createGalleryState("echarts", "line").adapterModel.dataset[0].dimensions).toEqual([
       "time",
       "checkout /cart 2xx",
@@ -122,6 +126,7 @@ describe("chart gallery data", () => {
     });
     expect(createGalleryState("agcharts", "area").adapterModel.series[0].type).toBe("area");
     expect(createGalleryState("highcharts", "scatter").adapterModel.chart.type).toBe("scatter");
+    expect(createGalleryState("highcharts", "histogram").adapterModel.chart.type).toBe("column");
     expect(createGalleryState("vegalite", "scatter").adapterModel.mark).toBe("point");
   });
 

--- a/site/charts/test/gallery-data.test.js
+++ b/site/charts/test/gallery-data.test.js
@@ -3,48 +3,57 @@ import { describe, expect, it } from "vitest";
 import {
   CHART_TYPES,
   createEngineResult,
+  createGalleryMetricStore,
   createGalleryState,
   createLibraryGalleryState,
   getSupportedChart,
   LIBRARIES,
-  serializableAdapterModel,
-  toEngineLatestValueModel,
-  toEngineWideTableModel,
-  toHistogramModel,
+  serializableAdapterOutput,
 } from "../js/gallery-data.js";
 
 describe("chart gallery data", () => {
-  it("builds one deterministic engine-shaped result for every gallery adapter", () => {
+  it("builds one deterministic TSDB engine result for every native chart preview", () => {
     const result = createEngineResult();
-    const wide = toEngineWideTableModel(result);
-    const latest = toEngineLatestValueModel(result);
-    const histogram = toHistogramModel(wide);
+    const { store, query } = createGalleryMetricStore();
+    const gallery = createLibraryGalleryState("tremor");
 
+    expect(store.seriesCount).toBe(4);
+    expect(store.sampleCount).toBeGreaterThanOrEqual(72);
+    expect(store.name).toBe("chart-gallery-rowgroup");
+    expect(query).toMatchObject({
+      metric: "http.server.duration",
+      maxPoints: 18,
+    });
+    expect(result.scannedSeries).toBe(4);
+    expect(result.scannedSamples).toBe(72);
     expect(result.series).toHaveLength(4);
-    expect(wide.rows).toHaveLength(18);
     expect(LIBRARIES).toHaveLength(13);
-    expect(CHART_TYPES).toHaveLength(9);
-    expect(wide.series.map((series) => series.label)).toEqual([
+    expect(CHART_TYPES).toHaveLength(10);
+    expect(gallery.seriesLegend.map((series) => series.label)).toEqual([
       "checkout /cart 2xx",
       "checkout /pay 5xx",
       "api /search 2xx",
       "worker /jobs 2xx",
     ]);
-    expect(latest.rows).toHaveLength(4);
-    expect(histogram.buckets.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(72);
+    expect(gallery.histogram.buckets.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(72);
   });
 
-  it("creates library-native adapter previews for each supported chart type", () => {
+  it("creates library-native preview data through exported adapter calls", () => {
     for (const library of LIBRARIES) {
       for (const chart of library.charts) {
         const gallery = createGalleryState(library.id, chart);
-        const output = serializableAdapterModel(gallery.adapterModel);
+        const output = serializableAdapterOutput(gallery.adapterOutput);
 
         expect(gallery.library.id).toBe(library.id);
         expect(gallery.chartType).toBe(chart);
         expect(output).toBeTruthy();
         expect(gallery.snippets.query).toContain("engine.query");
-        expect(gallery.snippets.adapter).toContain("toEngine");
+        expect(gallery.snippets.query).toContain("new ScanEngine");
+        expect(gallery.snippets.query).toContain("new RowGroupStore");
+        expect(gallery.snippets.query).toContain("store.append");
+        expect(gallery.snippets.adapter).toContain(library.package);
+        expect(gallery.snippets.adapter).not.toContain("toEngineWideTableModel");
+        expect(gallery.snippets.adapter).not.toContain("toEngineLatestValueModel");
       }
     }
   });
@@ -57,10 +66,9 @@ describe("chart gallery data", () => {
       expect(gallery.charts.map((chart) => chart.chartType)).toEqual(library.charts);
       for (const chart of gallery.charts) {
         expect(chart.result).toBe(gallery.result);
-        expect(chart.wide).toBe(gallery.wide);
-        expect(chart.latest).toBe(gallery.latest);
+        expect(chart.seriesLegend).toBe(gallery.seriesLegend);
         expect(chart.histogram).toBe(gallery.histogram);
-        expect(serializableAdapterModel(chart.adapterModel)).toBeTruthy();
+        expect(serializableAdapterOutput(chart.adapterOutput)).toBeTruthy();
       }
     }
   });
@@ -71,6 +79,7 @@ describe("chart gallery data", () => {
 
       expect(library.package).toBeTruthy();
       expect(library.package).toContain("@otlpkit/adapters/");
+      expect(library.mark).toBeTruthy();
       expect(gallery.snippets.adapter).toContain(library.package);
       expect(gallery.snippets.adapter).not.toContain("not exported yet");
     }
@@ -82,62 +91,73 @@ describe("chart gallery data", () => {
   });
 
   it("emits recognizable native shapes for key libraries", () => {
-    expect(createGalleryState("tremor", "line").adapterModel).toMatchObject({
+    expect(createGalleryState("tremor", "line").adapterOutput).toMatchObject({
       index: "time",
       categories: expect.arrayContaining(["checkout /cart 2xx"]),
     });
-    expect(createGalleryState("recharts", "line").adapterModel).toMatchObject({
+    expect(createGalleryState("recharts", "line").adapterOutput).toMatchObject({
       xAxisKey: "time",
       series: expect.arrayContaining([
         expect.objectContaining({
-          dataKey: "__name__=http.server.duration,route=/cart,service=checkout,status_class=2xx",
+          id: "__name__=http.server.duration,route=/cart,service=checkout,status_class=2xx",
         }),
       ]),
     });
-    expect(createGalleryState("recharts", "donut").adapterModel).toMatchObject({
+    expect(createGalleryState("recharts", "donut").adapterOutput).toMatchObject({
       categoryKey: "label",
       valueKey: "value",
     });
-    expect(createGalleryState("echarts", "line").adapterModel.dataset[0].dimensions).toEqual([
+    expect(createGalleryState("recharts", "latestBar").adapterOutput).toMatchObject({
+      categoryKey: "label",
+      valueKey: "value",
+    });
+    expect(createGalleryState("chartjs", "latestBar").adapterOutput.type).toBe("bar");
+    expect(createGalleryState("echarts", "line").adapterOutput.dataset[0].dimensions).toEqual([
       "time",
       "checkout /cart 2xx",
       "checkout /pay 5xx",
       "api /search 2xx",
       "worker /jobs 2xx",
     ]);
-    expect(createGalleryState("uplot", "line").adapterModel.data).toHaveLength(5);
-    expect(createGalleryState("plotly", "donut").adapterModel.data[0].type).toBe("pie");
-    expect(createGalleryState("apexcharts", "gauge").adapterModel.chart.type).toBe("radialBar");
-    expect(createGalleryState("nivo", "bar").adapterModel).toMatchObject({
+    expect(createGalleryState("echarts", "latestBar").adapterOutput.series[0].type).toBe("bar");
+    expect(createGalleryState("uplot", "line").adapterOutput.data).toHaveLength(5);
+    expect(createGalleryState("plotly", "donut").adapterOutput.data[0].type).toBe("pie");
+    expect(createGalleryState("apexcharts", "gauge").adapterOutput.chart.type).toBe("radialBar");
+    expect(createGalleryState("nivo", "bar").adapterOutput).toMatchObject({
       indexBy: "time",
       keys: expect.arrayContaining([
         "__name__=http.server.duration,route=/cart,service=checkout,status_class=2xx",
       ]),
     });
-    expect(createGalleryState("observable", "sparkline").adapterModel.marks[0].mark).toBe("lineY");
-    expect(createGalleryState("victory", "bar").adapterModel[0]).toMatchObject({
+    expect(createGalleryState("observable", "sparkline").adapterOutput.marks[0].mark).toBe("lineY");
+    expect(createGalleryState("victory", "bar").adapterOutput[0]).toMatchObject({
       x: "checkout /cart 2xx",
       y: expect.any(Number),
     });
-    expect(createGalleryState("agcharts", "area").adapterModel.series[0].type).toBe("area");
-    expect(createGalleryState("highcharts", "scatter").adapterModel.chart.type).toBe("scatter");
-    expect(createGalleryState("highcharts", "histogram").adapterModel.chart.type).toBe("column");
-    expect(createGalleryState("vegalite", "scatter").adapterModel.mark).toBe("point");
+    expect(createGalleryState("agcharts", "area").adapterOutput.series[0].type).toBe("area");
+    expect(createGalleryState("highcharts", "scatter").adapterOutput.chart.type).toBe("scatter");
+    expect(createGalleryState("highcharts", "histogram").adapterOutput.chart.type).toBe("column");
+    expect(createGalleryState("vegalite", "scatter").adapterOutput.mark).toBe("point");
   });
 
-  it("changes preview values during live updates without changing adapter model shape", () => {
+  it("changes preview values during live updates without changing adapter output shape", () => {
     const first = createGalleryState("chartjs", "line", 0);
     const next = createGalleryState("chartjs", "line", 4);
 
-    expect(first.adapterModel.type).toBe(next.adapterModel.type);
-    expect(first.adapterModel.data.datasets[0].data[0].y).not.toBe(
-      next.adapterModel.data.datasets[0].data[0].y
+    expect(first.adapterOutput.type).toBe(next.adapterOutput.type);
+    expect(first.adapterOutput.data.datasets[0].data[0].y).not.toBe(
+      next.adapterOutput.data.datasets[0].data[0].y
     );
   });
 
   it("advances live data as a stable sliding append window", () => {
+    const initialStore = createGalleryMetricStore(0).store;
     const first = createEngineResult(0);
     const next = createEngineResult(1);
+    const nextStore = createGalleryMetricStore(1).store;
+
+    expect(nextStore).toBe(initialStore);
+    expect(nextStore.sampleCount).toBeGreaterThanOrEqual(76);
 
     for (let seriesIndex = 0; seriesIndex < first.series.length; seriesIndex++) {
       const firstSeries = first.series[seriesIndex];

--- a/site/charts/test/gallery-data.test.js
+++ b/site/charts/test/gallery-data.test.js
@@ -85,6 +85,22 @@ describe("chart gallery data", () => {
     }
   });
 
+  it("only advertises ApexCharts shapes backed by exported ApexCharts adapters", () => {
+    const apexCharts = LIBRARIES.find((library) => library.id === "apexcharts");
+
+    expect(apexCharts?.charts).toEqual([
+      "line",
+      "area",
+      "bar",
+      "donut",
+      "scatter",
+      "sparkline",
+      "gauge",
+    ]);
+    expect(apexCharts?.charts).not.toContain("histogram");
+    expect(apexCharts?.charts).not.toContain("latestBar");
+  });
+
   it("falls back to the first natural chart type when a library does not support a shape", () => {
     expect(getSupportedChart("uplot", "donut")).toBe("line");
     expect(getSupportedChart("tremor", "donut")).toBe("donut");
@@ -97,6 +113,7 @@ describe("chart gallery data", () => {
     });
     expect(createGalleryState("recharts", "line").adapterOutput).toMatchObject({
       xAxisKey: "time",
+      unit: "ms",
       series: expect.arrayContaining([
         expect.objectContaining({
           id: "__name__=http.server.duration,route=/cart,service=checkout,status_class=2xx",
@@ -106,10 +123,16 @@ describe("chart gallery data", () => {
     expect(createGalleryState("recharts", "donut").adapterOutput).toMatchObject({
       categoryKey: "label",
       valueKey: "value",
+      unit: "ms",
     });
     expect(createGalleryState("recharts", "latestBar").adapterOutput).toMatchObject({
       categoryKey: "label",
       valueKey: "value",
+      unit: "ms",
+    });
+    expect(createGalleryState("recharts", "histogram").adapterOutput).toMatchObject({
+      valueKey: "count",
+      unit: "samples",
     });
     expect(createGalleryState("chartjs", "latestBar").adapterOutput.type).toBe("bar");
     expect(createGalleryState("echarts", "line").adapterOutput.dataset[0].dimensions).toEqual([

--- a/site/charts/test/gallery-data.test.js
+++ b/site/charts/test/gallery-data.test.js
@@ -22,7 +22,7 @@ describe("chart gallery data", () => {
 
     expect(result.series).toHaveLength(4);
     expect(wide.rows).toHaveLength(18);
-    expect(LIBRARIES).toHaveLength(14);
+    expect(LIBRARIES).toHaveLength(13);
     expect(CHART_TYPES).toHaveLength(9);
     expect(wide.series.map((series) => series.label)).toEqual([
       "checkout /cart 2xx",
@@ -65,19 +65,14 @@ describe("chart gallery data", () => {
     }
   });
 
-  it("marks exported adapter snippets separately from adapter-shape-only sketches", () => {
+  it("only declares gallery libraries with exported adapter snippets", () => {
     for (const library of LIBRARIES) {
       const gallery = createGalleryState(library.id, library.charts[0]);
 
       expect(library.package).toBeTruthy();
-      if (library.status === "implemented" || library.status === "exported") {
-        expect(library.package).toContain("@otlpkit/adapters/");
-        expect(gallery.snippets.adapter).toContain(library.package);
-        expect(gallery.snippets.adapter).not.toContain("not exported yet");
-      } else {
-        expect(library.package).not.toContain("@otlpkit/adapters/");
-        expect(gallery.snippets.adapter).toContain("not exported yet");
-      }
+      expect(library.package).toContain("@otlpkit/adapters/");
+      expect(gallery.snippets.adapter).toContain(library.package);
+      expect(gallery.snippets.adapter).not.toContain("not exported yet");
     }
   });
 
@@ -130,7 +125,7 @@ describe("chart gallery data", () => {
     expect(createGalleryState("vegalite", "scatter").adapterModel.mark).toBe("point");
   });
 
-  it("changes preview values during live updates without changing adapter shape", () => {
+  it("changes preview values during live updates without changing adapter model shape", () => {
     const first = createGalleryState("chartjs", "line", 0);
     const next = createGalleryState("chartjs", "line", 4);
 

--- a/site/charts/test/gallery-real-adapters.test.js
+++ b/site/charts/test/gallery-real-adapters.test.js
@@ -57,13 +57,13 @@ describe("chart gallery integration with real adapters", () => {
     expect(model.tooltipKey).toBe(galleryLine.tooltipKey);
     expect(model.series).toEqual(galleryLine.series);
     expect(model.data).toEqual(galleryLine.data);
-    expect(toRechartsLatestValuesData(result, { seriesLabel: gallerySeriesLabel })).toEqual(
-      createGalleryState("recharts", "donut").adapterOutput
-    );
-    expect(toRechartsHistogramData(result, { seriesLabel: gallerySeriesLabel })).toEqual(
-      createGalleryState("recharts", "histogram").adapterOutput
-    );
-    expect(toRechartsScatterData(result, { seriesLabel: gallerySeriesLabel })).toEqual(
+    expect(
+      toRechartsLatestValuesData(result, { seriesLabel: gallerySeriesLabel, unit: "ms" })
+    ).toEqual(createGalleryState("recharts", "donut").adapterOutput);
+    expect(
+      toRechartsHistogramData(result, { seriesLabel: gallerySeriesLabel, unit: "samples" })
+    ).toEqual(createGalleryState("recharts", "histogram").adapterOutput);
+    expect(toRechartsScatterData(result, { seriesLabel: gallerySeriesLabel, unit: "ms" })).toEqual(
       createGalleryState("recharts", "scatter").adapterOutput
     );
   });

--- a/site/charts/test/gallery-real-adapters.test.js
+++ b/site/charts/test/gallery-real-adapters.test.js
@@ -29,7 +29,6 @@ import {
 import { toUPlotEngineTimeSeriesModel } from "../../../packages/adapters/src/uplot.js";
 import { toVegaLiteEngineSpec } from "../../../packages/adapters/src/vegalite.js";
 import { toVictoryEngineSeries } from "../../../packages/adapters/src/victory.js";
-import { toVisxEngineXYChartModel } from "../../../packages/adapters/src/visx.js";
 import {
   createEngineResult,
   createGalleryState,
@@ -141,9 +140,6 @@ describe("chart gallery integration with real adapters", () => {
     );
     expect(toVegaLiteEngineSpec(wide).mark).toBe(
       createGalleryState("vegalite", "line").adapterModel.mark
-    );
-    expect(toVisxEngineXYChartModel(wide).data[0]?.key).toBe(
-      createGalleryState("visx", "line").adapterModel.data[0]?.key
     );
   });
 });

--- a/site/charts/test/gallery-real-adapters.test.js
+++ b/site/charts/test/gallery-real-adapters.test.js
@@ -8,12 +8,16 @@ import {
   toEngineLatestValueModel,
   toEngineWideTableModel,
 } from "../../../packages/adapters/src/engine.js";
-import { toHighchartsEngineTimeSeriesOptions } from "../../../packages/adapters/src/highcharts.js";
+import {
+  toHighchartsEngineHistogramOptions,
+  toHighchartsEngineTimeSeriesOptions,
+} from "../../../packages/adapters/src/highcharts.js";
 import { toNivoEngineBarModel } from "../../../packages/adapters/src/nivo.js";
 import { toObservablePlotEngineModel } from "../../../packages/adapters/src/observable.js";
 import { toPlotlyEngineLatestValuesModel } from "../../../packages/adapters/src/plotly.js";
 import {
   toRechartsEngineHistogramModel,
+  toRechartsEngineLatestValuesModel,
   toRechartsEngineScatterModel,
   toRechartsEngineTimeSeriesModel,
 } from "../../../packages/adapters/src/recharts.js";
@@ -79,6 +83,7 @@ describe("chart gallery integration with real adapters", () => {
   it("backs the Recharts gallery examples with implemented row and dataKey adapters", () => {
     const result = createEngineResult();
     const wide = toEngineWideTableModel(result, { seriesLabel: gallerySeriesLabel });
+    const latest = toEngineLatestValueModel(result, { seriesLabel: gallerySeriesLabel });
     const model = toRechartsEngineTimeSeriesModel(wide, { unit: "ms" });
     const galleryLine = createGalleryState("recharts", "line").adapterModel;
 
@@ -86,6 +91,9 @@ describe("chart gallery integration with real adapters", () => {
     expect(model.tooltipKey).toBe(galleryLine.tooltipKey);
     expect(model.series).toEqual(galleryLine.series);
     expect(model.data).toEqual(galleryLine.data);
+    expect(toRechartsEngineLatestValuesModel(latest)).toEqual(
+      createGalleryState("recharts", "donut").adapterModel
+    );
     expect(toRechartsEngineHistogramModel(toEngineHistogramModel(wide))).toEqual(
       createGalleryState("recharts", "histogram").adapterModel
     );
@@ -127,6 +135,9 @@ describe("chart gallery integration with real adapters", () => {
     );
     expect(toHighchartsEngineTimeSeriesOptions(wide).series).toEqual(
       createGalleryState("highcharts", "line").adapterModel.series
+    );
+    expect(toHighchartsEngineHistogramOptions(histogram).series).toEqual(
+      createGalleryState("highcharts", "histogram").adapterModel.series
     );
     expect(toVegaLiteEngineSpec(wide).mark).toBe(
       createGalleryState("vegalite", "line").adapterModel.mark

--- a/site/charts/test/gallery-real-adapters.test.js
+++ b/site/charts/test/gallery-real-adapters.test.js
@@ -1,145 +1,115 @@
 import { describe, expect, it } from "vitest";
-import { toAgChartsEngineTimeSeriesOptions } from "../../../packages/adapters/src/agcharts.js";
-import { toApexChartsEngineLatestValuesOptions } from "../../../packages/adapters/src/apexcharts.js";
-import { toChartJsEngineTimeSeriesConfig } from "../../../packages/adapters/src/chartjs.js";
-import { toEChartsEngineHistogramOption } from "../../../packages/adapters/src/echarts.js";
+import { toAgChartsTimeSeriesOptions } from "../../../packages/adapters/src/agcharts.js";
+import { toApexChartsLatestValuesOptions } from "../../../packages/adapters/src/apexcharts.js";
+import { toChartJsTimeSeriesConfig } from "../../../packages/adapters/src/chartjs.js";
+import { toEChartsHistogramOption } from "../../../packages/adapters/src/echarts.js";
 import {
-  toEngineHistogramModel,
-  toEngineLatestValueModel,
-  toEngineWideTableModel,
-} from "../../../packages/adapters/src/engine.js";
-import {
-  toHighchartsEngineHistogramOptions,
-  toHighchartsEngineTimeSeriesOptions,
+  toHighchartsHistogramOptions,
+  toHighchartsTimeSeriesOptions,
 } from "../../../packages/adapters/src/highcharts.js";
-import { toNivoEngineBarModel } from "../../../packages/adapters/src/nivo.js";
-import { toObservablePlotEngineModel } from "../../../packages/adapters/src/observable.js";
-import { toPlotlyEngineLatestValuesModel } from "../../../packages/adapters/src/plotly.js";
+import { toNivoBarData } from "../../../packages/adapters/src/nivo.js";
+import { toObservablePlotOptions } from "../../../packages/adapters/src/observable.js";
+import { toPlotlyLatestValuesFigure } from "../../../packages/adapters/src/plotly.js";
 import {
-  toRechartsEngineHistogramModel,
-  toRechartsEngineLatestValuesModel,
-  toRechartsEngineScatterModel,
-  toRechartsEngineTimeSeriesModel,
+  toRechartsHistogramData,
+  toRechartsLatestValuesData,
+  toRechartsScatterData,
+  toRechartsTimeSeriesData,
 } from "../../../packages/adapters/src/recharts.js";
 import {
   toTremorBarListProps,
   toTremorDonutChartProps,
   toTremorLineChartProps,
 } from "../../../packages/adapters/src/tremor.js";
-import { toUPlotEngineTimeSeriesModel } from "../../../packages/adapters/src/uplot.js";
-import { toVegaLiteEngineSpec } from "../../../packages/adapters/src/vegalite.js";
-import { toVictoryEngineSeries } from "../../../packages/adapters/src/victory.js";
-import {
-  createEngineResult,
-  createGalleryState,
-  toEngineLatestValueModel as toGalleryLatestValueModel,
-  toEngineWideTableModel as toGalleryWideTableModel,
-} from "../js/gallery-data.js";
+import { toUPlotTimeSeriesArgs } from "../../../packages/adapters/src/uplot.js";
+import { toVegaLiteSpec } from "../../../packages/adapters/src/vegalite.js";
+import { toVictorySeries } from "../../../packages/adapters/src/victory.js";
+import { createEngineResult, createGalleryState } from "../js/gallery-data.js";
 
 describe("chart gallery integration with real adapters", () => {
-  it("keeps the gallery engine fixture aligned with package engine models", () => {
-    const result = createEngineResult();
-    const galleryWide = toGalleryWideTableModel(result);
-    const packageWide = toEngineWideTableModel(result, {
-      seriesLabel: gallerySeriesLabel,
-    });
-    const galleryLatest = toGalleryLatestValueModel(result);
-    const packageLatest = toEngineLatestValueModel(result, {
-      seriesLabel: gallerySeriesLabel,
-    });
-
-    expect(galleryWide.series.map(({ id, label }) => ({ id, label }))).toEqual(
-      packageWide.series.map(({ id, label }) => ({ id, label }))
-    );
-    expect(galleryWide.rows).toEqual(packageWide.rows);
-    expect(galleryLatest.rows.map(({ id, label, t, value }) => ({ id, label, t, value }))).toEqual(
-      packageLatest.rows.map(({ id, label, t, value }) => ({ id, label, t, value }))
-    );
-  });
-
   it("backs the Tremor gallery examples with implemented prop adapters", () => {
     const result = createEngineResult();
-    const wide = toEngineWideTableModel(result, { seriesLabel: gallerySeriesLabel });
-    const latest = toEngineLatestValueModel(result, { seriesLabel: gallerySeriesLabel });
-    const line = toTremorLineChartProps(wide);
-    const donut = toTremorDonutChartProps(latest);
-    const barList = toTremorBarListProps(latest);
-    const galleryLine = createGalleryState("tremor", "line").adapterModel;
+    const line = toTremorLineChartProps(result, { seriesLabel: gallerySeriesLabel });
+    const donut = toTremorDonutChartProps(result, { seriesLabel: gallerySeriesLabel });
+    const barList = toTremorBarListProps(result, { seriesLabel: gallerySeriesLabel });
+    const galleryLine = createGalleryState("tremor", "line").adapterOutput;
 
     expect(line.index).toBe("time");
     expect(line.categories).toEqual(galleryLine.categories);
-    expect(line.data[0]?.time).toBe(wide.rows[0]?.t);
+    expect(line.data[0]?.time).toBe(Number((result.series[0]?.timestamps[0] ?? 0n) / 1_000_000n));
     for (const category of line.categories) {
       expect(line.data[0]?.[category]).toBe(galleryLine.data[0]?.[category]);
     }
-    expect(line.meta.series.map((series) => series.id)).toEqual(
-      wide.series.map((series) => series.id)
-    );
-    expect(donut.data).toEqual(createGalleryState("tremor", "donut").adapterModel.data);
-    expect(barList.data).toEqual(createGalleryState("tremor", "barList").adapterModel.data);
+    expect(line.meta.series).toHaveLength(result.series.length);
+    expect(donut.data).toEqual(createGalleryState("tremor", "donut").adapterOutput.data);
+    expect(barList.data).toEqual(createGalleryState("tremor", "barList").adapterOutput.data);
   });
 
   it("backs the Recharts gallery examples with implemented row and dataKey adapters", () => {
     const result = createEngineResult();
-    const wide = toEngineWideTableModel(result, { seriesLabel: gallerySeriesLabel });
-    const latest = toEngineLatestValueModel(result, { seriesLabel: gallerySeriesLabel });
-    const model = toRechartsEngineTimeSeriesModel(wide, { unit: "ms" });
-    const galleryLine = createGalleryState("recharts", "line").adapterModel;
+    const model = toRechartsTimeSeriesData(result, {
+      seriesLabel: gallerySeriesLabel,
+      unit: "ms",
+    });
+    const galleryLine = createGalleryState("recharts", "line").adapterOutput;
 
     expect(model.xAxisKey).toBe(galleryLine.xAxisKey);
     expect(model.tooltipKey).toBe(galleryLine.tooltipKey);
     expect(model.series).toEqual(galleryLine.series);
     expect(model.data).toEqual(galleryLine.data);
-    expect(toRechartsEngineLatestValuesModel(latest)).toEqual(
-      createGalleryState("recharts", "donut").adapterModel
+    expect(toRechartsLatestValuesData(result, { seriesLabel: gallerySeriesLabel })).toEqual(
+      createGalleryState("recharts", "donut").adapterOutput
     );
-    expect(toRechartsEngineHistogramModel(toEngineHistogramModel(wide))).toEqual(
-      createGalleryState("recharts", "histogram").adapterModel
+    expect(toRechartsHistogramData(result, { seriesLabel: gallerySeriesLabel })).toEqual(
+      createGalleryState("recharts", "histogram").adapterOutput
     );
-    expect(toRechartsEngineScatterModel(wide)).toEqual(
-      createGalleryState("recharts", "scatter").adapterModel
+    expect(toRechartsScatterData(result, { seriesLabel: gallerySeriesLabel })).toEqual(
+      createGalleryState("recharts", "scatter").adapterOutput
     );
   });
 
   it("backs package-rendered gallery examples with exported engine adapters", () => {
     const result = createEngineResult();
-    const wide = toEngineWideTableModel(result, { seriesLabel: gallerySeriesLabel });
-    const latest = toEngineLatestValueModel(result, { seriesLabel: gallerySeriesLabel });
-    const histogram = toEngineHistogramModel(wide);
-
-    expect(toChartJsEngineTimeSeriesConfig(wide).data.datasets).toEqual(
-      createGalleryState("chartjs", "line").adapterModel.data.datasets
+    expect(
+      toChartJsTimeSeriesConfig(result, { seriesLabel: gallerySeriesLabel }).data.datasets
+    ).toEqual(createGalleryState("chartjs", "line").adapterOutput.data.datasets);
+    expect(toEChartsHistogramOption(result, { seriesLabel: gallerySeriesLabel }).dataset).toEqual(
+      createGalleryState("echarts", "histogram").adapterOutput.dataset
     );
-    expect(toEChartsEngineHistogramOption(histogram).dataset).toEqual(
-      createGalleryState("echarts", "histogram").adapterModel.dataset
+    expect(toUPlotTimeSeriesArgs(result, { seriesLabel: gallerySeriesLabel }).data).toEqual(
+      createGalleryState("uplot", "line").adapterOutput.data
     );
-    expect(toUPlotEngineTimeSeriesModel(wide).data).toEqual(
-      createGalleryState("uplot", "line").adapterModel.data
+    expect(toNivoBarData(result, { seriesLabel: gallerySeriesLabel })).toEqual(
+      createGalleryState("nivo", "bar").adapterOutput
     );
-    expect(toNivoEngineBarModel(wide)).toEqual(createGalleryState("nivo", "bar").adapterModel);
-    expect(toObservablePlotEngineModel(wide).marks).toEqual(
-      createGalleryState("observable", "line").adapterModel.marks
+    expect(toObservablePlotOptions(result, { seriesLabel: gallerySeriesLabel }).marks).toEqual(
+      createGalleryState("observable", "line").adapterOutput.marks
     );
-    expect(toPlotlyEngineLatestValuesModel(latest).data).toEqual(
-      createGalleryState("plotly", "donut").adapterModel.data
+    expect(toPlotlyLatestValuesFigure(result, { seriesLabel: gallerySeriesLabel }).data).toEqual(
+      createGalleryState("plotly", "donut").adapterOutput.data
     );
-    expect(toApexChartsEngineLatestValuesOptions(latest, { chartType: "gauge" }).series).toEqual(
-      createGalleryState("apexcharts", "gauge").adapterModel.series
+    expect(
+      toApexChartsLatestValuesOptions(result, {
+        chartType: "gauge",
+        seriesLabel: gallerySeriesLabel,
+      }).series
+    ).toEqual(createGalleryState("apexcharts", "gauge").adapterOutput.series);
+    expect(
+      toVictorySeries(result, { seriesLabel: gallerySeriesLabel }).map((series) => series.component)
+    ).toEqual(
+      createGalleryState("victory", "line").adapterOutput.map((series) => series.component)
     );
-    expect(toVictoryEngineSeries(wide).map((series) => series.component)).toEqual(
-      createGalleryState("victory", "line").adapterModel.map((series) => series.component)
+    expect(toAgChartsTimeSeriesOptions(result, { seriesLabel: gallerySeriesLabel }).series).toEqual(
+      createGalleryState("agcharts", "line").adapterOutput.series
     );
-    expect(toAgChartsEngineTimeSeriesOptions(wide).series).toEqual(
-      createGalleryState("agcharts", "line").adapterModel.series
-    );
-    expect(toHighchartsEngineTimeSeriesOptions(wide).series).toEqual(
-      createGalleryState("highcharts", "line").adapterModel.series
-    );
-    expect(toHighchartsEngineHistogramOptions(histogram).series).toEqual(
-      createGalleryState("highcharts", "histogram").adapterModel.series
-    );
-    expect(toVegaLiteEngineSpec(wide).mark).toBe(
-      createGalleryState("vegalite", "line").adapterModel.mark
+    expect(
+      toHighchartsTimeSeriesOptions(result, { seriesLabel: gallerySeriesLabel }).series
+    ).toEqual(createGalleryState("highcharts", "line").adapterOutput.series);
+    expect(
+      toHighchartsHistogramOptions(result, { seriesLabel: gallerySeriesLabel }).series
+    ).toEqual(createGalleryState("highcharts", "histogram").adapterOutput.series);
+    expect(toVegaLiteSpec(result, { seriesLabel: gallerySeriesLabel }).mark).toBe(
+      createGalleryState("vegalite", "line").adapterOutput.mark
     );
   });
 });

--- a/site/charts/test/gallery-renderers.test.js
+++ b/site/charts/test/gallery-renderers.test.js
@@ -1,29 +1,12 @@
 import { describe, expect, it } from "vitest";
 
+import { LIBRARIES } from "../js/gallery-data.js";
 import { hasPackageRenderer } from "../js/gallery-renderers.js";
 
 describe("chart gallery package renderers", () => {
-  it("marks every browser-mounted chart package as package-backed", () => {
-    expect(
-      [
-        "tremor",
-        "recharts",
-        "chartjs",
-        "echarts",
-        "uplot",
-        "plotly",
-        "apexcharts",
-        "highcharts",
-        "vegalite",
-        "nivo",
-        "observable",
-        "victory",
-        "agcharts",
-      ].filter(hasPackageRenderer)
-    ).toHaveLength(13);
-  });
-
-  it("keeps adapter-shape-only libraries out of the package-rendered set", () => {
-    expect(hasPackageRenderer("visx")).toBe(false);
+  it("requires every gallery library to have a native package renderer", () => {
+    expect(LIBRARIES.map((library) => library.id).filter(hasPackageRenderer)).toEqual(
+      LIBRARIES.map((library) => library.id)
+    );
   });
 });

--- a/site/charts/vite.config.ts
+++ b/site/charts/vite.config.ts
@@ -1,9 +1,43 @@
+import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
+
+const siteRoot = resolve(__dirname, "..");
+
+const sharedSiteAssets = new Map([
+  [
+    "/o11ykit/styles.css",
+    { file: resolve(siteRoot, "styles.css"), contentType: "text/css; charset=utf-8" },
+  ],
+  ["/o11ykit/logo.svg", { file: resolve(siteRoot, "logo.svg"), contentType: "image/svg+xml" }],
+]);
 
 export default defineConfig({
   base: process.env.BASE_PATH ?? "/o11ykit/charts/",
   root: resolve(__dirname),
+  plugins: [
+    {
+      name: "serve-o11ykit-shared-assets",
+      configureServer(server) {
+        server.middlewares.use(async (req, res, next) => {
+          const pathname = req.url?.split("?")[0] ?? "";
+          const asset = sharedSiteAssets.get(pathname);
+          if (!asset) {
+            next();
+            return;
+          }
+
+          res.setHeader("Content-Type", asset.contentType);
+          res.end(await readFile(asset.file));
+        });
+      },
+    },
+  ],
+  resolve: {
+    alias: {
+      stardb: resolve(__dirname, "js/stardb-browser.ts"),
+    },
+  },
   build: {
     outDir: "dist",
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- rename the chart adapter surface around library-native inputs, so the public happy path is `engine.query(...) result -> published adapter -> native chart input`
- keep reusable engine normalization helpers in `@otlpkit/adapters/engine`, but remove the wide/latest model step from gallery docs and examples
- expand real native gallery coverage, including latest-value bars for Recharts, Chart.js, and ECharts
- make the gallery prove the contract: deterministic samples are appended into `RowGroupStore`, queried with `ScanEngine`, converted with exported adapters, and rendered by the actual chart packages
- polish the gallery UX by removing preview-only graph art, removing duplicate hardcoded legends, tightening live-update rendering, moving code buttons into card headers, and adding library logos/fallback marks
- add `AGENTS.md` guidance to preserve the project rule: no fake adapter layers or gallery-only chart renderers
- keep older view-frame examples honest by switching them to the explicit `View*` adapter names instead of stale engine-adapter names

## Validation
- `npx biome check packages/adapters site/charts AGENTS.md`
- `npx biome check examples/chartjs/src/main.ts examples/echarts/src/main.ts examples/recharts/src/main.tsx examples/uplot/src/main.ts examples/demo/src/main.tsx`
- `git diff --check`
- `npm run typecheck:packages`
- `npm run typecheck:examples`
- `npx vitest run site/charts/test/gallery-data.test.js site/charts/test/gallery-content.test.js site/charts/test/gallery-real-adapters.test.js site/charts/test/gallery-renderers.test.js --no-coverage`
- `BASE_PATH=/o11ykit/charts/ npx vite build site/charts`
- `npm run build`
- `make test-fast` (79 files, 1222 tests)

## Browser checks
- verified the running gallery has no `librarySummary`, no `.mini-legend`, no bottom chart action rows, and all visible chart render targets report rendered
- smoke-tested Tremor/Recharts/Chart.js/ECharts/Highcharts gallery rendering and a 60 Hz live-refresh toggle

## Notes
- Visx remains exported as a low-level compositional adapter, but stays out of the gallery because it is not a native chart renderer card in this React 19 gallery path.
- Some library picker logos come from Simple Icons or upstream/public favicons/avatars; uPlot and Nivo keep monogram fallbacks where I did not find a reliable lightweight public logo URL.
