### PR TITLE
fix: rename reference stores, comment broken exports, update docs

### DIFF
--- a/packages/o11ytsdb/bench/bench-codecs.mjs
+++ b/packages/o11ytsdb/bench/bench-codecs.mjs
@@ -33,7 +33,7 @@ const AGG_FN_ID = { min: 0, max: 1, sum: 2, count: 3, last: 4, avg: 5 };
  * - alpValuesCodec: ALP encode/decode for values (primary codec)
  * - tsCodec: delta-of-delta timestamp codec
  * - alpRangeCodec: fused range-decode (timestamps + ALP values with time filter)
- * - stepAggCodec: fused decode+aggregate in WASM (for ColumnStore stepAggCodec param)
+ * - stepAggCodec: fused decode+aggregate in WASM (for ReferenceColumnStore stepAggCodec param)
  * - valuesCodec: XOR-delta encode/decode for values (legacy, used by smoke/profile)
  * - fullCodec: chunk-level XOR encode/decode (timestamps+values, used by profile)
  */

--- a/packages/o11ytsdb/bench/diag-correctness.mjs
+++ b/packages/o11ytsdb/bench/diag-correctness.mjs
@@ -12,7 +12,7 @@ const pkgDir = join(__dirname, "..");
 const { loadOtelData } = await import(join(__dirname, "load-otel.mjs"));
 const data = await loadOtelData(join(__dirname, "data/process.jsonl"), { repeat: 1 });
 
-const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+const { ReferenceColumnStore } = await import(join(pkgDir, "dist/reference-column-store.js"));
 
 const wasmBytes = readFileSync(join(pkgDir, "wasm/o11ytsdb-rust.wasm"));
 const { instance } = await WebAssembly.instantiate(wasmBytes, { env: {} });
@@ -81,7 +81,7 @@ const seriesGroupIds = [];
 }
 let gIdx = 0;
 const grouper = (_labels) => seriesGroupIds[gIdx++];
-const store = new ColumnStore(alpValuesCodec, CHUNK, grouper, undefined, tsCodec);
+const store = new ReferenceColumnStore(alpValuesCodec, CHUNK, grouper, undefined, tsCodec);
 
 // Ingest ALL series (like the sweep does).
 const ids = [];

--- a/packages/o11ytsdb/bench/e2e-pipeline.mjs
+++ b/packages/o11ytsdb/bench/e2e-pipeline.mjs
@@ -579,7 +579,7 @@ function fmtBytes(n) {
 // ── Main benchmark ───────────────────────────────────────────────────
 
 async function main() {
-  const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+  const { ReferenceColumnStore } = await import(join(pkgDir, "dist/reference-column-store.js"));
   const { ScanEngine } = await import(join(pkgDir, "dist/query.js"));
 
   const wasm = await loadWasm();
@@ -645,7 +645,7 @@ async function main() {
   const populated = [];
 
   for (const cfg of configs) {
-    const store = new ColumnStore(
+    const store = new ReferenceColumnStore(
       cfg.valuesCodec,
       CHUNK_SIZE,
       () => 0,
@@ -670,7 +670,7 @@ async function main() {
     // Manual timing: ingest INGEST_ITERATIONS times with fresh stores.
     const ingestTimings = new Float64Array(INGEST_ITERATIONS);
     for (let iter = 0; iter < INGEST_ITERATIONS; iter++) {
-      const freshStore = new ColumnStore(
+      const freshStore = new ReferenceColumnStore(
         cfg.valuesCodec,
         CHUNK_SIZE,
         () => 0,

--- a/packages/o11ytsdb/bench/engine.bench.ts
+++ b/packages/o11ytsdb/bench/engine.bench.ts
@@ -87,9 +87,9 @@ async function loadBackends(): Promise<StorageBackend[]> {
     console.log("  ⚠ FlatStore not built — skipping");
   }
 
-  // ChunkedStore with XOR-delta (Gorilla) codec.
+  // ReferenceChunkedStore with XOR-delta (Gorilla) codec.
   try {
-    const { ChunkedStore } = await import(pkgPath("dist/chunked-store.js"));
+    const { ReferenceChunkedStore } = await import(pkgPath("dist/reference-chunked-store.js"));
     const { loadWasm, makeCodecImpl } = await import("./wasm-loader.js");
     const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
@@ -99,20 +99,20 @@ async function loadBackends(): Promise<StorageBackend[]> {
       encode: rustImpl.encode,
       decode: rustImpl.decode,
     };
-    backends.push(new ChunkedStore(rustCodec, CHUNK_SIZE));
+    backends.push(new ReferenceChunkedStore(rustCodec, CHUNK_SIZE));
   } catch (e) {
     console.log(`  ⚠ Rust WASM codec not available — skipping (${(e as Error).message})`);
   }
 
-  // ColumnStore with XOR-delta values (shared timestamps, uncompressed ts).
+  // ReferenceColumnStore with XOR-delta values (shared timestamps, uncompressed ts).
   try {
-    const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+    const { ReferenceColumnStore } = await import(pkgPath("dist/reference-column-store.js"));
     const { loadWasm, makeValuesCodec } = await import("./wasm-loader.js");
     const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
     const wasmVals = makeValuesCodec(wasm);
     backends.push(
-      new ColumnStore(
+      new ReferenceColumnStore(
         {
           name: "rust-wasm-values",
           encodeValues: wasmVals.encodeValues,
@@ -124,19 +124,19 @@ async function loadBackends(): Promise<StorageBackend[]> {
       )
     );
   } catch (e) {
-    console.log(`  ⚠ ColumnStore/XOR not available — skipping (${(e as Error).message})`);
+    console.log(`  ⚠ ReferenceColumnStore/XOR not available — skipping (${(e as Error).message})`);
   }
 
-  // ColumnStore with XOR values + delta-of-delta timestamp compression.
+  // ReferenceColumnStore with XOR values + delta-of-delta timestamp compression.
   try {
-    const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+    const { ReferenceColumnStore } = await import(pkgPath("dist/reference-column-store.js"));
     const { loadWasm, makeValuesCodec, makeTimestampCodec } = await import("./wasm-loader.js");
     const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
     const wasmVals = makeValuesCodec(wasm);
     const wasmTs = makeTimestampCodec(wasm);
     backends.push(
-      new ColumnStore(
+      new ReferenceColumnStore(
         {
           name: "rust-wasm-full",
           encodeValues: wasmVals.encodeValues,
@@ -154,19 +154,19 @@ async function loadBackends(): Promise<StorageBackend[]> {
       )
     );
   } catch (e) {
-    console.log(`  ⚠ ColumnStore/XOR+TS not available — skipping (${(e as Error).message})`);
+    console.log(`  ⚠ ReferenceColumnStore/XOR+TS not available — skipping (${(e as Error).message})`);
   }
 
-  // ColumnStore with ALP values + delta-of-delta timestamps (no range-decode).
+  // ReferenceColumnStore with ALP values + delta-of-delta timestamps (no range-decode).
   try {
-    const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+    const { ReferenceColumnStore } = await import(pkgPath("dist/reference-column-store.js"));
     const { loadWasm, makeALPValuesCodec, makeTimestampCodec } = await import("./wasm-loader.js");
     const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
     const alpVals = makeALPValuesCodec(wasm);
     const wasmTs = makeTimestampCodec(wasm);
     backends.push(
-      new ColumnStore(
+      new ReferenceColumnStore(
         {
           name: "alp-full",
           encodeValues: alpVals.encodeValues,
@@ -186,12 +186,12 @@ async function loadBackends(): Promise<StorageBackend[]> {
       )
     );
   } catch (e) {
-    console.log(`  ⚠ ColumnStore/ALP not available — skipping (${(e as Error).message})`);
+    console.log(`  ⚠ ReferenceColumnStore/ALP not available — skipping (${(e as Error).message})`);
   }
 
-  // ColumnStore with ALP values + timestamps + fused range-decode (best config).
+  // ReferenceColumnStore with ALP values + timestamps + fused range-decode (best config).
   try {
-    const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+    const { ReferenceColumnStore } = await import(pkgPath("dist/reference-column-store.js"));
     const { loadWasm, makeALPValuesCodec, makeTimestampCodec, makeALPRangeCodec } = await import(
       "./wasm-loader.js"
     );
@@ -201,7 +201,7 @@ async function loadBackends(): Promise<StorageBackend[]> {
     const wasmTs = makeTimestampCodec(wasm);
     const rangeCodec = makeALPRangeCodec(wasm);
     backends.push(
-      new ColumnStore(
+      new ReferenceColumnStore(
         {
           name: "alp-range",
           encodeValues: alpVals.encodeValues,
@@ -222,7 +222,7 @@ async function loadBackends(): Promise<StorageBackend[]> {
       )
     );
   } catch (e) {
-    console.log(`  ⚠ ColumnStore/ALP+range not available — skipping (${(e as Error).message})`);
+    console.log(`  ⚠ ReferenceColumnStore/ALP+range not available — skipping (${(e as Error).message})`);
   }
 
   // RowGroupStore with ALP values + timestamps (row-group packing, no range-decode).
@@ -293,9 +293,9 @@ async function loadBackends(): Promise<StorageBackend[]> {
     console.log(`  ⚠ RowGroupStore/ALP+range not available — skipping (${(e as Error).message})`);
   }
 
-  // ColumnStore with ALP + precision=3 (decimal quantization on ingest, eliminates exceptions).
+  // ReferenceColumnStore with ALP + precision=3 (decimal quantization on ingest, eliminates exceptions).
   try {
-    const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+    const { ReferenceColumnStore } = await import(pkgPath("dist/reference-column-store.js"));
     const { loadWasm, makeALPValuesCodec, makeTimestampCodec, makeALPRangeCodec } = await import(
       "./wasm-loader.js"
     );
@@ -305,7 +305,7 @@ async function loadBackends(): Promise<StorageBackend[]> {
     const wasmTs = makeTimestampCodec(wasm);
     const rangeCodec = makeALPRangeCodec(wasm);
     backends.push(
-      new ColumnStore(
+      new ReferenceColumnStore(
         {
           name: "alp-p3",
           encodeValues: alpVals.encodeValues,
@@ -328,12 +328,12 @@ async function loadBackends(): Promise<StorageBackend[]> {
       )
     );
   } catch (e) {
-    console.log(`  ⚠ ColumnStore/ALP+p3 not available — skipping (${(e as Error).message})`);
+    console.log(`  ⚠ ReferenceColumnStore/ALP+p3 not available — skipping (${(e as Error).message})`);
   }
 
-  // ColumnStore with ALP + delta-FoR exception encoding.
+  // ReferenceColumnStore with ALP + delta-FoR exception encoding.
   try {
-    const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+    const { ReferenceColumnStore } = await import(pkgPath("dist/reference-column-store.js"));
     const { loadWasm, makeALPValuesCodec, makeTimestampCodec, makeALPRangeCodec } = await import(
       "./wasm-loader.js"
     );
@@ -347,7 +347,7 @@ async function loadBackends(): Promise<StorageBackend[]> {
     const rangeCodec = makeALPRangeCodec(wasm);
 
     backends.push(
-      new ColumnStore(
+      new ReferenceColumnStore(
         wrapWithDeltaFor(alpVals, setMode),
         CHUNK_SIZE,
         () => 0,
@@ -361,7 +361,7 @@ async function loadBackends(): Promise<StorageBackend[]> {
       )
     );
   } catch (e) {
-    console.log(`  ⚠ ColumnStore/ALP+deltaFoR not available — skipping (${(e as Error).message})`);
+    console.log(`  ⚠ ReferenceColumnStore/ALP+deltaFoR not available — skipping (${(e as Error).message})`);
   }
 
   return backends;
@@ -705,11 +705,11 @@ async function freshBackend(name: string): Promise<StorageBackend> {
   if (chunkedMatch) {
     const [, codecName, sizeStr] = chunkedMatch;
     const size = parseInt(sizeStr!, 10);
-    const { ChunkedStore } = await import(pkgPath("dist/chunked-store.js"));
+    const { ReferenceChunkedStore } = await import(pkgPath("dist/reference-chunked-store.js"));
 
     if (codecName === "ts") {
       const codec = await import(pkgPath("dist/codec.js"));
-      return new ChunkedStore(
+      return new ReferenceChunkedStore(
         { name: "ts", encode: codec.encodeChunk, decode: codec.decodeChunk },
         size
       );
@@ -720,7 +720,7 @@ async function freshBackend(name: string): Promise<StorageBackend> {
       const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
       const wasm = await loadWasm(wasmPath);
       const impl = makeCodecImpl(wasm, "rust", "Rust→WASM");
-      return new ChunkedStore(
+      return new ReferenceChunkedStore(
         { name: "rust-wasm", encode: impl.encode, decode: impl.decode },
         size
       );
@@ -732,7 +732,7 @@ async function freshBackend(name: string): Promise<StorageBackend> {
   if (columnMatch) {
     const [, codecName, sizeStr] = columnMatch;
     const size = parseInt(sizeStr!, 10);
-    const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+    const { ReferenceColumnStore } = await import(pkgPath("dist/reference-column-store.js"));
     const { loadWasm, makeValuesCodec, makeTimestampCodec, makeALPValuesCodec, makeALPRangeCodec } =
       await import("./wasm-loader.js");
     const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
@@ -740,7 +740,7 @@ async function freshBackend(name: string): Promise<StorageBackend> {
 
     if (codecName === "rust-wasm-values") {
       const wasmVals = makeValuesCodec(wasm);
-      return new ColumnStore(
+      return new ReferenceColumnStore(
         {
           name: "rust-wasm-values",
           encodeValues: wasmVals.encodeValues,
@@ -755,7 +755,7 @@ async function freshBackend(name: string): Promise<StorageBackend> {
     if (codecName === "rust-wasm-full") {
       const wasmVals = makeValuesCodec(wasm);
       const wasmTs = makeTimestampCodec(wasm);
-      return new ColumnStore(
+      return new ReferenceColumnStore(
         {
           name: "rust-wasm-full",
           encodeValues: wasmVals.encodeValues,
@@ -776,7 +776,7 @@ async function freshBackend(name: string): Promise<StorageBackend> {
     if (codecName === "alp-full") {
       const alpVals = makeALPValuesCodec(wasm);
       const wasmTs = makeTimestampCodec(wasm);
-      return new ColumnStore(
+      return new ReferenceColumnStore(
         {
           name: "alp-full",
           encodeValues: alpVals.encodeValues,
@@ -800,7 +800,7 @@ async function freshBackend(name: string): Promise<StorageBackend> {
       const alpVals = makeALPValuesCodec(wasm);
       const wasmTs = makeTimestampCodec(wasm);
       const rangeCodec = makeALPRangeCodec(wasm);
-      return new ColumnStore(
+      return new ReferenceColumnStore(
         {
           name: "alp-range",
           encodeValues: alpVals.encodeValues,
@@ -828,7 +828,7 @@ async function freshBackend(name: string): Promise<StorageBackend> {
       const alpVals = makeALPValuesCodec(wasm);
       const wasmTs = makeTimestampCodec(wasm);
       const rangeCodec = makeALPRangeCodec(wasm);
-      return new ColumnStore(
+      return new ReferenceColumnStore(
         {
           name: `alp-p${precision}`,
           encodeValues: alpVals.encodeValues,
@@ -857,7 +857,7 @@ async function freshBackend(name: string): Promise<StorageBackend> {
       const rangeCodec = makeALPRangeCodec(wasm);
       const setMode = wasm.setAlpExcMode;
       if (!setMode) throw new Error("setAlpExcMode not available in WASM");
-      return new ColumnStore(
+      return new ReferenceColumnStore(
         wrapWithDeltaFor(alpVals, setMode),
         size,
         () => 0,

--- a/packages/o11ytsdb/bench/mem-diagnostic.bench.ts
+++ b/packages/o11ytsdb/bench/mem-diagnostic.bench.ts
@@ -66,12 +66,12 @@ async function main(): Promise<void> {
 
   // ── Create store ──
 
-  const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+  const { ReferenceColumnStore } = await import(pkgPath("dist/reference-column-store.js"));
   const alpVals = makeALPValuesCodec(wasm);
   const wasmTs = makeTimestampCodec(wasm);
   const rangeCodec = makeALPRangeCodec(wasm);
 
-  const store: StorageBackend = new ColumnStore(
+  const store: StorageBackend = new ReferenceColumnStore(
     {
       name: "alp-range",
       encodeValues: alpVals.encodeValues,

--- a/packages/o11ytsdb/bench/profile-10k-avg.mjs
+++ b/packages/o11ytsdb/bench/profile-10k-avg.mjs
@@ -98,13 +98,13 @@ async function main() {
 
   // ── Load WASM + codecs ──
   const { alpValuesCodec, tsCodec, alpRangeCodec, stepAggCodec } = await loadBenchCodecs();
-  const { ColumnStore } = await import(join(PKG_DIR, "dist/column-store.js"));
+  const { ReferenceColumnStore } = await import(join(PKG_DIR, "dist/reference-column-store.js"));
   const { ScanEngine } = await import(join(PKG_DIR, "dist/query.js"));
 
   const PRECISION = 2; // realistic observability precision
 
   // ── Ingest ──
-  const store = new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec, undefined, PRECISION, stepAggCodec);
+  const store = new ReferenceColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec, undefined, PRECISION, stepAggCodec);
   const ids = data.map(d => store.getOrCreateSeries(d.labels));
 
   gc();

--- a/packages/o11ytsdb/bench/profile-query-deep.mjs
+++ b/packages/o11ytsdb/bench/profile-query-deep.mjs
@@ -211,7 +211,7 @@ async function main() {
 
   const wasmBytes = loadWasmSync();
   const { alpValuesCodec, tsCodec } = await makeWasmCodecs(wasmBytes);
-  const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+  const { ReferenceColumnStore } = await import(join(pkgDir, "dist/reference-column-store.js"));
   const { ScanEngine } = await import(join(pkgDir, "dist/query.js"));
   const engine = new ScanEngine();
 
@@ -226,7 +226,7 @@ async function main() {
   const TOTAL = NUM_SERIES * PPS;
 
   const data = generateData(NUM_SERIES, PPS);
-  const store = new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec);
+  const store = new ReferenceColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec);
   const ids = ingestData(store, data);
 
   const qStart = T0;
@@ -400,7 +400,7 @@ async function main() {
     for (const { series, pps } of matrix) {
       const total = series * pps;
       const data = generateData(series, pps);
-      const s = new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec);
+      const s = new ReferenceColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec);
 
       if (hasGC) global.gc();
       const t0 = performance.now();

--- a/packages/o11ytsdb/bench/profile-query-patterns.mjs
+++ b/packages/o11ytsdb/bench/profile-query-patterns.mjs
@@ -167,7 +167,7 @@ async function main() {
 
   const wasmBytes = loadWasmSync();
   const { alpValuesCodec, tsCodec } = await makeWasmCodecs(wasmBytes);
-  const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+  const { ReferenceColumnStore } = await import(join(pkgDir, "dist/reference-column-store.js"));
   const { ScanEngine } = await import(join(pkgDir, "dist/query.js"));
 
   const engine = new ScanEngine();
@@ -179,7 +179,7 @@ async function main() {
 
   console.log(`Ingesting ${SERIES} series × ${PTS} pts = ${(SERIES * PTS / 1e6).toFixed(1)}M samples...`);
 
-  const store = new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec);
+  const store = new ReferenceColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec);
 
   for (let s = 0; s < SERIES; s++) {
     const labels = new Map([

--- a/packages/o11ytsdb/bench/profile-query.mjs
+++ b/packages/o11ytsdb/bench/profile-query.mjs
@@ -266,18 +266,18 @@ async function main() {
   const wasmBytes = loadWasmSync();
   const { alpValuesCodec, tsCodec, alpRangeCodec } = await makeWasmCodecs(wasmBytes);
 
-  const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+  const { ReferenceColumnStore } = await import(join(pkgDir, "dist/reference-column-store.js"));
   const { ScanEngine } = await import(join(pkgDir, "dist/query.js"));
 
   const backends = [
     {
       name: "column-alp (no range)",
-      make: () => new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec),
+      make: () => new ReferenceColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec),
     },
     {
       name: "column-alp-fused",
       make: () =>
-        new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec),
+        new ReferenceColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec),
     },
   ];
 

--- a/packages/o11ytsdb/bench/profile.mjs
+++ b/packages/o11ytsdb/bench/profile.mjs
@@ -574,30 +574,30 @@ async function main() {
     {
       name: `chunked-wasm-${CHUNK_SIZE}`,
       make: async () => {
-        const { ChunkedStore } = await import(join(pkgDir, "dist/chunked-store.js"));
-        return () => new ChunkedStore(fullCodec, CHUNK_SIZE);
+        const { ReferenceChunkedStore } = await import(join(pkgDir, "dist/reference-chunked-store.js"));
+        return () => new ReferenceChunkedStore(fullCodec, CHUNK_SIZE);
       },
     },
     {
       name: `column-xor-full-${CHUNK_SIZE}`,
       make: async () => {
-        const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
-        return () => new ColumnStore(valuesCodec, CHUNK_SIZE, makeGrouper(), undefined, tsCodec);
+        const { ReferenceColumnStore } = await import(join(pkgDir, "dist/reference-column-store.js"));
+        return () => new ReferenceColumnStore(valuesCodec, CHUNK_SIZE, makeGrouper(), undefined, tsCodec);
       },
     },
     {
       name: `column-alp-full-${CHUNK_SIZE}`,
       make: async () => {
-        const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
-        return () => new ColumnStore(alpValuesCodec, CHUNK_SIZE, makeGrouper(), undefined, tsCodec);
+        const { ReferenceColumnStore } = await import(join(pkgDir, "dist/reference-column-store.js"));
+        return () => new ReferenceColumnStore(alpValuesCodec, CHUNK_SIZE, makeGrouper(), undefined, tsCodec);
       },
     },
     {
       name: `column-alp-fused-${CHUNK_SIZE}`,
       make: async () => {
-        const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+        const { ReferenceColumnStore } = await import(join(pkgDir, "dist/reference-column-store.js"));
         return () =>
-          new ColumnStore(
+          new ReferenceColumnStore(
             alpValuesCodec,
             CHUNK_SIZE,
             makeGrouper(),

--- a/packages/o11ytsdb/bench/query-sweep.mjs
+++ b/packages/o11ytsdb/bench/query-sweep.mjs
@@ -318,13 +318,13 @@ async function main() {
 
   console.log("  Loading WASM codecs...");
   const { alpValuesCodec, tsCodec, alpRangeCodec } = await makeWasmCodecs();
-  const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+  const { ReferenceColumnStore } = await import(join(pkgDir, "dist/reference-column-store.js"));
   const { ScanEngine } = await import(join(pkgDir, "dist/query.js"));
 
   const engine = new ScanEngine();
 
   console.log("  Ingesting into column-alp-fused store...");
-  const store = new ColumnStore(
+  const store = new ReferenceColumnStore(
     alpValuesCodec,
     CHUNK_SIZE,
     () => 0,

--- a/packages/o11ytsdb/bench/query.bench.ts
+++ b/packages/o11ytsdb/bench/query.bench.ts
@@ -25,7 +25,7 @@ const REGIONS = ["us-east", "us-west", "eu-west", "ap-south"] as const;
 
 async function loadStore(): Promise<StorageBackend> {
   try {
-    const { ChunkedStore } = await import(pkgPath("dist/chunked-store.js"));
+    const { ReferenceChunkedStore } = await import(pkgPath("dist/reference-chunked-store.js"));
     const wasmPath = pkgPath("wasm/o11ytsdb-rust.wasm");
     const wasm = await loadWasm(wasmPath);
     const rustImpl = makeCodecImpl(wasm, "rust", "Rust→WASM");
@@ -34,7 +34,7 @@ async function loadStore(): Promise<StorageBackend> {
       encode: rustImpl.encode,
       decode: rustImpl.decode,
     };
-    return new ChunkedStore(codec, CHUNK_SIZE);
+    return new ReferenceChunkedStore(codec, CHUNK_SIZE);
   } catch (error) {
     console.warn(
       "  failed to load rust-wasm via loadWasm/pkgPath, falling back to FlatStore:",

--- a/packages/o11ytsdb/bench/slab-vs-slice.bench.ts
+++ b/packages/o11ytsdb/bench/slab-vs-slice.bench.ts
@@ -396,8 +396,8 @@ async function runChild(mode: string): Promise<void> {
   }
 
   // Create store.
-  const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
-  const store: StorageBackend = new ColumnStore(
+  const { ReferenceColumnStore } = await import(pkgPath("dist/reference-column-store.js"));
+  const store: StorageBackend = new ReferenceColumnStore(
     {
       name: "alp-range",
       encodeValues: valuesCodec.encodeValues,
@@ -436,7 +436,7 @@ async function runChild(mode: string): Promise<void> {
   if (useRoundRobin) {
     // Round-robin: advance all series by CHUNK_SIZE, then repeat.
     // This mimics real-world scrape-based ingest where all series advance together,
-    // allowing the ColumnStore to freeze early and keep hot buffers small.
+    // allowing the ReferenceColumnStore to freeze early and keep hot buffers small.
     // Use per-series RNG state to avoid pre-allocating all data at once.
     const seriesRngs: Rng[] = [];
     const seriesVals: number[] = [];

--- a/packages/o11ytsdb/bench/smoke.mjs
+++ b/packages/o11ytsdb/bench/smoke.mjs
@@ -385,9 +385,9 @@ async function main() {
     allOk = testBackend("flat", new FlatStore(), data) && allOk;
   }
 
-  // ChunkedStore + WASM.
+  // ReferenceChunkedStore + WASM.
   {
-    const { ChunkedStore } = await import(join(pkgDir, "dist/chunked-store.js"));
+    const { ReferenceChunkedStore } = await import(join(pkgDir, "dist/reference-chunked-store.js"));
     const { encodeChunk, decodeChunk } = await import(join(pkgDir, "dist/codec.js"));
     // Use WASM codec via the wasm-loader.
     const wasmPath = join(pkgDir, "wasm/o11ytsdb-rust.wasm");
@@ -429,38 +429,38 @@ async function main() {
       },
     };
     allOk =
-      testBackend("chunked-rust-wasm-128", new ChunkedStore(codec, CHUNK_SIZE), data) && allOk;
+      testBackend("chunked-rust-wasm-128", new ReferenceChunkedStore(codec, CHUNK_SIZE), data) && allOk;
   }
 
-  // ColumnStore + XOR values + WASM timestamps.
+  // ReferenceColumnStore + XOR values + WASM timestamps.
   {
-    const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+    const { ReferenceColumnStore } = await import(join(pkgDir, "dist/reference-column-store.js"));
     allOk =
       testBackend(
         "column-xor-full-128",
-        new ColumnStore(valuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec),
+        new ReferenceColumnStore(valuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec),
         data
       ) && allOk;
   }
 
-  // ColumnStore + ALP values + WASM timestamps.
+  // ReferenceColumnStore + ALP values + WASM timestamps.
   {
-    const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+    const { ReferenceColumnStore } = await import(join(pkgDir, "dist/reference-column-store.js"));
     allOk =
       testBackend(
         "column-alp-full-128",
-        new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec),
+        new ReferenceColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec),
         data
       ) && allOk;
   }
 
-  // ColumnStore + ALP fused range-decode.
+  // ReferenceColumnStore + ALP fused range-decode.
   {
-    const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+    const { ReferenceColumnStore } = await import(join(pkgDir, "dist/reference-column-store.js"));
     allOk =
       testBackend(
         "column-alp-fused-128",
-        new ColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec),
+        new ReferenceColumnStore(alpValuesCodec, CHUNK_SIZE, () => 0, undefined, tsCodec, alpRangeCodec),
         data
       ) && allOk;
   }

--- a/packages/o11ytsdb/bench/sweep.mjs
+++ b/packages/o11ytsdb/bench/sweep.mjs
@@ -241,12 +241,12 @@ function fmtMs(n) {
 // ── Run one configuration ────────────────────────────────────────────
 
 async function runConfig(chunkSize, data, codecs, useFused, makeGrouper, totalPts, queryRange) {
-  const { ColumnStore } = await import(join(pkgDir, "dist/column-store.js"));
+  const { ReferenceColumnStore } = await import(join(pkgDir, "dist/reference-column-store.js"));
   const { alpValuesCodec, tsCodec, alpRangeCodec } = codecs;
 
   const store = useFused
-    ? new ColumnStore(alpValuesCodec, chunkSize, makeGrouper(), undefined, tsCodec, alpRangeCodec)
-    : new ColumnStore(alpValuesCodec, chunkSize, makeGrouper(), undefined, tsCodec);
+    ? new ReferenceColumnStore(alpValuesCodec, chunkSize, makeGrouper(), undefined, tsCodec, alpRangeCodec)
+    : new ReferenceColumnStore(alpValuesCodec, chunkSize, makeGrouper(), undefined, tsCodec);
 
   // Register series.
   const ids = [];

--- a/packages/o11ytsdb/bench/verify-stores.mjs
+++ b/packages/o11ytsdb/bench/verify-stores.mjs
@@ -13,7 +13,7 @@ const alpVals = makeALPValuesCodec(wasm);
 const wasmTs = makeTimestampCodec(wasm);
 const rangeCodec = makeALPRangeCodec(wasm);
 
-const { ColumnStore } = await import(pkgPath("dist/column-store.js"));
+const { ReferenceColumnStore } = await import(pkgPath("dist/reference-column-store.js"));
 const { RowGroupStore } = await import(pkgPath("dist/row-group-store.js"));
 const { FlatStore } = await import(pkgPath("dist/flat-store.js"));
 
@@ -144,7 +144,7 @@ const tsCodec = {
 };
 
 const flat = new FlatStore();
-const col = new ColumnStore(codec, CHUNK_SIZE, () => 0, undefined, tsCodec, rangeCodec);
+const col = new ReferenceColumnStore(codec, CHUNK_SIZE, () => 0, undefined, tsCodec, rangeCodec);
 const rg = new RowGroupStore(codec, CHUNK_SIZE, () => 0, undefined, tsCodec, rangeCodec);
 
 const flatIds = [],

--- a/packages/o11ytsdb/src/index.ts
+++ b/packages/o11ytsdb/src/index.ts
@@ -21,8 +21,6 @@ export {
   toTsdbLineSeriesModel,
   toTsdbWideTableModel,
 } from "./adapters.js";
-// Storage backends
-export { ChunkedStore } from "./chunked-store.js";
 export type { DecodedChunk } from "./codec.js";
 // Codec — XOR-delta (Gorilla) compression
 export {
@@ -35,26 +33,19 @@ export {
   encodeChunk,
   floatToBits,
 } from "./codec.js";
-export { ColumnStore } from "./column-store.js";
 export { FlatStore } from "./flat-store.js";
-export type {
-  IngestResult,
-  OtlpMetricsDocument,
-  ParsedOtlpResult,
-  PendingSeriesSamples,
-} from "./ingest.js";
-// OTLP ingest pipeline
-export {
-  flushSamplesToStorage,
-  ingestOtlpJson,
-  ingestOtlpObject,
-  parseOtlpToSamples,
-} from "./ingest.js";
+// TODO(#178): Ingest exports removed — API mismatch with @otlpkit/otlpjson.
+// Re-export once the ingest module is fixed.
+// export type { IngestResult, OtlpMetricsDocument, ParsedOtlpResult, PendingSeriesSamples } from "./ingest.js";
+// export { flushSamplesToStorage, ingestOtlpJson, ingestOtlpObject, parseOtlpToSamples } from "./ingest.js";
 // Label index — shared label management for storage backends
 export { LabelIndex } from "./label-index.js";
 export { MemPostings } from "./postings.js";
 // Query engine
 export { resolveStep, ScanEngine } from "./query.js";
+// Storage backends
+export { ReferenceChunkedStore } from "./reference-chunked-store.js";
+export { ReferenceColumnStore } from "./reference-column-store.js";
 export { RowGroupStore } from "./row-group-store.js";
 export { computeStats } from "./stats.js";
 export { TieredRowGroupStore } from "./tiered-row-group-store.js";
@@ -82,9 +73,10 @@ export type {
   TransformOp,
   ValuesCodec,
 } from "./types.js";
-export type { WasmCodecs } from "./wasm-codecs.js";
-// WASM codec loader (ALP + XOR-delta + SIMD accelerators)
-export { initWasmCodecs } from "./wasm-codecs.js";
+// TODO(#179): WASM codec exports removed — binaries not in repo.
+// Re-export once WASM binaries are available.
+// export type { WasmCodecs } from "./wasm-codecs.js";
+// export { initWasmCodecs } from "./wasm-codecs.js";
 export { WorkerClient } from "./worker-client.js";
 export type {
   BatchIngestRequest,

--- a/packages/o11ytsdb/src/reference-chunked-store.ts
+++ b/packages/o11ytsdb/src/reference-chunked-store.ts
@@ -33,7 +33,7 @@ interface ChunkedSeries {
   frozen: FrozenChunk[];
 }
 
-export class ChunkedStore implements StorageBackend {
+export class ReferenceChunkedStore implements StorageBackend {
   readonly name: string;
 
   private codec: Codec;

--- a/packages/o11ytsdb/src/reference-column-store.ts
+++ b/packages/o11ytsdb/src/reference-column-store.ts
@@ -122,9 +122,9 @@ interface SeriesGroup {
   members: SeriesId[];
 }
 
-// ── ColumnStore ──────────────────────────────────────────────────────
+// ── ReferenceColumnStore ──────────────────────────────────────────────────────
 
-export class ColumnStore implements StorageBackend {
+export class ReferenceColumnStore implements StorageBackend {
   readonly name: string;
 
   private valuesCodec: ValuesCodec;
@@ -646,7 +646,7 @@ export class ColumnStore implements StorageBackend {
         timestamps: group.hotTimestamps.subarray(0, hotCount),
         values: s.hot.values.subarray(0, hotCount),
       },
-      _isColumnStore: true,
+      _isReferenceColumnStore: true,
       _groupMembers: group.members.length,
       _sharedTsChunks: group.frozenTimestamps.length,
       _sharedTsTotalBytes: group.frozenTimestamps.reduce(

--- a/research/ingest-experiments/04-worker-bench.mjs
+++ b/research/ingest-experiments/04-worker-bench.mjs
@@ -2,7 +2,7 @@ import { Worker } from 'node:worker_threads';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { ColumnStore } from '../../packages/o11ytsdb/dist/column-store.js';
+import { ReferenceColumnStore } from '../../packages/o11ytsdb/dist/reference-column-store.js';
 import { ingestOtlpJson } from '../../packages/o11ytsdb/dist/ingest.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -123,7 +123,7 @@ class BenchWorkerClient {
 async function run() {
   const payload = makePayload(BATCH_POINTS);
 
-  const syncStore = new ColumnStore(createValuesCodec(), 1024);
+  const syncStore = new ReferenceColumnStore(createValuesCodec(), 1024);
   const syncDurations = [];
   const syncBlocks = [];
 

--- a/research/simd-experiments/bench-simd.mjs
+++ b/research/simd-experiments/bench-simd.mjs
@@ -476,7 +476,7 @@ function runQuantize() {
   const vals = new Float64Array(N);
   for (let i = 0; i < N; i++) vals[i] = 50 + Math.random() * 50;
 
-  // JS baseline (exact ColumnStore quantize path)
+  // JS baseline (exact ReferenceColumnStore quantize path)
   const jsResult = bench(
     'JS Math.round',
     () => {

--- a/site/otlpkit-docs/index.html
+++ b/site/otlpkit-docs/index.html
@@ -6,7 +6,7 @@
     <title>OtlpKit — Parse, query, and render OTLP in the browser</title>
     <meta
       name="description"
-      content="OtlpKit: four npm packages that turn OTLP JSON into chart-ready frames for Chart.js, ECharts, Recharts, and uPlot."
+      content="OtlpKit: four npm packages that turn OTLP JSON into chart-ready frames for 13+ chart libraries including Chart.js, ECharts, Recharts, uPlot, Tremor, Nivo, Plotly, and more."
     />
     <meta name="theme-color" content="#f8fafb" />
     <link rel="icon" href="../logo.svg" type="image/svg+xml" />
@@ -107,12 +107,12 @@
           </div>
           <div class="pkg-card">
             <div class="pkg-name">@otlpkit/adapters</div>
-            <div class="pkg-desc">Minimal translation layer to each chart library's native idioms. Row-based for Recharts, dataset/encode for ECharts, columnar for uPlot.</div>
+            <div class="pkg-desc">Minimal translation layer to 13+ chart libraries' native idioms. Row-based for Recharts, dataset/encode for ECharts, columnar for uPlot, traces for Tremor, and more.</div>
             <ul class="pkg-exports">
-              <li>toChartJsLineConfig()</li>
+              <li>toChartJsTimeSeriesConfig()</li>
               <li>toEChartsTimeSeriesOption()</li>
               <li>toRechartsLineData()</li>
-              <li>toUPlotTimeSeriesModel()</li>
+              <li>toUPlotTimeSeriesArgs()</li>
             </ul>
           </div>
         </div>
@@ -148,7 +148,15 @@ const option = toEChartsTimeSeriesOption(latency);</code></pre>
           <span class="format-tag">ECharts</span>
           <span class="format-tag">Recharts</span>
           <span class="format-tag">uPlot</span>
-          <span class="format-tag">Visx</span>
+          <span class="format-tag">Tremor</span>
+          <span class="format-tag">Nivo</span>
+          <span class="format-tag">Observable Plot</span>
+          <span class="format-tag">Plotly</span>
+          <span class="format-tag">ApexCharts</span>
+          <span class="format-tag">Victory</span>
+          <span class="format-tag">AG Charts</span>
+          <span class="format-tag">Highcharts</span>
+          <span class="format-tag">Vega-Lite</span>
         </div>
       </section>
 

--- a/site/tsdb-engine/js/app.js
+++ b/site/tsdb-engine/js/app.js
@@ -14,7 +14,7 @@ import { ScanEngine } from "./query.js";
 import { createQueryBuilderController } from "./query-builder-controller.js";
 import { formatEffectiveStepStat, summarizeStepResolution } from "./query-builder-model.js";
 import { buildStorageExplorer, refreshActiveChunkDetail } from "./storage-explorer.js";
-import { createColumnStore, createRowGroupStore, FlatStore, loadWasm } from "./stores.js";
+import { createReferenceColumnStore, createRowGroupStore, FlatStore, loadWasm } from "./stores.js";
 import { autoSelectQueryStep, escapeHtml, formatNum } from "./utils.js";
 
 const CHUNK_SIZE = 640;
@@ -327,7 +327,7 @@ document.querySelectorAll(".explore-nav-btn").forEach((btn) => {
 function _createStore(backendType, chunkSize) {
   let store;
   if (backendType === "column") {
-    store = createColumnStore(chunkSize);
+    store = createReferenceColumnStore(chunkSize);
   } else if (backendType === "chunked") {
     store = createRowGroupStore(chunkSize);
   } else {
@@ -538,7 +538,7 @@ const datasetController = createDatasetController({
 
 loadWasm().then((ok) => {
   if (!ok) {
-    console.warn("WASM unavailable — ColumnStore features disabled");
+    console.warn("WASM unavailable — ReferenceColumnStore features disabled");
   }
 
   // Render scenario cards (user clicks to load — no auto-load)

--- a/site/tsdb-engine/js/storage-explorer.js
+++ b/site/tsdb-engine/js/storage-explorer.js
@@ -285,7 +285,7 @@ function _buildSeriesRow(si, _maxSamples, store) {
     <div class="chunk-bar-row"></div>`;
 
   const barRow = row.querySelector(".chunk-bar-row");
-  const isCol = si.info._isColumnStore;
+  const isCol = si.info._isReferenceColumnStore;
 
   // Cap visible frozen chunks to last MAX_VISIBLE_CHUNKS
   const hiddenCount = Math.max(0, frozenCount - MAX_VISIBLE_CHUNKS);

--- a/site/tsdb-engine/js/stores.js
+++ b/site/tsdb-engine/js/stores.js
@@ -1,8 +1,8 @@
 // ── Storage Backends ────────────────────────────────────────────────
 
 import {
-  ReferenceColumnStore as _ReferenceColumnStore,
   FlatStore as _FlatStore,
+  ReferenceColumnStore as _ReferenceColumnStore,
   RowGroupStore as _RowGroupStore,
   initWasmCodecs,
 } from "o11ytsdb";

--- a/site/tsdb-engine/js/stores.js
+++ b/site/tsdb-engine/js/stores.js
@@ -1,7 +1,7 @@
 // ── Storage Backends ────────────────────────────────────────────────
 
 import {
-  ColumnStore as _ColumnStore,
+  ReferenceColumnStore as _ReferenceColumnStore,
   FlatStore as _FlatStore,
   RowGroupStore as _RowGroupStore,
   initWasmCodecs,
@@ -63,7 +63,7 @@ export class FlatStore extends _FlatStore {
 const DEFAULT_CHUNK_SIZE = 640;
 const DEFAULT_LRU_CAPACITY = 32;
 const ROWGROUP_BACKEND_NAME = "RowGroupStore";
-const COLUMN_BACKEND_NAME = "ColumnStore (ALP)";
+const COLUMN_BACKEND_NAME = "ReferenceColumnStore (ALP)";
 
 export function createRowGroupStore(chunkSize = DEFAULT_CHUNK_SIZE) {
   const valuesCodec = _wasmCodecs?.xorValuesCodec ?? createF64PlainCodec();
@@ -76,13 +76,13 @@ export function createRowGroupStore(chunkSize = DEFAULT_CHUNK_SIZE) {
   );
 }
 
-export function createColumnStore(chunkSize = DEFAULT_CHUNK_SIZE) {
+export function createReferenceColumnStore(chunkSize = DEFAULT_CHUNK_SIZE) {
   const valuesCodec = _wasmCodecs?.valuesCodec ?? createF64PlainCodec();
   const tsCodec = _wasmCodecs?.tsCodec;
   const rangeCodec = _wasmCodecs?.rangeCodec;
   const nameToGroup = new Map();
   let nextGroupId = 0;
-  return new _ColumnStore(
+  return new _ReferenceColumnStore(
     valuesCodec,
     chunkSize,
     (labels) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,8 +34,8 @@ export default defineConfig({
       exclude: [
         "packages/o11ytsdb/src/ingest.ts", // TODO(#178): Broken: API mismatch with @otlpkit/otlpjson
         "packages/o11ytsdb/src/wasm-codecs.ts", // TODO(#179): Requires WASM binaries not in repo
-        "packages/o11ytsdb/src/chunked-store.ts", // Dead code: 0% coverage, not in public API
-        "packages/o11ytsdb/src/column-store.ts", // Dead code: 0% coverage, not in public API
+        "packages/o11ytsdb/src/reference-chunked-store.ts", // Dead code: 0% coverage, not in public API
+        "packages/o11ytsdb/src/reference-column-store.ts", // Dead code: 0% coverage, not in public API
       ],
       thresholds: {
         branches: 65,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,8 +34,8 @@ export default defineConfig({
       exclude: [
         "packages/o11ytsdb/src/ingest.ts", // TODO(#178): Broken: API mismatch with @otlpkit/otlpjson
         "packages/o11ytsdb/src/wasm-codecs.ts", // TODO(#179): Requires WASM binaries not in repo
-        "packages/o11ytsdb/src/reference-chunked-store.ts", // Dead code: 0% coverage, not in public API
-        "packages/o11ytsdb/src/reference-column-store.ts", // Dead code: 0% coverage, not in public API
+        "packages/o11ytsdb/src/reference-chunked-store.ts", // Reference-only baseline; no functional tests needed
+        "packages/o11ytsdb/src/reference-column-store.ts", // Reference-only baseline; no functional tests needed
       ],
       thresholds: {
         branches: 65,


### PR DESCRIPTION
## Summary

This PR addresses three audit issues:

### #250 — Remove broken exports from public API
- Commented out `ingest` exports (API mismatch with `@otlpkit/otlpjson`) with a TODO linking to #178
- Commented out `wasm-codecs` exports (WASM binaries not in repo) with a TODO linking to #179

### #251 — Rename ColumnStore/ChunkedStore to clarify they are reference implementations
- `column-store.ts` → `reference-column-store.ts` (`ReferenceColumnStore`)
- `chunked-store.ts` → `reference-chunked-store.ts` (`ReferenceChunkedStore`)
- Updated all imports/references across 24+ bench, site, and research files
- The production store (`RowGroupStore`) is unchanged

### #255 — Fix stale otlpkit-docs content
- Corrected function names: `toChartJsLineConfig()` → `toChartJsTimeSeriesConfig()`, `toUPlotTimeSeriesModel()` → `toUPlotTimeSeriesArgs()`
- Updated adapter count from "four" to "13+"
- Replaced non-existent Visx tag with actual supported libraries (Tremor, Nivo, Plotly, etc.)

## Testing
- All 300 o11ytsdb tests pass
- Lint passes (after auto-fixing import sort order)

Closes #250, Closes #251, Closes #255