### PR TITLE
Expand native chart adapter coverage

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -58,6 +58,7 @@
         "packages/o11ylogsdb/src/chunk.ts",
         "packages/o11ylogsdb/src/drain.ts",
         "packages/o11ylogsdb/bench/**",
+        "packages/o11ylogsdb/test/**",
         "packages/o11ytsdb/test/**"
       ],
       "linter": {

--- a/biome.json
+++ b/biome.json
@@ -58,8 +58,7 @@
         "packages/o11ylogsdb/src/chunk.ts",
         "packages/o11ylogsdb/src/drain.ts",
         "packages/o11ylogsdb/bench/**",
-        "packages/o11ylogsdb/test/**",
-        "packages/o11ytsdb/test/**"
+        "packages/o11ylogsdb/test/**"
       ],
       "linter": {
         "rules": {

--- a/biome.json
+++ b/biome.json
@@ -19,7 +19,8 @@
       "!examples/demo/src/browser-scraper.ts",
       "!octo11y",
       "!packages/o11ytsdb/bench",
-      "!research"
+      "!research",
+      "!**/*.html"
     ]
   },
   "formatter": {

--- a/octo11y/package-lock.json
+++ b/octo11y/package-lock.json
@@ -1621,9 +1621,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.129.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+      "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1837,9 +1837,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
       "cpu": [
         "arm64"
       ],
@@ -1854,9 +1854,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
       "cpu": [
         "arm64"
       ],
@@ -1871,9 +1871,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
       "cpu": [
         "x64"
       ],
@@ -1888,9 +1888,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+      "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
       "cpu": [
         "x64"
       ],
@@ -1905,9 +1905,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
       "cpu": [
         "arm"
       ],
@@ -1922,9 +1922,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
       "cpu": [
         "arm64"
       ],
@@ -1939,9 +1939,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
       "cpu": [
         "arm64"
       ],
@@ -1956,9 +1956,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+      "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
       "cpu": [
         "ppc64"
       ],
@@ -1973,9 +1973,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+      "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
       "cpu": [
         "s390x"
       ],
@@ -1990,9 +1990,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
       "cpu": [
         "x64"
       ],
@@ -2007,9 +2007,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
       "cpu": [
         "x64"
       ],
@@ -2024,9 +2024,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+      "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
       "cpu": [
         "arm64"
       ],
@@ -2041,9 +2041,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+      "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
       "cpu": [
         "wasm32"
       ],
@@ -2060,9 +2060,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
       "cpu": [
         "arm64"
       ],
@@ -2077,9 +2077,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
       "cpu": [
         "x64"
       ],
@@ -2094,9 +2094,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+      "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2511,9 +2511,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -5176,9 +5176,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -5410,14 +5410,14 @@
       "license": "Unlicense"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+      "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.129.0",
+        "@rolldown/pluginutils": "1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -5426,21 +5426,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.0",
+        "@rolldown/binding-darwin-arm64": "1.0.0",
+        "@rolldown/binding-darwin-x64": "1.0.0",
+        "@rolldown/binding-freebsd-x64": "1.0.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-musl": "1.0.0",
+        "@rolldown/binding-openharmony-arm64": "1.0.0",
+        "@rolldown/binding-wasm32-wasi": "1.0.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/rollup": {
@@ -6026,7 +6026,7 @@
       },
       "devDependencies": {
         "@preact/preset-vite": "^2.9.0",
-        "vite": "^8.0.10"
+        "vite": "^8.0.11"
       }
     },
     "packages/dashboard/node_modules/@esbuild/aix-ppc64": {
@@ -6542,16 +6542,16 @@
       }
     },
     "packages/dashboard/node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+      "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -6568,7 +6568,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -33,7 +33,7 @@ The goal is to preserve each chart library's idioms:
 - uPlot: aligned columnar arrays + minimal option scaffolding
 - Plotly: traces plus layout
 - ApexCharts: options plus series arrays
-- Nivo: nested series, bar keys, and pie data
+- Nivo: nested series, bar keys, pie data, and bar-ready latest/histogram data
 - Observable Plot: tidy rows plus marks
 - Victory: component-oriented data series
 - AG Charts and Highcharts: option trees with explicit series keys
@@ -63,6 +63,11 @@ not in the gallery because it is not a native chart renderer with a React 19-cle
 | uPlot | exported | aligned arrays |
 | Nivo, Observable Plot, Plotly, ApexCharts, Victory, AG Charts, Highcharts, Vega-Lite | exported, package-rendered gallery | library-native inputs |
 | Visx | exported, not gallery-mounted | low-level accessors, series arrays, and scale hints |
+
+The gallery is also the support contract. If a chart shape appears there, the card is backed by a
+published adapter function and the real chart package renderer. If a library can only support a
+shape through custom drawing or a gallery-only translation, it should stay out of the gallery until
+the package adapter exposes a native path.
 
 ## Ergonomics Audit
 
@@ -156,6 +161,69 @@ New engine-backed adapters should keep the same user contract:
 - Keep sparse points as `null` when the chart library can represent gaps.
 - Filter `null` latest values for donut, pie, and bar-list charts.
 - Add gallery coverage and tests that compare the gallery example with the exported adapter.
+
+### Package-shaped recipes
+
+These examples show the intended ergonomics for package-backed adapters. The function names describe
+the native object returned, not an o11ykit intermediate DTO.
+
+```ts
+import {
+  toApexChartsHistogramOptions,
+  toApexChartsLatestValuesOptions,
+  toApexChartsTimeSeriesOptions,
+} from "@otlpkit/adapters/apexcharts";
+
+const line = toApexChartsTimeSeriesOptions(result, { chartType: "line", seriesLabel });
+const latestBars = toApexChartsLatestValuesOptions(result, {
+  chartType: "latestBar",
+  seriesLabel,
+});
+const histogram = toApexChartsHistogramOptions(result, { bucketCount: 12, seriesLabel });
+
+await new ApexCharts(node, line).render();
+```
+
+```ts
+import {
+  toNivoHistogramBarData,
+  toNivoLatestBarData,
+  toNivoLineSeries,
+} from "@otlpkit/adapters/nivo";
+
+const lineData = toNivoLineSeries(result, { seriesLabel });
+const latestBarData = toNivoLatestBarData(result, { seriesLabel });
+const histogramBarData = toNivoHistogramBarData(result, { bucketCount: 10, seriesLabel });
+```
+
+```ts
+import {
+  toAgChartsHistogramOptions,
+  toAgChartsLatestValuesOptions,
+  toAgChartsTimeSeriesOptions,
+} from "@otlpkit/adapters/agcharts";
+
+const options = toAgChartsTimeSeriesOptions(result, { chartType: "area", seriesLabel });
+const latest = toAgChartsLatestValuesOptions(result, { chartType: "latestBar", seriesLabel });
+const histogram = toAgChartsHistogramOptions(result, { bucketCount: 10, seriesLabel });
+
+AgCharts.create(options);
+```
+
+```ts
+import {
+  toHighchartsHistogramOptions,
+  toHighchartsLatestValuesOptions,
+  toPlotlyLatestValuesFigure,
+} from "@otlpkit/adapters";
+
+const highchartsBars = toHighchartsLatestValuesOptions(result, {
+  chartType: "latestBar",
+  seriesLabel,
+});
+const highchartsHistogram = toHighchartsHistogramOptions(result, { bucketCount: 10, seriesLabel });
+const plotlyBars = toPlotlyLatestValuesFigure(result, { chartType: "latestBar", seriesLabel });
+```
 
 ### Tremor
 

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -214,14 +214,18 @@ AgCharts.create(options);
 import {
   toHighchartsHistogramOptions,
   toHighchartsLatestValuesOptions,
-  toPlotlyLatestValuesFigure,
-} from "@otlpkit/adapters";
+} from "@otlpkit/adapters/highcharts";
 
 const highchartsBars = toHighchartsLatestValuesOptions(result, {
   chartType: "latestBar",
   seriesLabel,
 });
 const highchartsHistogram = toHighchartsHistogramOptions(result, { bucketCount: 10, seriesLabel });
+```
+
+```ts
+import { toPlotlyLatestValuesFigure } from "@otlpkit/adapters/plotly";
+
 const plotlyBars = toPlotlyLatestValuesFigure(result, { chartType: "latestBar", seriesLabel });
 ```
 

--- a/packages/adapters/src/agcharts.ts
+++ b/packages/adapters/src/agcharts.ts
@@ -2,19 +2,30 @@ import {
   asEngineLatestValueModel,
   asEngineWideTableModel,
   type EngineAdapterOptions,
+  type EngineHistogramOptions,
   type EngineLatestValueInput,
   type EngineWideTableInput,
 } from "./engine.js";
 import { gaugeValue, rowToRecord } from "./engine-chart-shared.js";
 
-export type AgChartsChartType = "line" | "area" | "bar" | "donut" | "scatter" | "gauge";
+export type AgChartsChartType =
+  | "line"
+  | "area"
+  | "bar"
+  | "donut"
+  | "latestBar"
+  | "histogram"
+  | "scatter"
+  | "gauge";
 
 export interface AgChartsSeriesOptions {
-  readonly type: "line" | "area" | "bar" | "donut" | "scatter";
+  readonly type: "line" | "area" | "bar" | "donut" | "histogram" | "scatter";
   readonly id?: string;
   readonly xKey?: string;
   readonly yKey?: string;
   readonly yName?: string;
+  readonly xName?: string;
+  readonly binCount?: number;
   readonly angleKey?: string;
   readonly calloutLabelKey?: string;
 }
@@ -86,10 +97,38 @@ export function toAgChartsLatestValuesOptions(
       scale: { min: 0, max: 200 },
     };
   }
+  if (chartType === "bar" || chartType === "latestBar") {
+    return {
+      data: latest.rows.flatMap((row) =>
+        row.value === null ? [] : [{ label: row.label, value: row.value }]
+      ),
+      series: [{ type: "bar", xKey: "label", yKey: "value", yName: "latest" }],
+    };
+  }
   return {
     data: latest.rows.flatMap((row) =>
       row.value === null ? [] : [{ label: row.label, value: row.value }]
     ),
     series: [{ type: "donut", angleKey: "value", calloutLabelKey: "label" }],
+  };
+}
+
+export function toAgChartsHistogramOptions(
+  model: EngineWideTableInput,
+  options: EngineAdapterOptions & EngineHistogramOptions = {}
+): AgChartsOptions {
+  const wide = asEngineWideTableModel(model, options);
+  return {
+    data: wide.rows.flatMap((row) =>
+      row.values.flatMap((value) => (value === null || !Number.isFinite(value) ? [] : [{ value }]))
+    ),
+    series: [
+      {
+        type: "histogram",
+        xKey: "value",
+        xName: "value",
+        ...(options.bucketCount ? { binCount: options.bucketCount } : {}),
+      },
+    ],
   };
 }

--- a/packages/adapters/src/agcharts.ts
+++ b/packages/adapters/src/agcharts.ts
@@ -2,9 +2,11 @@ import {
   asEngineLatestValueModel,
   asEngineWideTableModel,
   type EngineAdapterOptions,
+  type EngineHistogramInput,
   type EngineHistogramOptions,
   type EngineLatestValueInput,
   type EngineWideTableInput,
+  isEngineHistogramModel,
 } from "./engine.js";
 import { gaugeValue, rowToRecord } from "./engine-chart-shared.js";
 
@@ -114,14 +116,23 @@ export function toAgChartsLatestValuesOptions(
 }
 
 export function toAgChartsHistogramOptions(
-  model: EngineWideTableInput,
+  model: EngineHistogramInput,
   options: EngineAdapterOptions & EngineHistogramOptions = {}
 ): AgChartsOptions {
-  const wide = asEngineWideTableModel(model, options);
+  // AG Charts performs its own binning so it needs raw values.
+  // If given a pre-binned EngineHistogramModel, synthesise individual data
+  // points from bucket midpoints so the library can re-bin them.
+  const rawData: Array<{ value: number }> = isEngineHistogramModel(model)
+    ? model.buckets.flatMap((bucket) =>
+        Array.from({ length: bucket.count }, () => ({ value: (bucket.start + bucket.end) / 2 }))
+      )
+    : asEngineWideTableModel(model, options).rows.flatMap((row) =>
+        row.values.flatMap((value) =>
+          value === null || !Number.isFinite(value) ? [] : [{ value }]
+        )
+      );
   return {
-    data: wide.rows.flatMap((row) =>
-      row.values.flatMap((value) => (value === null || !Number.isFinite(value) ? [] : [{ value }]))
-    ),
+    data: rawData,
     series: [
       {
         type: "histogram",

--- a/packages/adapters/src/agcharts.ts
+++ b/packages/adapters/src/agcharts.ts
@@ -121,11 +121,15 @@ export function toAgChartsHistogramOptions(
 ): AgChartsOptions {
   // AG Charts performs its own binning so it needs raw values.
   // If given a pre-binned EngineHistogramModel, synthesise individual data
-  // points from bucket midpoints so the library can re-bin them.
+  // points from bucket midpoints. Cap at MAX_SYNTHETIC per bucket to avoid
+  // unbounded memory allocation for large counts.
+  const MAX_SYNTHETIC = 1_000;
   const rawData: Array<{ value: number }> = isEngineHistogramModel(model)
-    ? model.buckets.flatMap((bucket) =>
-        Array.from({ length: bucket.count }, () => ({ value: (bucket.start + bucket.end) / 2 }))
-      )
+    ? model.buckets.flatMap((bucket) => {
+        const count = Math.min(bucket.count, MAX_SYNTHETIC);
+        const mid = (bucket.start + bucket.end) / 2;
+        return Array.from({ length: count }, () => ({ value: mid }));
+      })
     : asEngineWideTableModel(model, options).rows.flatMap((row) =>
         row.values.flatMap((value) =>
           value === null || !Number.isFinite(value) ? [] : [{ value }]

--- a/packages/adapters/src/apexcharts.ts
+++ b/packages/adapters/src/apexcharts.ts
@@ -1,7 +1,10 @@
 import {
+  asEngineHistogramModel,
   asEngineLatestValueModel,
   asEngineWideTableModel,
   type EngineAdapterOptions,
+  type EngineHistogramInput,
+  type EngineHistogramOptions,
   type EngineLatestValueInput,
   type EngineWideTableInput,
 } from "./engine.js";
@@ -12,6 +15,8 @@ export type ApexChartsChartType =
   | "area"
   | "bar"
   | "donut"
+  | "latestBar"
+  | "histogram"
   | "scatter"
   | "sparkline"
   | "gauge";
@@ -19,6 +24,7 @@ export type ApexChartsChartType =
 export interface ApexChartsAdapterOptions extends EngineAdapterOptions {
   readonly chartType?: ApexChartsChartType;
   readonly chartId?: string;
+  readonly title?: string;
 }
 
 export interface ApexChartsOptions {
@@ -29,7 +35,10 @@ export interface ApexChartsOptions {
   };
   readonly series: readonly unknown[];
   readonly labels?: readonly string[];
-  readonly xaxis?: { readonly type: "datetime" | "category" };
+  readonly xaxis?: {
+    readonly type: "datetime" | "category";
+    readonly categories?: readonly string[];
+  };
   readonly stroke?: { readonly curve: "smooth" };
   readonly fill?: { readonly opacity: number };
 }
@@ -74,10 +83,31 @@ export function toApexChartsLatestValuesOptions(
     };
   }
   const rows = latest.rows.filter((row) => row.value !== null);
+  if (chartType === "bar" || chartType === "latestBar") {
+    return {
+      chart: { ...(options.chartId ? { id: options.chartId } : {}), type: "bar" },
+      xaxis: { type: "category", categories: rows.map((row) => row.label) },
+      series: [{ name: options.title ?? "latest", data: rows.map((row) => row.value ?? 0) }],
+    };
+  }
   return {
     chart: { ...(options.chartId ? { id: options.chartId } : {}), type: "donut" },
     labels: rows.map((row) => row.label),
     series: rows.map((row) => row.value ?? 0),
+  };
+}
+
+export function toApexChartsHistogramOptions(
+  model: EngineHistogramInput,
+  options: ApexChartsAdapterOptions & EngineHistogramOptions = {}
+): ApexChartsOptions {
+  const histogram = asEngineHistogramModel(model, options);
+  return {
+    chart: { ...(options.chartId ? { id: options.chartId } : {}), type: "bar" },
+    xaxis: { type: "category", categories: histogram.buckets.map((bucket) => bucket.label) },
+    series: [
+      { name: options.title ?? "samples", data: histogram.buckets.map((bucket) => bucket.count) },
+    ],
   };
 }
 

--- a/packages/adapters/src/highcharts.ts
+++ b/packages/adapters/src/highcharts.ts
@@ -17,6 +17,7 @@ export type HighchartsChartType =
   | "area"
   | "bar"
   | "donut"
+  | "latestBar"
   | "histogram"
   | "scatter"
   | "sparkline"
@@ -70,12 +71,20 @@ export function toHighchartsLatestValuesOptions(
       series: [{ name: "average", data: [gaugeValue(latest)] }],
     };
   }
+  const rows = latest.rows.filter((row) => row.value !== null);
+  if (chartType === "bar" || chartType === "latestBar") {
+    return {
+      chart: { type: "bar" },
+      xAxis: { categories: rows.map((row) => row.label) },
+      series: [{ name: "latest", type: "bar", data: rows.map((row) => row.value ?? 0) }],
+    };
+  }
   return {
     chart: { type: "pie" },
     plotOptions: { pie: { innerSize: "55%" } },
     series: [
       {
-        data: latest.rows.flatMap((row) => (row.value === null ? [] : [[row.label, row.value]])),
+        data: rows.map((row) => [row.label, row.value]),
       },
     ],
   };

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,9 +1,11 @@
 import {
+  toAgChartsHistogramOptions,
   toAgChartsLatestValuesOptions,
   toAgChartsTimeSeriesOptions,
   toAgChartsUpdateDelta,
 } from "./agcharts.js";
 import {
+  toApexChartsHistogramOptions,
   toApexChartsLatestValuesOptions,
   toApexChartsSeriesUpdate,
   toApexChartsTimeSeriesOptions,
@@ -32,6 +34,10 @@ import {
 import {
   toNivoBarData,
   toNivoBarProps,
+  toNivoHistogramBarData,
+  toNivoHistogramBarProps,
+  toNivoLatestBarData,
+  toNivoLatestBarProps,
   toNivoLineProps,
   toNivoLineSeries,
   toNivoPieData,
@@ -72,9 +78,11 @@ import { toVisxHistogramModel, toVisxLatestValuesModel, toVisxXYChartModel } fro
 import { traceWaterfallToLaneRows } from "./waterfall.js";
 
 export const adapterModules: {
+  readonly toAgChartsHistogramOptions: typeof toAgChartsHistogramOptions;
   readonly toAgChartsLatestValuesOptions: typeof toAgChartsLatestValuesOptions;
   readonly toAgChartsTimeSeriesOptions: typeof toAgChartsTimeSeriesOptions;
   readonly toAgChartsUpdateDelta: typeof toAgChartsUpdateDelta;
+  readonly toApexChartsHistogramOptions: typeof toApexChartsHistogramOptions;
   readonly toApexChartsLatestValuesOptions: typeof toApexChartsLatestValuesOptions;
   readonly toApexChartsSeriesUpdate: typeof toApexChartsSeriesUpdate;
   readonly toApexChartsTimeSeriesOptions: typeof toApexChartsTimeSeriesOptions;
@@ -95,6 +103,10 @@ export const adapterModules: {
   readonly toHighchartsTimeSeriesOptions: typeof toHighchartsTimeSeriesOptions;
   readonly toNivoBarData: typeof toNivoBarData;
   readonly toNivoBarProps: typeof toNivoBarProps;
+  readonly toNivoHistogramBarData: typeof toNivoHistogramBarData;
+  readonly toNivoHistogramBarProps: typeof toNivoHistogramBarProps;
+  readonly toNivoLatestBarData: typeof toNivoLatestBarData;
+  readonly toNivoLatestBarProps: typeof toNivoLatestBarProps;
   readonly toNivoLineSeries: typeof toNivoLineSeries;
   readonly toNivoLineProps: typeof toNivoLineProps;
   readonly toNivoPieData: typeof toNivoPieData;
@@ -131,9 +143,11 @@ export const adapterModules: {
   readonly toVisxXYChartModel: typeof toVisxXYChartModel;
   readonly traceWaterfallToLaneRows: typeof traceWaterfallToLaneRows;
 } = {
+  toAgChartsHistogramOptions,
   toAgChartsLatestValuesOptions,
   toAgChartsTimeSeriesOptions,
   toAgChartsUpdateDelta,
+  toApexChartsHistogramOptions,
   toApexChartsLatestValuesOptions,
   toApexChartsSeriesUpdate,
   toApexChartsTimeSeriesOptions,
@@ -154,6 +168,10 @@ export const adapterModules: {
   toHighchartsTimeSeriesOptions,
   toNivoBarData,
   toNivoBarProps,
+  toNivoHistogramBarData,
+  toNivoHistogramBarProps,
+  toNivoLatestBarData,
+  toNivoLatestBarProps,
   toNivoLineSeries,
   toNivoLineProps,
   toNivoPieData,
@@ -192,11 +210,13 @@ export const adapterModules: {
 };
 
 export {
+  toAgChartsHistogramOptions,
   toAgChartsLatestValuesOptions,
   toAgChartsTimeSeriesOptions,
   toAgChartsUpdateDelta,
 } from "./agcharts.js";
 export {
+  toApexChartsHistogramOptions,
   toApexChartsLatestValuesOptions,
   toApexChartsSeriesUpdate,
   toApexChartsTimeSeriesOptions,
@@ -237,6 +257,10 @@ export {
   toHighchartsTimeSeriesOptions,
   toNivoBarData,
   toNivoBarProps,
+  toNivoHistogramBarData,
+  toNivoHistogramBarProps,
+  toNivoLatestBarData,
+  toNivoLatestBarProps,
   toNivoLineProps,
   toNivoLineSeries,
   toNivoPieData,

--- a/packages/adapters/src/nivo.ts
+++ b/packages/adapters/src/nivo.ts
@@ -1,7 +1,10 @@
 import {
+  asEngineHistogramModel,
   asEngineLatestValueModel,
   asEngineWideTableModel,
   type EngineAdapterOptions,
+  type EngineHistogramInput,
+  type EngineHistogramOptions,
   type EngineLatestValueInput,
   type EngineWideTableInput,
 } from "./engine.js";
@@ -18,7 +21,7 @@ export interface NivoSeries {
 }
 
 export interface NivoBarData {
-  readonly data: readonly Record<string, number | null>[];
+  readonly data: readonly Record<string, number | string | null>[];
   readonly keys: readonly string[];
   readonly indexBy: string;
 }
@@ -93,6 +96,52 @@ export function toNivoBarProps(
 ): NivoBarProps {
   return {
     ...toNivoBarData(model, options),
+    groupMode: options.groupMode ?? "grouped",
+  };
+}
+
+export function toNivoLatestBarData(
+  model: EngineLatestValueInput,
+  options: EngineAdapterOptions = {}
+): NivoBarData {
+  return {
+    data: asEngineLatestValueModel(model, options).rows.flatMap((row) =>
+      row.value === null ? [] : [{ label: row.label, value: row.value }]
+    ),
+    keys: ["value"],
+    indexBy: "label",
+  };
+}
+
+export function toNivoLatestBarProps(
+  model: EngineLatestValueInput,
+  options: EngineAdapterOptions & { readonly groupMode?: "grouped" | "stacked" } = {}
+): NivoBarProps {
+  return {
+    ...toNivoLatestBarData(model, options),
+    groupMode: options.groupMode ?? "grouped",
+  };
+}
+
+export function toNivoHistogramBarData(
+  model: EngineHistogramInput,
+  options: EngineAdapterOptions & EngineHistogramOptions = {}
+): NivoBarData {
+  const histogram = asEngineHistogramModel(model, options);
+  return {
+    data: histogram.buckets.map((bucket) => ({ label: bucket.label, count: bucket.count })),
+    keys: ["count"],
+    indexBy: "label",
+  };
+}
+
+export function toNivoHistogramBarProps(
+  model: EngineHistogramInput,
+  options: EngineAdapterOptions &
+    EngineHistogramOptions & { readonly groupMode?: "grouped" | "stacked" } = {}
+): NivoBarProps {
+  return {
+    ...toNivoHistogramBarData(model, options),
     groupMode: options.groupMode ?? "grouped",
   };
 }

--- a/packages/adapters/src/plotly.ts
+++ b/packages/adapters/src/plotly.ts
@@ -17,6 +17,7 @@ export type PlotlyChartType =
   | "area"
   | "bar"
   | "donut"
+  | "latestBar"
   | "histogram"
   | "scatter"
   | "sparkline"
@@ -82,6 +83,21 @@ export function toPlotlyLatestValuesFigure(
     };
   }
   const rows = latest.rows.filter((row) => row.value !== null);
+  if (chartType === "bar" || chartType === "latestBar") {
+    return {
+      data: [
+        {
+          uid: "latest-values-bar",
+          type: "bar",
+          name: "latest",
+          x: rows.map((row) => row.label),
+          y: rows.map((row) => row.value ?? 0),
+        },
+      ],
+      layout: { xaxis: { type: "category" }, uirevision: "engine-latest" },
+      config: { responsive: true, displaylogo: false },
+    };
+  }
   return {
     data: [
       {

--- a/packages/adapters/test/index.test.ts
+++ b/packages/adapters/test/index.test.ts
@@ -15,9 +15,11 @@ import {
 } from "../src/engine.js";
 import * as adapterBarrel from "../src/index.js";
 import {
+  toAgChartsHistogramOptions,
   toAgChartsLatestValuesOptions,
   toAgChartsTimeSeriesOptions,
   toAgChartsUpdateDelta,
+  toApexChartsHistogramOptions,
   toApexChartsLatestValuesOptions,
   toApexChartsSeriesUpdate,
   toApexChartsTimeSeriesOptions,
@@ -33,9 +35,12 @@ import {
   toEChartsViewHistogramOption,
   toEChartsViewLatestValuesOption,
   toEChartsViewTimeSeriesOption,
+  toHighchartsLatestValuesOptions,
   toHighchartsTimeSeriesOptions,
   toNivoBarData,
   toNivoBarProps,
+  toNivoHistogramBarData,
+  toNivoLatestBarData,
   toNivoLineProps,
   toNivoLineSeries,
   toNivoPieProps,
@@ -175,6 +180,8 @@ describe("@otlpkit/adapters", () => {
     expect(toEChartsHistogramOption(histogram).dataset[0]?.source).toHaveLength(3);
     expect(toUPlotTimeSeriesArgs(wide).data).toHaveLength(3);
     expect(toNivoBarData(wide).keys).toEqual(["__name__=cpu,host=a", "__name__=cpu,host=b"]);
+    expect(toNivoLatestBarData(latest).keys).toEqual(["value"]);
+    expect(toNivoHistogramBarData(histogram).indexBy).toBe("label");
     expect(toNivoLineProps(wide, { chartType: "sparkline" }).enablePoints).toBe(false);
     expect(toNivoPieProps(latest).value).toBe("value");
     expect(toObservablePlotOptions(wide).marks[0]?.mark).toBe("lineY");
@@ -183,19 +190,35 @@ describe("@otlpkit/adapters", () => {
     expect(toPlotlyTimeSeriesFigure(wide).data[0]?.uid).toMatch(/^engine-0-[a-z0-9]+$/);
     expect(toPlotlyTimeSeriesFigure(wide).data[0]?.name).toBe("a");
     expect(toPlotlyLatestValuesFigure(latest).config.responsive).toBe(true);
+    expect(toPlotlyLatestValuesFigure(latest, { chartType: "latestBar" }).data[0]?.type).toBe(
+      "bar"
+    );
     expect(toRechartsHistogramData(histogram).valueKey).toBe("count");
     expect(toRechartsScatterData(wide).series.map((series) => series.name)).toEqual(["a", "b"]);
     expect(toApexChartsLatestValuesOptions(latest, { chartType: "gauge" }).chart.type).toBe(
       "radialBar"
     );
+    expect(toApexChartsLatestValuesOptions(latest, { chartType: "latestBar" }).chart.type).toBe(
+      "bar"
+    );
+    expect(toApexChartsHistogramOptions(histogram).xaxis?.categories).toHaveLength(3);
     expect(toApexChartsSeriesUpdate(toApexChartsLatestValuesOptions(latest)).series).toEqual([
       3, 30,
     ]);
     expect(toVictorySeries(wide, { chartType: "area" })[0]?.component).toBe("VictoryArea");
     expect(toVictoryChartProps(wide).scale.x).toBe("time");
     expect(toAgChartsTimeSeriesOptions(wide, { chartType: "area" }).series?.[0]?.type).toBe("area");
+    expect(
+      toAgChartsLatestValuesOptions(latest, { chartType: "latestBar" }).series?.[0]?.type
+    ).toBe("bar");
+    expect(toAgChartsHistogramOptions(wide, { bucketCount: 3 }).series?.[0]?.type).toBe(
+      "histogram"
+    );
     expect(toAgChartsUpdateDelta(toAgChartsTimeSeriesOptions(wide)).data).toHaveLength(3);
     expect(toHighchartsTimeSeriesOptions(wide).chart.type).toBe("line");
+    expect(toHighchartsLatestValuesOptions(latest, { chartType: "latestBar" }).chart.type).toBe(
+      "bar"
+    );
     expect(toHighchartsTimeSeriesOptions(wide).xAxis?.type).toBe("datetime");
     expect(toVegaLiteSpec(wide, { mark: "scatter" }).mark).toBe("point");
     expect(toVegaLiteSpec(wide).$schema).toContain("vega-lite");
@@ -229,11 +252,18 @@ describe("@otlpkit/adapters", () => {
       "__name__=cpu,host=b",
     ]);
     expect(toNivoBarProps(engineResult, options).data[0]?.["__name__=cpu,host=a"]).toBe(1);
+    expect(toNivoLatestBarData(engineResult, options).data[1]?.value).toBe(30);
+    expect(toNivoHistogramBarData(engineResult, { ...options, bucketCount: 3 }).data).toHaveLength(
+      3
+    );
     expect(toObservablePlotOptions(engineResult, options).data[0]?.series).toBe("a");
     expect(toPlotlyTimeSeriesFigure(engineResult, options).data[0]?.name).toBe("a");
     expect(
       toPlotlyHistogramFigure(engineResult, { ...options, bucketCount: 3 }).data[0]?.type
     ).toBe("bar");
+    expect(
+      toPlotlyLatestValuesFigure(engineResult, { ...options, chartType: "latestBar" }).data[0]?.x
+    ).toEqual(["a", "b"]);
     expect(toRechartsTimeSeriesData(engineResult, options).series[0]?.name).toBe("a");
     expect(toRechartsLatestValuesData(engineResult, options).data[1]?.value).toBe(30);
     expect(toRechartsHistogramData(engineResult, { ...options, bucketCount: 3 }).data).toHaveLength(
@@ -241,6 +271,13 @@ describe("@otlpkit/adapters", () => {
     );
     expect(toApexChartsTimeSeriesOptions(engineResult, options).series[0]?.name).toBe("a");
     expect(toApexChartsLatestValuesOptions(engineResult, options).labels).toEqual(["a", "b"]);
+    expect(
+      toApexChartsLatestValuesOptions(engineResult, { ...options, chartType: "latestBar" }).xaxis
+        ?.categories
+    ).toEqual(["a", "b"]);
+    expect(
+      toApexChartsHistogramOptions(engineResult, { ...options, bucketCount: 3 }).series[0]
+    ).toMatchObject({ name: "samples" });
     expect(toVictorySeries(engineResult, options)[0]?.label).toBe("a");
     expect(toVictoryLatestData(engineResult, options)).toEqual([
       { x: "a", y: 3 },
@@ -251,7 +288,18 @@ describe("@otlpkit/adapters", () => {
       { label: "a", value: 3 },
       { label: "b", value: 30 },
     ]);
+    expect(
+      toAgChartsLatestValuesOptions(engineResult, { ...options, chartType: "latestBar" })
+        .series?.[0]?.type
+    ).toBe("bar");
+    expect(
+      toAgChartsHistogramOptions(engineResult, { ...options, bucketCount: 3 }).data
+    ).toHaveLength(4);
     expect(toHighchartsTimeSeriesOptions(engineResult, options).series?.[0]?.name).toBe("a");
+    expect(
+      toHighchartsLatestValuesOptions(engineResult, { ...options, chartType: "latestBar" })
+        .series[0]?.data
+    ).toEqual([3, 30]);
     expect(toVegaLiteSpec(engineResult, options).data.values[0]?.series).toBe("a");
   });
 
@@ -688,7 +736,10 @@ describe("@otlpkit/adapters", () => {
     };
 
     expect(typeof adapterBarrel.adapterModules.toChartJsViewLineConfig).toBe("function");
+    expect(typeof adapterBarrel.adapterModules.toApexChartsHistogramOptions).toBe("function");
+    expect(typeof adapterBarrel.adapterModules.toNivoLatestBarData).toBe("function");
     expect(typeof adapterBarrel.adapterModules.toAgChartsTimeSeriesOptions).toBe("function");
+    expect(typeof adapterBarrel.adapterModules.toAgChartsHistogramOptions).toBe("function");
     expect(typeof adapterBarrel.adapterModules.toVegaLiteSpec).toBe("function");
     expect(typeof adapterBarrel.adapterModules.toVisxXYChartModel).toBe("function");
     expect("toEngineWideTableModel" in adapterBarrel.adapterModules).toBe(false);

--- a/packages/o11ylogsdb/src/codec-typed.ts
+++ b/packages/o11ylogsdb/src/codec-typed.ts
@@ -39,7 +39,7 @@ import {
   type SidecarEntry,
 } from "./codec-utils.js";
 import { Drain, PARAM_STR, tokenize } from "./drain.js";
-import type { AnyValue, LogRecord, SeverityText } from "./types.js";
+import type { AnyValue, LogRecord } from "./types.js";
 
 // Body kinds (same enum as ColumnarDrainPolicy).
 const KIND_RAW_STRING = 0;

--- a/packages/o11ylogsdb/test/codec-typed-correctness.test.ts
+++ b/packages/o11ylogsdb/test/codec-typed-correctness.test.ts
@@ -248,7 +248,7 @@ describe("TypedColumnarDrainPolicy: toks in codecMeta", () => {
     expect(meta.toks).toBeDefined();
     expect(Array.isArray(meta.toks)).toBe(true);
     // Should contain literal tokens from the template (not wildcards)
-    expect(meta.toks!.length).toBeGreaterThan(0);
+    expect(meta.toks?.length).toBeGreaterThan(0);
     // "user", "logged", "in", "from" should appear as literal tokens
     const toks = meta.toks!;
     expect(toks.some((t) => t === "user" || t === "logged" || t === "in" || t === "from")).toBe(

--- a/packages/o11ylogsdb/test/compact-extended.test.ts
+++ b/packages/o11ylogsdb/test/compact-extended.test.ts
@@ -36,8 +36,8 @@ describe("compact: codec diversity", () => {
     // Verify records round-trip
     const records = readRecords(result.chunk, registry, policy);
     expect(records).toHaveLength(16);
-    expect(records[0]!.body).toBe("line 0");
-    expect(records[15]!.body).toBe("line 15");
+    expect(records[0]?.body).toBe("line 0");
+    expect(records[15]?.body).toBe("line 15");
   });
 
   it("compact from zstd-19 to zstd-3 (lower compression)", () => {
@@ -53,7 +53,7 @@ describe("compact: codec diversity", () => {
 
     const records = readRecords(result.chunk, registry, policy);
     expect(records).toHaveLength(32);
-    expect(records[0]!.body).toBe("log entry number 0 with some padding text");
+    expect(records[0]?.body).toBe("log entry number 0 with some padding text");
   });
 
   it("compact preserves non-string bodies (kvlist)", () => {
@@ -68,9 +68,9 @@ describe("compact: codec diversity", () => {
     const result = compactChunk(chunk, registry, "zstd-3");
     const records = readRecords(result.chunk, registry, policy);
     expect(records).toHaveLength(3);
-    expect(records[0]!.body).toEqual({ method: "GET", status: 200 });
-    expect(records[1]!.body).toEqual({ method: "POST", status: 201 });
-    expect(records[2]!.body).toBe("plain string body");
+    expect(records[0]?.body).toEqual({ method: "GET", status: 200 });
+    expect(records[1]?.body).toEqual({ method: "POST", status: 201 });
+    expect(records[2]?.body).toBe("plain string body");
   });
 
   it("compact preserves rich metadata (traceId, spanId, eventName)", () => {
@@ -138,8 +138,8 @@ describe("compact: TypedColumnar chunks", () => {
     // Read back with policy (needed because typed columnar needs codec meta)
     const records = readRecords(result.chunk, registry, policy);
     expect(records).toHaveLength(16);
-    expect(records[0]!.body).toContain("192.168.1.0");
-    expect(records[15]!.body).toContain("192.168.1.15");
+    expect(records[0]?.body).toContain("192.168.1.0");
+    expect(records[15]?.body).toContain("192.168.1.15");
   });
 });
 

--- a/packages/o11ylogsdb/test/engine-extended.test.ts
+++ b/packages/o11ylogsdb/test/engine-extended.test.ts
@@ -63,7 +63,7 @@ describe("LogStore flush edge cases", () => {
     // First 4 records auto-freeze a chunk
     let lastStats: IngestStats | undefined;
     for (let i = 0; i < 4; i++) lastStats = store.append(resource, scope, rec(i));
-    expect(lastStats!.chunksClosed).toBe(1);
+    expect(lastStats?.chunksClosed).toBe(1);
 
     // Next 2 records are in-flight
     store.append(resource, scope, rec(10));
@@ -93,7 +93,7 @@ describe("LogStore iterRecords edge cases", () => {
     const results = [...store.iterRecords()];
     expect(results).toHaveLength(2);
     // Different resources → different stream IDs
-    expect(results[0]!.streamId).not.toBe(results[1]!.streamId);
+    expect(results[0]?.streamId).not.toBe(results[1]?.streamId);
   });
 
   it("iterRecords with multiple chunks from same stream", () => {
@@ -104,12 +104,12 @@ describe("LogStore iterRecords edge cases", () => {
     const results = [...store.iterRecords()];
     // 10 records → 2 full chunks (4 each) + 1 partial (2)
     expect(results).toHaveLength(3);
-    expect(results[0]!.records).toHaveLength(4);
-    expect(results[1]!.records).toHaveLength(4);
-    expect(results[2]!.records).toHaveLength(2);
+    expect(results[0]?.records).toHaveLength(4);
+    expect(results[1]?.records).toHaveLength(4);
+    expect(results[2]?.records).toHaveLength(2);
     // All same streamId
-    expect(results[0]!.streamId).toBe(results[1]!.streamId);
-    expect(results[1]!.streamId).toBe(results[2]!.streamId);
+    expect(results[0]?.streamId).toBe(results[1]?.streamId);
+    expect(results[1]?.streamId).toBe(results[2]?.streamId);
   });
 });
 
@@ -148,8 +148,8 @@ describe("LogStore with TypedColumnarDrainPolicy", () => {
     const allRecords = results.flatMap((r) => r.records);
     expect(allRecords).toHaveLength(10);
     // Verify round-trip correctness
-    expect(allRecords[0]!.body).toBe("log line 0");
-    expect(allRecords[9]!.body).toBe("log line 9");
-    expect(Number(allRecords[5]!.timeUnixNano)).toBe(1000000005);
+    expect(allRecords[0]?.body).toBe("log line 0");
+    expect(allRecords[9]?.body).toBe("log line 9");
+    expect(Number(allRecords[5]?.timeUnixNano)).toBe(1000000005);
   });
 });

--- a/packages/o11ylogsdb/test/filtered-decode.test.ts
+++ b/packages/o11ylogsdb/test/filtered-decode.test.ts
@@ -54,8 +54,8 @@ describe("decodeFilteredByBodyNeedle: correctness", () => {
     const filtered = readRecordsFilteredFromRaw(raw, chunk.header, "connection", policy);
     const matches = filtered.filter((r) => r !== undefined);
     expect(matches).toHaveLength(2);
-    expect(matches[0]!.body).toContain("connection");
-    expect(matches[1]!.body).toContain("connection");
+    expect(matches[0]?.body).toContain("connection");
+    expect(matches[1]?.body).toContain("connection");
   });
 
   it("returns empty sparse array when no bodies match", () => {
@@ -103,7 +103,7 @@ describe("decodeFilteredByBodyNeedle: correctness", () => {
     expect(match.body).toBe("error in handler");
     expect(match.severityText).toBe("WARN");
     expect(match.attributes).toHaveLength(1);
-    expect(match.attributes[0]!.key).toBe("method");
+    expect(match.attributes[0]?.key).toBe("method");
     expect(match.traceId).toBeDefined();
     expect(match.spanId).toBeDefined();
   });
@@ -153,9 +153,9 @@ describe("decodeFilteredByBodyNeedle: correctness", () => {
 
     expect(filteredRecords).toHaveLength(allRecords.length);
     for (let i = 0; i < allRecords.length; i++) {
-      expect(filteredRecords[i]!.body).toBe(allRecords[i]!.body);
-      expect(filteredRecords[i]!.timeUnixNano).toBe(allRecords[i]!.timeUnixNano);
-      expect(filteredRecords[i]!.severityNumber).toBe(allRecords[i]!.severityNumber);
+      expect(filteredRecords[i]?.body).toBe(allRecords[i]?.body);
+      expect(filteredRecords[i]?.timeUnixNano).toBe(allRecords[i]?.timeUnixNano);
+      expect(filteredRecords[i]?.severityNumber).toBe(allRecords[i]?.severityNumber);
     }
   });
 });
@@ -202,7 +202,7 @@ describe("decodeFilteredByBodyNeedle: template-literal shortcut", () => {
     const filtered = readRecordsFilteredFromRaw(raw, chunk.header, "admin", policy);
     const matches = filtered.filter((r) => r !== undefined);
     expect(matches).toHaveLength(1);
-    expect(matches[0]!.body).toContain("admin");
+    expect(matches[0]?.body).toContain("admin");
   });
 });
 
@@ -226,7 +226,7 @@ describe("decodeFilteredByBodyNeedle: non-string bodies", () => {
     const matches = filtered.filter((r) => r !== undefined);
     // Only the string body "text with map in it" should match
     expect(matches).toHaveLength(1);
-    expect(matches[0]!.body).toBe("text with map in it");
+    expect(matches[0]?.body).toBe("text with map in it");
   });
 });
 

--- a/packages/o11ylogsdb/test/ndjson-roundtrip.test.ts
+++ b/packages/o11ylogsdb/test/ndjson-roundtrip.test.ts
@@ -22,7 +22,7 @@ describe("NDJSON round-trip: falsy field preservation", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.eventName).toBe("");
+    expect(records[0]?.eventName).toBe("");
   });
 
   it("droppedAttributesCount=0 round-trips correctly", () => {
@@ -38,7 +38,7 @@ describe("NDJSON round-trip: falsy field preservation", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.droppedAttributesCount).toBe(0);
+    expect(records[0]?.droppedAttributesCount).toBe(0);
   });
 
   it("flags=0 round-trips correctly", () => {
@@ -54,7 +54,7 @@ describe("NDJSON round-trip: falsy field preservation", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.flags).toBe(0);
+    expect(records[0]?.flags).toBe(0);
   });
 
   it("all optional fields undefined stay undefined on round-trip", () => {
@@ -69,12 +69,12 @@ describe("NDJSON round-trip: falsy field preservation", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.eventName).toBeUndefined();
-    expect(records[0]!.droppedAttributesCount).toBeUndefined();
-    expect(records[0]!.flags).toBeUndefined();
-    expect(records[0]!.traceId).toBeUndefined();
-    expect(records[0]!.spanId).toBeUndefined();
-    expect(records[0]!.observedTimeUnixNano).toBeUndefined();
+    expect(records[0]?.eventName).toBeUndefined();
+    expect(records[0]?.droppedAttributesCount).toBeUndefined();
+    expect(records[0]?.flags).toBeUndefined();
+    expect(records[0]?.traceId).toBeUndefined();
+    expect(records[0]?.spanId).toBeUndefined();
+    expect(records[0]?.observedTimeUnixNano).toBeUndefined();
   });
 
   it("observedTimeUnixNano=0n round-trips correctly", () => {
@@ -90,7 +90,7 @@ describe("NDJSON round-trip: falsy field preservation", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.observedTimeUnixNano).toBe(0n);
+    expect(records[0]?.observedTimeUnixNano).toBe(0n);
   });
 
   it("traceId and spanId with all zeros round-trip", () => {
@@ -107,8 +107,8 @@ describe("NDJSON round-trip: falsy field preservation", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.traceId).toEqual(new Uint8Array(16));
-    expect(records[0]!.spanId).toEqual(new Uint8Array(8));
+    expect(records[0]?.traceId).toEqual(new Uint8Array(16));
+    expect(records[0]?.spanId).toEqual(new Uint8Array(8));
   });
 });
 
@@ -125,7 +125,7 @@ describe("NDJSON round-trip: complex bodies", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.body).toBeNull();
+    expect(records[0]?.body).toBeNull();
   });
 
   it("nested object body round-trips", () => {
@@ -141,7 +141,7 @@ describe("NDJSON round-trip: complex bodies", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.body).toEqual(body);
+    expect(records[0]?.body).toEqual(body);
   });
 
   it("numeric body round-trips", () => {
@@ -156,7 +156,7 @@ describe("NDJSON round-trip: complex bodies", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.body).toBe(42);
+    expect(records[0]?.body).toBe(42);
   });
 
   it("boolean body round-trips", () => {
@@ -171,7 +171,7 @@ describe("NDJSON round-trip: complex bodies", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.body).toBe(false);
+    expect(records[0]?.body).toBe(false);
   });
 
   it("array body round-trips", () => {
@@ -186,7 +186,7 @@ describe("NDJSON round-trip: complex bodies", () => {
     });
     const chunk = builder.freeze();
     const records = readRecords(chunk, registry, policy);
-    expect(records[0]!.body).toEqual([1, "two", { three: 3 }]);
+    expect(records[0]?.body).toEqual([1, "two", { three: 3 }]);
   });
 });
 
@@ -213,13 +213,13 @@ describe("LogStore: full pipeline round-trip with all fields", () => {
     store.flush();
 
     const results = [...store.iterRecords()];
-    const decoded = results[0]!.records[0]!;
-    expect(decoded.timeUnixNano).toBe(1234567890n);
-    expect(decoded.observedTimeUnixNano).toBe(1234567891n);
-    expect(decoded.severityNumber).toBe(17);
-    expect(decoded.severityText).toBe("ERROR");
-    expect(decoded.body).toBe("request failed with status 500");
-    expect(decoded.attributes).toEqual([
+    const decoded = results[0]?.records[0];
+    expect(decoded?.timeUnixNano).toBe(1234567890n);
+    expect(decoded?.observedTimeUnixNano).toBe(1234567891n);
+    expect(decoded?.severityNumber).toBe(17);
+    expect(decoded?.severityText).toBe("ERROR");
+    expect(decoded?.body).toBe("request failed with status 500");
+    expect(decoded?.attributes).toEqual([
       { key: "url", value: "/api/users" },
       { key: "method", value: "POST" },
     ]);

--- a/packages/o11ylogsdb/test/query-edge-cases.test.ts
+++ b/packages/o11ylogsdb/test/query-edge-cases.test.ts
@@ -35,8 +35,8 @@ describe("query: raw byte scan edge cases", () => {
     const store = makeStore(records);
     const { records: hits } = query(store, { bodyContains: "🚀" });
     expect(hits).toHaveLength(2);
-    expect(hits[0]!.body).toContain("🚀");
-    expect(hits[1]!.body).toContain("🚀");
+    expect(hits[0]?.body).toContain("🚀");
+    expect(hits[1]?.body).toContain("🚀");
   });
 
   it("CJK multi-byte needle works", () => {
@@ -55,7 +55,7 @@ describe("query: raw byte scan edge cases", () => {
     const store = makeStore(records);
     const { records: hits } = query(store, { bodyContains: "ERROR" });
     expect(hits).toHaveLength(1);
-    expect(hits[0]!.body).toBe("ERROR: something broke");
+    expect(hits[0]?.body).toBe("ERROR: something broke");
   });
 
   it("needle at exact end of body matches", () => {
@@ -91,7 +91,7 @@ describe("query: raw byte scan edge cases", () => {
     const { records: hits } = query(store, { bodyContains: "match" });
     // Only the string-body record matches
     expect(hits).toHaveLength(1);
-    expect(hits[0]!.body).toBe("match me too");
+    expect(hits[0]?.body).toBe("match me too");
   });
 });
 
@@ -194,7 +194,7 @@ describe("query: time range boundary precision", () => {
     const store = makeStore(records);
     const { records: hits } = query(store, { range: { from: 200n, to: 250n } });
     expect(hits).toHaveLength(1);
-    expect(hits[0]!.body).toBe("exact");
+    expect(hits[0]?.body).toBe("exact");
   });
 
   it("range.to is exclusive", () => {
@@ -206,7 +206,7 @@ describe("query: time range boundary precision", () => {
     const store = makeStore(records);
     const { records: hits } = query(store, { range: { from: 100n, to: 200n } });
     expect(hits).toHaveLength(1);
-    expect(hits[0]!.body).toBe("before");
+    expect(hits[0]?.body).toBe("before");
   });
 
   it("chunk boundary: maxNano === range.from passes pruning", () => {
@@ -218,7 +218,7 @@ describe("query: time range boundary precision", () => {
     // range.from = 31000 (the maxNano of chunk 1)
     const { records: hits, stats } = query(store, { range: { from: 31000n, to: 32000n } });
     expect(hits).toHaveLength(1);
-    expect(hits[0]!.body).toBe("line 31");
+    expect(hits[0]?.body).toBe("line 31");
     // Both chunks should be visited (chunk1 has maxNano=31000 === range.from)
     expect(stats.chunksPruned).toBe(1); // chunk2 pruned (minNano=32000 >= to=32000)
   });

--- a/packages/o11ylogsdb/test/query-integration.test.ts
+++ b/packages/o11ylogsdb/test/query-integration.test.ts
@@ -69,8 +69,8 @@ describe("query engine: body fast path uses readRecordsFromRaw", () => {
 
     const { records: hits } = query(store, { bodyContains: "login" });
     expect(hits).toHaveLength(2);
-    expect(hits[0]!.body).toContain("login");
-    expect(hits[1]!.body).toContain("login");
+    expect(hits[0]?.body).toContain("login");
+    expect(hits[1]?.body).toContain("login");
   });
 
   it("bodyContains + limit on NDJSON store", () => {
@@ -132,7 +132,7 @@ describe("query engine: resourceEquals stream pruning", () => {
 
     const { records: hits, stats } = query(store, { resourceEquals: { service: "api" } });
     expect(hits).toHaveLength(2);
-    expect(hits[0]!.body).toBe("api log 1");
+    expect(hits[0]?.body).toBe("api log 1");
     expect(stats.streamsPruned).toBe(1);
   });
 
@@ -156,7 +156,7 @@ describe("query engine: resourceEquals stream pruning", () => {
 
     const { records: hits } = query(store, { resourceEquals: { service: "api", env: "prod" } });
     expect(hits).toHaveLength(1);
-    expect(hits[0]!.body).toBe("prod api");
+    expect(hits[0]?.body).toBe("prod api");
   });
 
   it("resourceEquals with non-matching key prunes all streams", () => {
@@ -208,7 +208,7 @@ describe("query engine: queryStream generator behavior", () => {
     const results = [...queryStream(store, {})];
     expect(results).toHaveLength(12);
     for (let i = 0; i < 12; i++) {
-      expect(results[i]!.body).toBe(`line ${i}`);
+      expect(results[i]?.body).toBe(`line ${i}`);
     }
   });
 });

--- a/packages/o11ytracesdb/src/codec-columnar.ts
+++ b/packages/o11ytracesdb/src/codec-columnar.ts
@@ -25,11 +25,6 @@ import type { KeyValue, SpanEvent, SpanLink, SpanRecord, StatusCode } from "./ty
 
 // ─── Dictionary builder ──────────────────────────────────────────────
 
-interface DictWithIndex {
-  dict: string[];
-  index: Map<string, number>;
-}
-
 // Collect attribute keys/values without intermediate array allocations
 function collectAttrKeys(spans: readonly SpanRecord[]): Iterable<string> {
   return {

--- a/packages/o11ytracesdb/src/codec-columnar.ts
+++ b/packages/o11ytracesdb/src/codec-columnar.ts
@@ -21,7 +21,7 @@
 
 import { ByteBuf, ByteReader, buildDictWithIndex, decodeAnyValue, encodeAnyValue } from "stardb";
 import type { ChunkPolicy } from "./chunk.js";
-import type { AnyValue, KeyValue, SpanEvent, SpanLink, SpanRecord, StatusCode } from "./types.js";
+import type { KeyValue, SpanEvent, SpanLink, SpanRecord, StatusCode } from "./types.js";
 
 // ─── Dictionary builder ──────────────────────────────────────────────
 

--- a/site/charts/index.html
+++ b/site/charts/index.html
@@ -149,7 +149,8 @@ const recharts =
             The adapters handle the repetitive conversion work: aligned timestamps, latest values,
             histogram buckets, labels, sparse values, and package-specific field names. You keep
             control over presentation, colors, tooltips, axes, and the update strategy each chart
-            library recommends.
+            library recommends. A chart shape only appears in this gallery when that library has a
+            published adapter and a real native renderer path for it.
           </p>
           <div class="ergonomics-grid">
             <article class="ergonomics-card">
@@ -199,8 +200,9 @@ const recharts =
           <h2 class="t-h2" style="margin:8px 0 8px">Chart shape by chart shape.</h2>
           <p class="t-body" style="max-width:72ch;margin:0 0 28px">
             A checked cell means this gallery has a published adapter call and a native package
-            render path for that chart shape. Recipe cells are intentional examples that can be built
-            from the exported primitives without adding gallery-only drawing.
+            render path for that chart shape. The latest-bar and histogram cards use the chart
+            package's own bar, histogram, or category-series inputs; there are no gallery-only
+            drawing layers behind them.
           </p>
           <div class="coverage-table-wrap">
             <table id="coverageTable" class="coverage-table"></table>

--- a/site/charts/js/gallery-data.js
+++ b/site/charts/js/gallery-data.js
@@ -1,8 +1,10 @@
 import {
+  toAgChartsHistogramOptions,
   toAgChartsLatestValuesOptions,
   toAgChartsTimeSeriesOptions,
 } from "../../../packages/adapters/src/agcharts.ts";
 import {
+  toApexChartsHistogramOptions,
   toApexChartsLatestValuesOptions,
   toApexChartsTimeSeriesOptions,
 } from "../../../packages/adapters/src/apexcharts.ts";
@@ -24,6 +26,8 @@ import {
 } from "../../../packages/adapters/src/highcharts.ts";
 import {
   toNivoBarData,
+  toNivoHistogramBarData,
+  toNivoLatestBarData,
   toNivoLineSeries,
   toNivoPieData,
   toNivoScatterSeries,
@@ -160,7 +164,7 @@ export const LIBRARIES = [
     updateModel: "React data updates",
     status: "exported",
     package: "@otlpkit/adapters/nivo",
-    charts: ["line", "area", "bar", "donut", "scatter"],
+    charts: ["line", "area", "bar", "donut", "latestBar", "histogram", "scatter"],
     note: "Map engine series into Nivo's nested data while keeping labels and colors predictable.",
   },
   {
@@ -184,7 +188,17 @@ export const LIBRARIES = [
     updateModel: "extendTraces",
     status: "exported",
     package: "@otlpkit/adapters/plotly",
-    charts: ["line", "area", "bar", "donut", "histogram", "scatter", "sparkline", "gauge"],
+    charts: [
+      "line",
+      "area",
+      "bar",
+      "donut",
+      "latestBar",
+      "histogram",
+      "scatter",
+      "sparkline",
+      "gauge",
+    ],
     note: "Produce traces and layouts, with a path toward extendTraces for live dashboards.",
   },
   {
@@ -196,8 +210,18 @@ export const LIBRARIES = [
     updateModel: "updateSeries",
     status: "exported",
     package: "@otlpkit/adapters/apexcharts",
-    charts: ["line", "area", "bar", "donut", "scatter", "sparkline", "gauge"],
-    note: "Return compact options plus series arrays, including sparkline and radial gauge shapes.",
+    charts: [
+      "line",
+      "area",
+      "bar",
+      "donut",
+      "latestBar",
+      "histogram",
+      "scatter",
+      "sparkline",
+      "gauge",
+    ],
+    note: "Return compact options plus series arrays, including category bars and radial gauge shapes.",
   },
   {
     id: "victory",
@@ -220,7 +244,7 @@ export const LIBRARIES = [
     updateModel: "update options",
     status: "exported",
     package: "@otlpkit/adapters/agcharts",
-    charts: ["line", "area", "bar", "donut", "scatter"],
+    charts: ["line", "area", "bar", "donut", "latestBar", "histogram", "scatter"],
     note: "Project engine rows into AG Charts options with explicit keys and series definitions.",
   },
   {
@@ -232,7 +256,17 @@ export const LIBRARIES = [
     updateModel: "setData",
     status: "exported",
     package: "@otlpkit/adapters/highcharts",
-    charts: ["line", "area", "bar", "donut", "histogram", "scatter", "sparkline", "gauge"],
+    charts: [
+      "line",
+      "area",
+      "bar",
+      "donut",
+      "latestBar",
+      "histogram",
+      "scatter",
+      "sparkline",
+      "gauge",
+    ],
     note: "Return Highcharts-style options while preserving stable engine ids for updates.",
   },
   {
@@ -449,23 +483,27 @@ export function createAdapterOutput(library, chartType, result) {
     case "plotly":
       return chartType === "histogram"
         ? toPlotlyHistogramFigure(result)
-        : chartType === "donut" || chartType === "gauge"
+        : chartType === "donut" || chartType === "gauge" || chartType === "latestBar"
           ? toPlotlyLatestValuesFigure(result, { chartType, seriesLabel })
           : toPlotlyTimeSeriesFigure(result, { chartType, seriesLabel });
     case "apexcharts":
-      return chartType === "donut" || chartType === "gauge"
-        ? toApexChartsLatestValuesOptions(result, { chartType, seriesLabel })
-        : toApexChartsTimeSeriesOptions(result, { chartType, seriesLabel });
+      return chartType === "histogram"
+        ? toApexChartsHistogramOptions(result, { seriesLabel })
+        : chartType === "donut" || chartType === "gauge" || chartType === "latestBar"
+          ? toApexChartsLatestValuesOptions(result, { chartType, seriesLabel })
+          : toApexChartsTimeSeriesOptions(result, { chartType, seriesLabel });
     case "victory":
       return victoryModel(chartType, result);
     case "agcharts":
-      return chartType === "donut" || chartType === "gauge"
-        ? toAgChartsLatestValuesOptions(result, { chartType, seriesLabel })
-        : toAgChartsTimeSeriesOptions(result, { chartType, seriesLabel });
+      return chartType === "histogram"
+        ? toAgChartsHistogramOptions(result, { seriesLabel })
+        : chartType === "donut" || chartType === "gauge" || chartType === "latestBar"
+          ? toAgChartsLatestValuesOptions(result, { chartType, seriesLabel })
+          : toAgChartsTimeSeriesOptions(result, { chartType, seriesLabel });
     case "highcharts":
       return chartType === "histogram"
         ? toHighchartsHistogramOptions(result)
-        : chartType === "donut" || chartType === "gauge"
+        : chartType === "donut" || chartType === "gauge" || chartType === "latestBar"
           ? toHighchartsLatestValuesOptions(result, { chartType, seriesLabel })
           : toHighchartsTimeSeriesOptions(result, { chartType, seriesLabel });
     case "vegalite":
@@ -520,6 +558,12 @@ function nivoModel(chartType, result) {
       ...row,
       color: COLORS[index % COLORS.length],
     }));
+  }
+  if (chartType === "latestBar") {
+    return toNivoLatestBarData(result, { seriesLabel });
+  }
+  if (chartType === "histogram") {
+    return toNivoHistogramBarData(result, { seriesLabel });
   }
   if (chartType === "bar") {
     return toNivoBarData(result, { seriesLabel });
@@ -639,7 +683,7 @@ const config = ${fn}(result, {
     const fn =
       chartType === "histogram"
         ? "toPlotlyHistogramFigure"
-        : chartType === "donut" || chartType === "gauge"
+        : chartType === "donut" || chartType === "gauge" || chartType === "latestBar"
           ? "toPlotlyLatestValuesFigure"
           : "toPlotlyTimeSeriesFigure";
     return `import { ${fn} } from "@otlpkit/adapters/plotly";
@@ -651,9 +695,11 @@ const figure = ${fn}(result, {
   }
   if (libraryId === "apexcharts") {
     const fn =
-      chartType === "donut" || chartType === "gauge"
-        ? "toApexChartsLatestValuesOptions"
-        : "toApexChartsTimeSeriesOptions";
+      chartType === "histogram"
+        ? "toApexChartsHistogramOptions"
+        : chartType === "donut" || chartType === "gauge" || chartType === "latestBar"
+          ? "toApexChartsLatestValuesOptions"
+          : "toApexChartsTimeSeriesOptions";
     return `import { ${fn} } from "@otlpkit/adapters/apexcharts";
 
 const options = ${fn}(result, {
@@ -673,9 +719,11 @@ const data = ${fn}(result, {
   }
   if (libraryId === "agcharts") {
     const fn =
-      chartType === "donut" || chartType === "gauge"
-        ? "toAgChartsLatestValuesOptions"
-        : "toAgChartsTimeSeriesOptions";
+      chartType === "histogram"
+        ? "toAgChartsHistogramOptions"
+        : chartType === "donut" || chartType === "gauge" || chartType === "latestBar"
+          ? "toAgChartsLatestValuesOptions"
+          : "toAgChartsTimeSeriesOptions";
     return `import { ${fn} } from "@otlpkit/adapters/agcharts";
 
 const options = ${fn}(result, {
@@ -687,7 +735,7 @@ const options = ${fn}(result, {
     const fn =
       chartType === "histogram"
         ? "toHighchartsHistogramOptions"
-        : chartType === "donut" || chartType === "gauge"
+        : chartType === "donut" || chartType === "gauge" || chartType === "latestBar"
           ? "toHighchartsLatestValuesOptions"
           : "toHighchartsTimeSeriesOptions";
     return `import { ${fn} } from "@otlpkit/adapters/highcharts";
@@ -727,6 +775,20 @@ const data = toNivoPieData(result, {
     return `import { toNivoBarData } from "@otlpkit/adapters/nivo";
 
 const data = toNivoBarData(result, {
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
+});`;
+  }
+  if (libraryId === "nivo" && chartType === "latestBar") {
+    return `import { toNivoLatestBarData } from "@otlpkit/adapters/nivo";
+
+const data = toNivoLatestBarData(result, {
+  seriesLabel: (s) => s.labels.get("service") ?? "service",
+});`;
+  }
+  if (libraryId === "nivo" && chartType === "histogram") {
+    return `import { toNivoHistogramBarData } from "@otlpkit/adapters/nivo";
+
+const data = toNivoHistogramBarData(result, {
   seriesLabel: (s) => s.labels.get("service") ?? "service",
 });`;
   }

--- a/site/charts/js/gallery-data.js
+++ b/site/charts/js/gallery-data.js
@@ -896,6 +896,8 @@ function componentFor(libraryId, chartType) {
       line: "ResponsiveLine",
       area: "ResponsiveLine",
       bar: "ResponsiveBar",
+      latestBar: "ResponsiveBar",
+      histogram: "ResponsiveBar",
       donut: "ResponsivePie",
     },
   };

--- a/site/charts/js/gallery-data.js
+++ b/site/charts/js/gallery-data.js
@@ -867,7 +867,11 @@ chart.setOption(option);`;
   if (libraryId === "uplot")
     return `const plot = new uPlot(args.options, args.data, node);
 plot.setData(nextArgs.data);`;
-  if (libraryId === "nivo") return `<${componentName} data={data} animate={false} />`;
+  if (libraryId === "nivo") {
+    // bar-like adapters return { data, keys, indexBy } — use spread
+    if (componentName === "ResponsiveBar") return `<${componentName} {...data} animate={false} />`;
+    return `<${componentName} data={data} animate={false} />`;
+  }
   if (libraryId === "observable")
     return `Plot.plot({
   marks: options.marks.map((mark) => Plot[mark.mark](options.data, mark)),

--- a/site/charts/js/gallery-renderers.js
+++ b/site/charts/js/gallery-renderers.js
@@ -547,6 +547,7 @@ async function renderPlotly(target, chart, generation) {
 
   const model = chart.adapterOutput;
   const timeRange = timeRangeForChart(chart);
+  const isCategoryChart = chart.chartType === "histogram" || chart.chartType === "latestBar";
   const layout = {
     ...model.layout,
     autosize: true,
@@ -559,12 +560,12 @@ async function renderPlotly(target, chart, generation) {
     xaxis: {
       ...(model.layout?.xaxis ?? {}),
       visible: chart.chartType !== "sparkline",
-      ...(timeRange ? { range: [timeRange.min, timeRange.max] } : {}),
+      ...(timeRange && !isCategoryChart ? { range: [timeRange.min, timeRange.max] } : {}),
     },
     yaxis: {
       ...(model.layout?.yaxis ?? {}),
       visible: chart.chartType !== "sparkline",
-      range: [VALUE_DOMAIN.min, VALUE_DOMAIN.max],
+      range: isCategoryChart ? undefined : [VALUE_DOMAIN.min, VALUE_DOMAIN.max],
     },
   };
   const config = {
@@ -589,6 +590,7 @@ async function renderApexCharts(target, chart, generation) {
 
   const model = chart.adapterOutput;
   const timeRange = timeRangeForChart(chart);
+  const isCategoryChart = chart.chartType === "histogram" || chart.chartType === "latestBar";
   const options = {
     ...model,
     chart: {
@@ -608,13 +610,14 @@ async function renderApexCharts(target, chart, generation) {
     grid: { borderColor: "rgba(17,17,15,0.12)" },
     legend: { show: chart.chartType !== "sparkline" && chart.chartType !== "gauge" },
     xaxis: {
-      type: "datetime",
+      ...(model.xaxis ?? {}),
+      type: model.xaxis?.type ?? "datetime",
       labels: { show: chart.chartType !== "sparkline" },
-      ...(timeRange ?? {}),
+      ...(timeRange && !isCategoryChart ? timeRange : {}),
     },
     yaxis: {
-      min: VALUE_DOMAIN.min,
-      max: VALUE_DOMAIN.max,
+      min: isCategoryChart ? 0 : VALUE_DOMAIN.min,
+      max: isCategoryChart ? undefined : VALUE_DOMAIN.max,
       labels: { show: chart.chartType !== "sparkline" },
     },
   };
@@ -637,6 +640,7 @@ async function renderHighcharts(target, chart, generation) {
 
   const model = chart.adapterOutput;
   const timeRange = timeRangeForChart(chart);
+  const isCategoryChart = chart.chartType === "histogram" || chart.chartType === "latestBar";
   const options = {
     ...model,
     chart: {
@@ -654,14 +658,14 @@ async function renderHighcharts(target, chart, generation) {
     xAxis: {
       ...(model.xAxis ?? {}),
       visible: chart.chartType !== "sparkline",
-      type: chart.chartType === "histogram" ? undefined : "datetime",
-      ...(timeRange ?? {}),
+      type: isCategoryChart ? undefined : "datetime",
+      ...(timeRange && !isCategoryChart ? timeRange : {}),
     },
     yAxis: {
       title: { text: undefined },
       visible: chart.chartType !== "sparkline",
-      min: VALUE_DOMAIN.min,
-      max: VALUE_DOMAIN.max,
+      min: isCategoryChart ? 0 : VALUE_DOMAIN.min,
+      max: isCategoryChart ? undefined : VALUE_DOMAIN.max,
     },
     plotOptions: {
       ...(model.plotOptions ?? {}),
@@ -743,22 +747,12 @@ async function renderNivo(target, chart, generation) {
       runtime.createRoot
     );
   }
-  if (chart.chartType === "bar") {
-    return renderReact(
-      target,
-      React.createElement(runtime.ResponsiveBar, {
-        ...common,
-        data: chart.adapterOutput.data,
-        keys: chart.adapterOutput.keys,
-        indexBy: chart.adapterOutput.indexBy,
-        groupMode: "grouped",
-        enableLabel: false,
-        axisBottom: { tickSize: 0, tickPadding: 6, format: () => "" },
-        axisLeft: { tickSize: 0, tickPadding: 6 },
-        isInteractive: false,
-      }),
-      runtime.createRoot
-    );
+  if (
+    chart.chartType === "bar" ||
+    chart.chartType === "latestBar" ||
+    chart.chartType === "histogram"
+  ) {
+    return renderNivoBar(target, runtime, common, chart);
   }
   if (chart.chartType === "scatter") {
     return renderReact(
@@ -795,6 +789,25 @@ async function renderNivo(target, chart, generation) {
       yScale: { type: "linear", stacked: false, min: VALUE_DOMAIN.min, max: VALUE_DOMAIN.max },
       axisBottom: { tickSize: 0, tickPadding: 6, format: () => "" },
       axisLeft: { tickSize: 0, tickPadding: 6 },
+    }),
+    runtime.createRoot
+  );
+}
+
+function renderNivoBar(target, runtime, common, chart) {
+  const { React } = runtime;
+  return renderReact(
+    target,
+    React.createElement(runtime.ResponsiveBar, {
+      ...common,
+      data: chart.adapterOutput.data,
+      keys: chart.adapterOutput.keys,
+      indexBy: chart.adapterOutput.indexBy,
+      groupMode: "grouped",
+      enableLabel: false,
+      axisBottom: { tickSize: 0, tickPadding: 6, format: () => "" },
+      axisLeft: { tickSize: 0, tickPadding: 6 },
+      isInteractive: false,
     }),
     runtime.createRoot
   );
@@ -929,6 +942,8 @@ async function renderAgCharts(target, chart, generation) {
   if (!isCurrentRender(target, generation)) return undefined;
 
   const model = chart.adapterOutput;
+  const isCategoryChart = chart.chartType === "bar" || chart.chartType === "latestBar";
+  const isHistogram = chart.chartType === "histogram";
   const baseOptions = {
     ...model,
     container: target,
@@ -941,15 +956,15 @@ async function renderAgCharts(target, chart, generation) {
         ? undefined
         : {
             x: {
-              type: chart.chartType === "bar" ? "category" : "number",
+              type: isCategoryChart ? "category" : "number",
               position: "bottom",
               label: { enabled: false },
             },
             y: {
               type: "number",
               position: "left",
-              min: VALUE_DOMAIN.min,
-              max: VALUE_DOMAIN.max,
+              min: isHistogram ? 0 : VALUE_DOMAIN.min,
+              max: isHistogram ? undefined : VALUE_DOMAIN.max,
             },
           },
     theme: {

--- a/site/charts/js/gallery-renderers.js
+++ b/site/charts/js/gallery-renderers.js
@@ -963,8 +963,8 @@ async function renderAgCharts(target, chart, generation) {
             y: {
               type: "number",
               position: "left",
-              min: isHistogram ? 0 : VALUE_DOMAIN.min,
-              max: isHistogram ? undefined : VALUE_DOMAIN.max,
+              min: isCategoryChart || isHistogram ? 0 : VALUE_DOMAIN.min,
+              max: isCategoryChart || isHistogram ? undefined : VALUE_DOMAIN.max,
             },
           },
     theme: {

--- a/site/charts/test/gallery-data.test.js
+++ b/site/charts/test/gallery-data.test.js
@@ -85,7 +85,7 @@ describe("chart gallery data", () => {
     }
   });
 
-  it("only advertises ApexCharts shapes backed by exported ApexCharts adapters", () => {
+  it("advertises ApexCharts shapes only after exported adapter support exists", () => {
     const apexCharts = LIBRARIES.find((library) => library.id === "apexcharts");
 
     expect(apexCharts?.charts).toEqual([
@@ -93,12 +93,12 @@ describe("chart gallery data", () => {
       "area",
       "bar",
       "donut",
+      "latestBar",
+      "histogram",
       "scatter",
       "sparkline",
       "gauge",
     ]);
-    expect(apexCharts?.charts).not.toContain("histogram");
-    expect(apexCharts?.charts).not.toContain("latestBar");
   });
 
   it("falls back to the first natural chart type when a library does not support a shape", () => {
@@ -145,12 +145,23 @@ describe("chart gallery data", () => {
     expect(createGalleryState("echarts", "latestBar").adapterOutput.series[0].type).toBe("bar");
     expect(createGalleryState("uplot", "line").adapterOutput.data).toHaveLength(5);
     expect(createGalleryState("plotly", "donut").adapterOutput.data[0].type).toBe("pie");
+    expect(createGalleryState("plotly", "latestBar").adapterOutput.data[0].type).toBe("bar");
     expect(createGalleryState("apexcharts", "gauge").adapterOutput.chart.type).toBe("radialBar");
+    expect(createGalleryState("apexcharts", "latestBar").adapterOutput.chart.type).toBe("bar");
+    expect(createGalleryState("apexcharts", "histogram").adapterOutput.xaxis.type).toBe("category");
     expect(createGalleryState("nivo", "bar").adapterOutput).toMatchObject({
       indexBy: "time",
       keys: expect.arrayContaining([
         "__name__=http.server.duration,route=/cart,service=checkout,status_class=2xx",
       ]),
+    });
+    expect(createGalleryState("nivo", "latestBar").adapterOutput).toMatchObject({
+      indexBy: "label",
+      keys: ["value"],
+    });
+    expect(createGalleryState("nivo", "histogram").adapterOutput).toMatchObject({
+      indexBy: "label",
+      keys: ["count"],
     });
     expect(createGalleryState("observable", "sparkline").adapterOutput.marks[0].mark).toBe("lineY");
     expect(createGalleryState("victory", "bar").adapterOutput[0]).toMatchObject({
@@ -158,7 +169,12 @@ describe("chart gallery data", () => {
       y: expect.any(Number),
     });
     expect(createGalleryState("agcharts", "area").adapterOutput.series[0].type).toBe("area");
+    expect(createGalleryState("agcharts", "latestBar").adapterOutput.series[0].type).toBe("bar");
+    expect(createGalleryState("agcharts", "histogram").adapterOutput.series[0].type).toBe(
+      "histogram"
+    );
     expect(createGalleryState("highcharts", "scatter").adapterOutput.chart.type).toBe("scatter");
+    expect(createGalleryState("highcharts", "latestBar").adapterOutput.chart.type).toBe("bar");
     expect(createGalleryState("highcharts", "histogram").adapterOutput.chart.type).toBe("column");
     expect(createGalleryState("vegalite", "scatter").adapterOutput.mark).toBe("point");
   });

--- a/site/charts/test/gallery-real-adapters.test.js
+++ b/site/charts/test/gallery-real-adapters.test.js
@@ -1,13 +1,25 @@
 import { describe, expect, it } from "vitest";
-import { toAgChartsTimeSeriesOptions } from "../../../packages/adapters/src/agcharts.js";
-import { toApexChartsLatestValuesOptions } from "../../../packages/adapters/src/apexcharts.js";
+import {
+  toAgChartsHistogramOptions,
+  toAgChartsLatestValuesOptions,
+  toAgChartsTimeSeriesOptions,
+} from "../../../packages/adapters/src/agcharts.js";
+import {
+  toApexChartsHistogramOptions,
+  toApexChartsLatestValuesOptions,
+} from "../../../packages/adapters/src/apexcharts.js";
 import { toChartJsTimeSeriesConfig } from "../../../packages/adapters/src/chartjs.js";
 import { toEChartsHistogramOption } from "../../../packages/adapters/src/echarts.js";
 import {
   toHighchartsHistogramOptions,
+  toHighchartsLatestValuesOptions,
   toHighchartsTimeSeriesOptions,
 } from "../../../packages/adapters/src/highcharts.js";
-import { toNivoBarData } from "../../../packages/adapters/src/nivo.js";
+import {
+  toNivoBarData,
+  toNivoHistogramBarData,
+  toNivoLatestBarData,
+} from "../../../packages/adapters/src/nivo.js";
 import { toObservablePlotOptions } from "../../../packages/adapters/src/observable.js";
 import { toPlotlyLatestValuesFigure } from "../../../packages/adapters/src/plotly.js";
 import {
@@ -82,6 +94,12 @@ describe("chart gallery integration with real adapters", () => {
     expect(toNivoBarData(result, { seriesLabel: gallerySeriesLabel })).toEqual(
       createGalleryState("nivo", "bar").adapterOutput
     );
+    expect(toNivoLatestBarData(result, { seriesLabel: gallerySeriesLabel })).toEqual(
+      createGalleryState("nivo", "latestBar").adapterOutput
+    );
+    expect(toNivoHistogramBarData(result, { seriesLabel: gallerySeriesLabel })).toEqual(
+      createGalleryState("nivo", "histogram").adapterOutput
+    );
     expect(toObservablePlotOptions(result, { seriesLabel: gallerySeriesLabel }).marks).toEqual(
       createGalleryState("observable", "line").adapterOutput.marks
     );
@@ -89,11 +107,26 @@ describe("chart gallery integration with real adapters", () => {
       createGalleryState("plotly", "donut").adapterOutput.data
     );
     expect(
+      toPlotlyLatestValuesFigure(result, {
+        chartType: "latestBar",
+        seriesLabel: gallerySeriesLabel,
+      }).data
+    ).toEqual(createGalleryState("plotly", "latestBar").adapterOutput.data);
+    expect(
       toApexChartsLatestValuesOptions(result, {
         chartType: "gauge",
         seriesLabel: gallerySeriesLabel,
       }).series
     ).toEqual(createGalleryState("apexcharts", "gauge").adapterOutput.series);
+    expect(
+      toApexChartsLatestValuesOptions(result, {
+        chartType: "latestBar",
+        seriesLabel: gallerySeriesLabel,
+      }).series
+    ).toEqual(createGalleryState("apexcharts", "latestBar").adapterOutput.series);
+    expect(
+      toApexChartsHistogramOptions(result, { seriesLabel: gallerySeriesLabel }).series
+    ).toEqual(createGalleryState("apexcharts", "histogram").adapterOutput.series);
     expect(
       toVictorySeries(result, { seriesLabel: gallerySeriesLabel }).map((series) => series.component)
     ).toEqual(
@@ -103,11 +136,26 @@ describe("chart gallery integration with real adapters", () => {
       createGalleryState("agcharts", "line").adapterOutput.series
     );
     expect(
+      toAgChartsLatestValuesOptions(result, {
+        chartType: "latestBar",
+        seriesLabel: gallerySeriesLabel,
+      }).series
+    ).toEqual(createGalleryState("agcharts", "latestBar").adapterOutput.series);
+    expect(toAgChartsHistogramOptions(result, { seriesLabel: gallerySeriesLabel }).series).toEqual(
+      createGalleryState("agcharts", "histogram").adapterOutput.series
+    );
+    expect(
       toHighchartsTimeSeriesOptions(result, { seriesLabel: gallerySeriesLabel }).series
     ).toEqual(createGalleryState("highcharts", "line").adapterOutput.series);
     expect(
       toHighchartsHistogramOptions(result, { seriesLabel: gallerySeriesLabel }).series
     ).toEqual(createGalleryState("highcharts", "histogram").adapterOutput.series);
+    expect(
+      toHighchartsLatestValuesOptions(result, {
+        chartType: "latestBar",
+        seriesLabel: gallerySeriesLabel,
+      }).series
+    ).toEqual(createGalleryState("highcharts", "latestBar").adapterOutput.series);
     expect(toVegaLiteSpec(result, { seriesLabel: gallerySeriesLabel }).mark).toBe(
       createGalleryState("vegalite", "line").adapterOutput.mark
     );


### PR DESCRIPTION
## Summary
- add real native adapter coverage for latest-bar and histogram shapes across package-backed chart libraries
- add ApexCharts histogram options and category latest bars, then restore those shapes to the gallery
- add Nivo latest-bar and histogram bar helpers, AG Charts native histogram/latest bars, and latest-bar branches for Plotly and Highcharts
- wire the gallery to exported adapters only, with tests comparing gallery output to the package adapter functions
- expand adapter docs with package-shaped recipes and reiterate the no gallery-only renderer rule

## Validation
- `npx biome check --write packages/adapters/src packages/adapters/test/index.test.ts site/charts/js/gallery-data.js site/charts/js/gallery-renderers.js site/charts/test/gallery-data.test.js site/charts/test/gallery-real-adapters.test.js`
- `npx vitest run packages/adapters/test/index.test.ts site/charts/test/gallery-data.test.js site/charts/test/gallery-content.test.js site/charts/test/gallery-real-adapters.test.js site/charts/test/gallery-renderers.test.js --no-coverage`
- `npm run typecheck:packages`
- `BASE_PATH=/o11ykit/charts/ npx vite build site/charts`
- `make test-fast`
- `npx biome check packages/adapters site/charts`
- `npm run build`

## Notes
- Browser smoke via Playwright was attempted, but local Chromium failed to launch with a macOS MachPort permission error before loading the page. The production site build and gallery integration tests passed.
- The original Codex worktree lost Git access because its `.git` pointer targets a protected `~/Documents` parent worktree record. I copied the edited files into a fresh clone under the Codex work area for this commit; source validation was run before the copy.
