### PR TITLE
fix: remove false claims, soften over-promises, polish site nav

### DIFF
--- a/site/benchkit/index.html
+++ b/site/benchkit/index.html
@@ -24,6 +24,7 @@
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+          <a href="/o11ykit/charts/">Charts</a>
           <a href="/o11ykit/tracesdb-engine/">TracesDB</a>
           <a href="/o11ykit/logsdb-engine/">LogsDB</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>

--- a/site/index.html
+++ b/site/index.html
@@ -6,7 +6,7 @@
     <title>o11ykit &middot; OTLP in. Pixels out.</title>
     <meta
       name="description"
-      content="Browser-native databases for metrics, traces, and logs. Columnar compression at sub-4 bytes per point, zero-latency cross-signal correlation, and no backend required. The observability database category the browser never had."
+      content="Browser-native databases for metrics, traces, and logs. Columnar storage, local cross-signal correlation, and no backend required. The observability database category the browser never had."
     />
     <meta name="theme-color" content="#F2EFE7" />
     <link rel="icon" href="./logo.svg" type="image/svg+xml" />
@@ -46,7 +46,7 @@
           <p class="hero-sub">
             Every observability SPA today is a dumb terminal&mdash;every pan, zoom, and filter
             round-trips to a backend. o11ykit puts a real columnar database in the browser:
-            sub-4 bytes per point, instant cross-signal correlation, zero GC pressure.
+            compact columnar storage, local cross-signal correlation, and browser-side querying.
             No Prometheus. No Elasticsearch. No backend.
           </p>
           <div class="hero-actions">
@@ -60,7 +60,7 @@
             <div class="pipeline-step pipeline-arrow-r">
               <div class="pipeline-step-num">01</div>
               <div class="pipeline-step-name">OTLP</div>
-              <div class="pipeline-step-desc">Protobuf or JSON ingest via OtlpKit</div>
+              <div class="pipeline-step-desc">JSON ingest via OtlpKit</div>
             </div>
             <div class="pipeline-step pipeline-arrow-r">
               <div class="pipeline-step-num">02</div>
@@ -113,7 +113,7 @@
             <div class="primitive-card">
               <span class="primitive-name">tsdb</span>
               <span class="primitive-signal">metrics</span>
-              <p class="primitive-desc">ALP + XOR-delta + dictionary encoding. Sub-4 bytes per sample. Columnar compression purpose-built for time-series.</p>
+              <p class="primitive-desc">ALP + XOR-delta + dictionary encoding for compact time-series storage. Columnar compression purpose-built for metrics.</p>
               <a class="primitive-link" href="/o11ykit/tsdb-engine/">demo</a>
             </div>
             <div class="primitive-card">
@@ -131,7 +131,7 @@
             <div class="primitive-card">
               <span class="primitive-name">otlpkit</span>
               <span class="primitive-signal">ingest</span>
-              <p class="primitive-desc">OTLP protobuf and JSON decoder. Zero-copy where possible. Streams directly into o11y*db columnar format.</p>
+              <p class="primitive-desc">OTLP JSON decoder. Streams directly into o11y*db columnar format.</p>
               <a class="primitive-link" href="/o11ykit/otlpkit-docs/">docs</a>
             </div>
             <div class="primitive-card">
@@ -189,7 +189,7 @@ logTable.update(logs);</pre>
                 <hr class="hair" />
                 <div>
                   <span class="tag" style="margin-bottom:6px;display:inline-block">step 3</span>
-                  <p class="t-body" style="margin:4px 0 0">Render all three panels in the same animation frame. Total latency: 0 ms network, sub-ms compute.</p>
+                  <p class="t-body" style="margin:4px 0 0">Render all three panels without network round-trips. Compute stays local to the page.</p>
                 </div>
               </div>
             </div>

--- a/site/logsdb-engine/index.html
+++ b/site/logsdb-engine/index.html
@@ -6,7 +6,7 @@
     <title>o11ylogsdb — Browser-Native Log Database Engine</title>
     <meta
       name="description"
-      content="Interactive documentation for o11ylogsdb: a browser-native log database with Drain template extraction, FSST compression, typed columnar codecs, and real-time query engine. Generate millions of logs and query them live."
+      content="Interactive documentation for o11ylogsdb: a browser-native log database with Drain templating, typed columnar codecs, and local query exploration."
     />
     <meta name="theme-color" content="#11110F" />
     <link rel="icon" href="/o11ykit/logo.svg" type="image/svg+xml" />
@@ -26,6 +26,7 @@
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+          <a href="/o11ykit/charts/">Charts</a>
           <a href="/o11ykit/tracesdb-engine/">TracesDB</a>
           <a href="/o11ykit/logsdb-engine/" aria-current="page">LogsDB</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
@@ -41,7 +42,7 @@
          <p class="hero-lede">
           Generate realistic observability log datasets, inspect byte-level storage
           efficiency, and query them in real-time. Drain template extraction + typed
-          columnar codecs achieve 20–60× compression over raw OTLP/JSON.
+          columnar codecs target major storage reduction over raw OTLP/JSON.
         </p>
         <div class="hero-actions">
            <a class="stamp-fill" href="#section-dataset">Launch Live Demo ↓</a>
@@ -112,7 +113,7 @@
             <strong>How log storage works:</strong> Each service gets its own <em>stream</em>.
             Within a stream, logs are batched into <em>chunks</em> of ~1024 records.
             Drain template extraction finds repeating patterns and stores variable slots
-            in typed columnar encodings — achieving 3–17 bytes/log vs ~350 bytes raw.
+            in typed columnar encodings — for compact log storage with chunk-level summaries and typed columns.
           </div>
 
           <h3>Per-Service Storage Breakdown</h3>
@@ -129,7 +130,7 @@
           <div class="learn-callout">
             <strong>How log analysis works:</strong> The engine queries chunks using zone-map
             pruning — each chunk header stores severity and time ranges. Chunks that can't
-            match are skipped without decoding, making queries over millions of logs sub-second.
+            match are skipped without decoding, reducing query work on larger log datasets.
           </div>
 
           <div id="logs-loading" class="muted" hidden>Analyzing...</div>

--- a/site/otlpkit/index.html
+++ b/site/otlpkit/index.html
@@ -24,6 +24,7 @@
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit/" aria-current="page">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+          <a href="/o11ykit/charts/">Charts</a>
           <a href="/o11ykit/tracesdb-engine/">TracesDB</a>
           <a href="/o11ykit/logsdb-engine/">LogsDB</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
@@ -42,7 +43,7 @@
         </p>
         <div class="hero-actions">
            <a class="stamp-fill" href="/o11ykit/otlpkit-docs/">Open package docs</a>
-           <a class="stamp" href="/o11ykit/#experiences">Browse interactive routes</a>
+           <a class="stamp" href="/o11ykit/">Browse site overview</a>
           <a class="stamp" href="https://github.com/strawgate/o11ykit/tree/main/packages" target="_blank" rel="noreferrer">Browse package sources</a>
         </div>
         <div class="pill-row" aria-label="Core capabilities">

--- a/site/tracesdb-engine/index.html
+++ b/site/tracesdb-engine/index.html
@@ -6,11 +6,11 @@
     <title>o11ytracesdb — Browser-Native Distributed Traces Database</title>
     <meta
       name="description"
-      content="SQLite for observability in the browser. o11ytracesdb stores OpenTelemetry spans at &lt;30 bytes/span with dictionary encoding, bloom filter lookups, and structural queries — zero network calls."
+      content="o11ytracesdb stores OpenTelemetry spans with dictionary encoding, bloom-filter-assisted lookup, and structural queries in the browser — zero network calls."
     />
     <meta name="theme-color" content="#f8fafb" />
     <meta property="og:title" content="o11ytracesdb — SQLite for Traces in the Browser" />
-    <meta property="og:description" content="Store 500K+ OpenTelemetry spans at &lt;30 bytes/span. Dictionary encoding, bloom filters, structural queries — all client-side, zero network calls." />
+    <meta property="og:description" content="Store 500K+ OpenTelemetry spans with dictionary encoding, bloom filters, structural queries — all client-side, zero network calls." />
     <meta property="og:type" content="website" />
     <link rel="icon" href="/o11ykit/logo.svg" type="image/svg+xml" />
     <base href="/o11ykit/tracesdb-engine/" />
@@ -33,6 +33,7 @@
         <nav class="topnav" aria-label="Primary">
           <a href="/o11ykit/otlpkit-docs/">OtlpKit</a>
           <a href="/o11ykit/tsdb-engine/">TSDB Engine</a>
+          <a href="/o11ykit/charts/">Charts</a>
           <a href="/o11ykit/tracesdb-engine/" aria-current="page">TracesDB</a>
           <a href="/o11ykit/logsdb-engine/">LogsDB</a>
           <a href="/o11ykit/octo11y/">Octo11y</a>
@@ -47,7 +48,7 @@
         <h1>A distributed traces database<br/>that runs <em>in your browser</em>.</h1>
         <p class="hero-sub">SQLite for observability — embedded, serverless, zero network calls.</p>
         <p class="hero-lede">
-          Store hundreds of thousands of OpenTelemetry spans at <strong>&lt;30 bytes/span</strong> using
+          Store hundreds of thousands of OpenTelemetry spans with compact
           columnar compression and dictionary encoding. Query with structural operators, explore with
           bloom-accelerated lookups, and visualize waterfalls — all client-side. No backend required.
         </p>

--- a/site/tracesdb-engine/learn/index.html
+++ b/site/tracesdb-engine/learn/index.html
@@ -297,7 +297,7 @@
           <p class="lede">
             A browser-native traces database takes hundreds of thousands of OpenTelemetry spans
             and packs them into a fraction of their original size — then answers structural queries
-            across all of them in milliseconds.
+            across them locally in the browser.
             <br /><br />
             Each experience below lets you <strong>see</strong> and <strong>interact</strong> with
             one piece of that puzzle. Click any card to explore.
@@ -315,7 +315,7 @@
 │  Waterfall Rendering    │ span → pixel mapping
 └─────────────────────────┘
   ↓
-Answer in &lt;1ms</div>
+Answer locally</div>
         </div>
       </div>
 

--- a/site/tsdb-engine/learn/index.html
+++ b/site/tsdb-engine/learn/index.html
@@ -157,7 +157,7 @@
         <div class="hub-intro">
           <p class="lede">
             A time-series database takes billions of floating-point measurements and packs them into
-            a fraction of their original size — then answers queries across all of them in milliseconds.
+            a fraction of their original size — then answers queries across them locally in the browser.
             <br/><br/>
             Each experience below lets you <strong>see</strong> and <strong>interact</strong> with
             one piece of that puzzle. Click any card to explore.
@@ -176,7 +176,7 @@
 │  Query Builder          │ fluent API → plan tree
 └─────────────────────────┘
   ↓
-Answer in &lt;1ms</div>
+Answer locally</div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

This PR addresses three audit issues related to site content accuracy and polish.

### #248 — Remove false protobuf claims
- Homepage pipeline diagram: "Protobuf or JSON ingest" → "JSON ingest"
- OtlpKit card: "OTLP protobuf and JSON decoder. Zero-copy where possible." → "OTLP JSON decoder."

### #252 — Soften over-promised performance claims
- Homepage meta/hero: removed "sub-4 bytes per point", "zero GC pressure", "sub-ms compute"
- TracesDB: removed "<30 bytes/span" (contradicted by package README stating ~50 B/span)
- LogsDB: softened "20–60× compression" and "3–17 bytes/log" to general language
- Learn pages: replaced "answers queries in milliseconds" / "Answer in <1ms" with "locally in the browser"

### #258 — Site polish
- Fixed broken `#experiences` anchor on OtlpKit page
- Added missing "Charts" nav link to otlpkit, benchkit, tracesdb, and logsdb subpage navigation

All changes are content-only (HTML). No code changes.

Closes #248, Closes #252, Closes #258