### PR TITLE
fix: rewrite examples to use RowGroupStore + ScanEngine (gallery contract)

### DIFF
--- a/examples/chartjs/package.json
+++ b/examples/chartjs/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@otlpkit/adapters": "file:../../packages/adapters",
-    "@otlpkit/views": "file:../../packages/views",
+    "o11ytsdb": "file:../../packages/o11ytsdb",
     "chart.js": "^4.5.1"
   }
 }

--- a/examples/chartjs/src/main.ts
+++ b/examples/chartjs/src/main.ts
@@ -1,12 +1,11 @@
 import {
-  toChartJsViewHistogramConfig,
-  toChartJsViewLatestValuesConfig,
-  toChartJsViewLineConfig,
+  toChartJsHistogramConfig,
+  toChartJsLatestValuesConfig,
+  toChartJsTimeSeriesConfig,
 } from "@otlpkit/adapters/chartjs";
-import { buildHistogramFrame, buildLatestValuesFrame, buildTimeSeriesFrame } from "@otlpkit/views";
 import Chart from "chart.js/auto";
 
-import { sampleMetricsDocument } from "../../shared/sample.js";
+import { query } from "../../shared/store.js";
 
 function requireCanvas(selector: string): HTMLCanvasElement {
   const canvas = document.querySelector<HTMLCanvasElement>(selector);
@@ -16,27 +15,13 @@ function requireCanvas(selector: string): HTMLCanvasElement {
   return canvas;
 }
 
-const timeSeriesFrame = buildTimeSeriesFrame(sampleMetricsDocument, {
-  metricName: "logfwd.inflight_batches",
-  intervalMs: 1000,
-  splitBy: "output",
-  title: "Inflight batches by output",
-});
-const latestValuesFrame = buildLatestValuesFrame(sampleMetricsDocument, {
-  metricName: "logfwd.inflight_batches",
-  splitBy: "output",
-  title: "Latest inflight batches by output",
-});
-const histogramFrame = buildHistogramFrame(sampleMetricsDocument, {
-  metricName: "logfwd.output.duration",
-  title: "Output duration histogram",
-  binCount: 6,
-});
+// Query the RowGroupStore via ScanEngine
+const result = query();
 
 for (const [selector, config] of [
-  ["#time-series", toChartJsViewLineConfig(timeSeriesFrame)],
-  ["#latest-values", toChartJsViewLatestValuesConfig(latestValuesFrame)],
-  ["#histogram", toChartJsViewHistogramConfig(histogramFrame)],
+  ["#time-series", toChartJsTimeSeriesConfig(result, { timestampUnit: "nanoseconds" })],
+  ["#latest-values", toChartJsLatestValuesConfig(result, { timestampUnit: "nanoseconds" })],
+  ["#histogram", toChartJsHistogramConfig(result, { timestampUnit: "nanoseconds" })],
 ] as const) {
   const context = requireCanvas(selector).getContext("2d");
   if (!context) {

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@otlpkit/adapters": "file:../../packages/adapters",
-    "@otlpkit/views": "file:../../packages/views",
+    "o11ytsdb": "file:../../packages/o11ytsdb",
     "react": "^19.2.6",
     "react-dom": "^19.2.5",
     "recharts": "^3.8.1",

--- a/examples/demo/src/demo-store.ts
+++ b/examples/demo/src/demo-store.ts
@@ -19,8 +19,15 @@ const valuesCodec: ValuesCodec = {
   },
   decodeValues(buf: Uint8Array): Float64Array {
     if (buf.byteLength < 4) return new Float64Array(0);
-    const count = new DataView(buf.buffer, buf.byteOffset, buf.byteLength).getUint32(0, true);
-    return new Float64Array(buf.buffer, buf.byteOffset + 4, count);
+    const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+    const count = dv.getUint32(0, true);
+    const requiredBytes = 4 + count * 8;
+    if (buf.byteLength < requiredBytes) return new Float64Array(0);
+    const result = new Float64Array(count);
+    for (let i = 0; i < count; i++) {
+      result[i] = dv.getFloat64(4 + i * 8, true);
+    }
+    return result;
   },
 };
 
@@ -116,11 +123,8 @@ const durationSeries = store.getOrCreateSeries(
   new Map([["__name__", "checkout.request.duration_ms"]])
 );
 
-// Generate duration samples that create a realistic histogram shape
-const durationSamples = [
-  65, 72, 78, 85, 88, 92, 95, 98, 102, 108, 112, 118, 125, 132, 140, 148, 155, 165, 178, 192, 205,
-  220, 245, 260, 285, 310,
-];
+// Generate duration samples that create a realistic histogram shape (one per second, aligned to END_S)
+const durationSamples = [65, 72, 78, 85, 88, 92, 95, 98, 102, 108, 112, 118, 125];
 
 for (const [i, value] of durationSamples.entries()) {
   const timestamp = BigInt(START_S + i) * NS_PER_S;

--- a/examples/demo/src/demo-store.ts
+++ b/examples/demo/src/demo-store.ts
@@ -1,0 +1,166 @@
+/**
+ * Demo store: ingests deterministic incident scenario metrics into
+ * a RowGroupStore for the demo gallery example.
+ *
+ * Gallery contract: data lives in real o11ytsdb storage, queried via ScanEngine.
+ */
+
+import type { QueryOpts, QueryResult, ValuesCodec } from "o11ytsdb";
+import { RowGroupStore, ScanEngine } from "o11ytsdb";
+
+// ── Minimal values codec ────────────────────────────────────────────
+const valuesCodec: ValuesCodec = {
+  name: "f64-plain",
+  encodeValues(values: Float64Array): Uint8Array {
+    const out = new Uint8Array(4 + values.byteLength);
+    new DataView(out.buffer).setUint32(0, values.length, true);
+    out.set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), 4);
+    return out;
+  },
+  decodeValues(buf: Uint8Array): Float64Array {
+    if (buf.byteLength < 4) return new Float64Array(0);
+    const count = new DataView(buf.buffer, buf.byteOffset, buf.byteLength).getUint32(0, true);
+    return new Float64Array(buf.buffer, buf.byteOffset + 4, count);
+  },
+};
+
+// ── Deterministic sample data ───────────────────────────────────────
+const NS_PER_S = 1_000_000_000n;
+const START_S = 1; // seconds
+const END_S = 13;
+
+const store: RowGroupStore = new RowGroupStore(valuesCodec, 64, () => 0, 32, "demo-store");
+export const engine: ScanEngine = new ScanEngine();
+
+// ── Metric 1: checkout.inflight_requests (gauge, by route) ──────────
+const inflightRoutes = ["/checkout", "/inventory", "/payment"] as const;
+const inflightSeries = inflightRoutes.map((route) =>
+  store.getOrCreateSeries(
+    new Map([
+      ["__name__", "checkout.inflight_requests"],
+      ["route", route],
+    ])
+  )
+);
+
+const inflightData: Record<string, number[]> = {
+  "/checkout": [12, 15, 22, 28, 31, 27, 19, 14, 10, 8, 6, 5, 4],
+  "/inventory": [8, 10, 14, 18, 22, 20, 16, 12, 9, 7, 5, 4, 3],
+  "/payment": [5, 7, 11, 16, 24, 30, 26, 20, 15, 11, 8, 6, 4],
+};
+
+for (let s = START_S; s <= END_S; s++) {
+  const timestamp = BigInt(s) * NS_PER_S;
+  store.append(
+    new BigInt64Array([timestamp]),
+    inflightSeries.map((id, i) => ({
+      id,
+      values: new Float64Array([inflightData[inflightRoutes[i]!]![s - START_S]!]),
+    }))
+  );
+}
+
+// ── Metric 2: checkout.retry_rate (gauge, by route) ─────────────────
+const retrySeries = inflightRoutes.map((route) =>
+  store.getOrCreateSeries(
+    new Map([
+      ["__name__", "checkout.retry_rate"],
+      ["route", route],
+    ])
+  )
+);
+
+const retryData: Record<string, number[]> = {
+  "/checkout": [0.5, 1.2, 2.8, 4.1, 5.3, 4.8, 3.2, 2.1, 1.4, 0.8, 0.5, 0.3, 0.2],
+  "/inventory": [0.3, 0.6, 1.4, 2.2, 3.1, 2.8, 2.0, 1.3, 0.9, 0.5, 0.3, 0.2, 0.1],
+  "/payment": [0.8, 1.5, 3.2, 5.6, 7.8, 8.2, 6.5, 4.3, 2.8, 1.6, 1.0, 0.6, 0.4],
+};
+
+for (let s = START_S; s <= END_S; s++) {
+  const timestamp = BigInt(s) * NS_PER_S;
+  store.append(
+    new BigInt64Array([timestamp]),
+    retrySeries.map((id, i) => ({
+      id,
+      values: new Float64Array([retryData[inflightRoutes[i]!]![s - START_S]!]),
+    }))
+  );
+}
+
+// ── Metric 3: checkout.error_rate (gauge, by route) ─────────────────
+const errorSeries = inflightRoutes.map((route) =>
+  store.getOrCreateSeries(
+    new Map([
+      ["__name__", "checkout.error_rate"],
+      ["route", route],
+    ])
+  )
+);
+
+const errorFinalValues: Record<string, number> = {
+  "/checkout": 2.1,
+  "/inventory": 1.4,
+  "/payment": 4.8,
+};
+
+// Single point at end for latest-values display
+for (const [i, route] of inflightRoutes.entries()) {
+  const timestamp = BigInt(END_S) * NS_PER_S;
+  store.append(new BigInt64Array([timestamp]), [
+    { id: errorSeries[i]!, values: new Float64Array([errorFinalValues[route]!]) },
+  ]);
+}
+
+// ── Metric 4: checkout.request.duration_ms (gauge samples for histogram) ─
+const durationSeries = store.getOrCreateSeries(
+  new Map([["__name__", "checkout.request.duration_ms"]])
+);
+
+// Generate duration samples that create a realistic histogram shape
+const durationSamples = [
+  65, 72, 78, 85, 88, 92, 95, 98, 102, 108, 112, 118, 125, 132, 140, 148, 155, 165, 178, 192, 205,
+  220, 245, 260, 285, 310,
+];
+
+for (const [i, value] of durationSamples.entries()) {
+  const timestamp = BigInt(START_S + i) * NS_PER_S;
+  store.append(new BigInt64Array([timestamp]), [
+    { id: durationSeries, values: new Float64Array([value]) },
+  ]);
+}
+
+// ── Metric 5: collector.cpu_percent (gauge, by pod) ─────────────────
+const pods = ["collector-1", "collector-2"] as const;
+const cpuSeries = pods.map((pod) =>
+  store.getOrCreateSeries(
+    new Map([
+      ["__name__", "collector.cpu_percent"],
+      ["pod", pod],
+    ])
+  )
+);
+
+const cpuData: Record<string, number[]> = {
+  "collector-1": [12, 15, 22, 35, 42, 38, 28, 20, 16, 14, 12, 11, 10],
+  "collector-2": [8, 10, 18, 28, 35, 32, 25, 18, 14, 11, 9, 8, 7],
+};
+
+for (let s = START_S; s <= END_S; s++) {
+  const timestamp = BigInt(s) * NS_PER_S;
+  store.append(
+    new BigInt64Array([timestamp]),
+    cpuSeries.map((id, i) => ({
+      id,
+      values: new Float64Array([cpuData[pods[i]!]![s - START_S]!]),
+    }))
+  );
+}
+
+// ── Exports ─────────────────────────────────────────────────────────
+export { store };
+
+const fullRange = { start: BigInt(START_S) * NS_PER_S, end: BigInt(END_S) * NS_PER_S };
+
+export function queryMetric(metric: string, opts?: Partial<QueryOpts>): QueryResult {
+  return engine.query(store, { metric, ...fullRange, ...opts });
+}

--- a/examples/demo/src/main.tsx
+++ b/examples/demo/src/main.tsx
@@ -1,10 +1,9 @@
 import {
-  toRechartsViewHistogramData,
-  toRechartsViewLatestValuesData,
-  toRechartsViewTimeSeriesData,
+  toRechartsHistogramData,
+  toRechartsLatestValuesData,
+  toRechartsTimeSeriesData,
 } from "@otlpkit/adapters/recharts";
-import { toUPlotViewTimeSeriesArgs } from "@otlpkit/adapters/uplot";
-import { buildHistogramFrame, buildLatestValuesFrame, buildTimeSeriesFrame } from "@otlpkit/views";
+import { toUPlotTimeSeriesArgs } from "@otlpkit/adapters/uplot";
 import type { JSX } from "react";
 import { useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
@@ -22,43 +21,23 @@ import {
 import uPlot, { type AlignedData, type Options, type Series } from "uplot";
 import "uplot/dist/uPlot.min.css";
 
-import { demoMetricsDocument } from "./demo-data.js";
+import { queryMetric } from "./demo-store.js";
 import "./styles.css";
 
-const inflightFrame = buildTimeSeriesFrame(demoMetricsDocument, {
-  metricName: "checkout.inflight_requests",
-  intervalMs: 1000,
-  splitBy: "route",
-  title: "Checkout inflight requests",
-});
-const retryFrame = buildTimeSeriesFrame(demoMetricsDocument, {
-  metricName: "checkout.retry_rate",
-  intervalMs: 1000,
-  splitBy: "route",
-  title: "Retry-rate turbulence",
-});
-const errorFrame = buildLatestValuesFrame(demoMetricsDocument, {
-  metricName: "checkout.error_rate",
-  splitBy: "route",
-  title: "Final route error rates",
-});
-const durationFrame = buildHistogramFrame(demoMetricsDocument, {
-  metricName: "checkout.request.duration_ms",
-  title: "Request latency shape",
-  binCount: 7,
-});
-const collectorPulseFrame = buildTimeSeriesFrame(demoMetricsDocument, {
-  metricName: "collector.cpu_percent",
-  intervalMs: 1000,
-  splitBy: "pod",
-  title: "Collector heartbeat",
-});
+// Query the RowGroupStore via ScanEngine for each metric
+const inflightResult = queryMetric("checkout.inflight_requests");
+const retryResult = queryMetric("checkout.retry_rate");
+const errorResult = queryMetric("checkout.error_rate");
+const durationResult = queryMetric("checkout.request.duration_ms");
+const cpuResult = queryMetric("collector.cpu_percent");
 
-const inflightModel = toRechartsViewTimeSeriesData(inflightFrame);
-const retryModel = toRechartsViewTimeSeriesData(retryFrame);
-const errorModel = toRechartsViewLatestValuesData(errorFrame);
-const durationModel = toRechartsViewHistogramData(durationFrame);
-const collectorPulseModel = toUPlotViewTimeSeriesArgs(collectorPulseFrame);
+const adapterOpts = { timestampUnit: "nanoseconds" as const };
+
+const inflightModel = toRechartsTimeSeriesData(inflightResult, adapterOpts);
+const retryModel = toRechartsTimeSeriesData(retryResult, adapterOpts);
+const errorModel = toRechartsLatestValuesData(errorResult, adapterOpts);
+const durationModel = toRechartsHistogramData(durationResult, { ...adapterOpts, bucketCount: 7 });
+const collectorPulseModel = toUPlotTimeSeriesArgs(cpuResult, adapterOpts);
 
 const routeKeys = inflightModel.series.map((series) => series.dataKey);
 const peakInflight = inflightModel.data.reduce((peak, row) => {
@@ -68,23 +47,41 @@ const peakInflight = inflightModel.data.reduce((peak, row) => {
   }, 0);
   return Math.max(peak, total);
 }, 0);
-const highestErrorRoute = errorFrame.rows.reduce<(typeof errorFrame.rows)[number] | null>(
-  (worst, row) => (!worst || row.value > worst.value ? row : worst),
+const highestErrorRoute = errorModel.data.reduce<(typeof errorModel.data)[number] | null>(
+  (worst, row) => {
+    const currentVal = typeof row.value === "number" ? row.value : 0;
+    const worstVal = worst ? (typeof worst.value === "number" ? worst.value : 0) : 0;
+    return !worst || currentVal > worstVal ? row : worst;
+  },
   null
 );
-const retrySamples = retryFrame.series.flatMap((series) => series.points);
+const retryValues = retryModel.data.flatMap((row) =>
+  retryModel.series.map((s) => {
+    const v = row[s.dataKey];
+    return typeof v === "number" ? v : 0;
+  })
+);
 const averageRetryRate =
-  retrySamples.length > 0
-    ? retrySamples.reduce((sum, point) => sum + point.value, 0) / retrySamples.length
-    : 0;
-const modalLatencyBin = durationFrame.bins.reduce<(typeof durationFrame.bins)[number] | null>(
-  (mostFrequent, bin) => (!mostFrequent || bin.count > mostFrequent.count ? bin : mostFrequent),
+  retryValues.length > 0 ? retryValues.reduce((s, v) => s + v, 0) / retryValues.length : 0;
+const modalLatencyBin = durationModel.data.reduce<(typeof durationModel.data)[number] | null>(
+  (mostFrequent, bin) => {
+    const currentCount = typeof bin.count === "number" ? bin.count : 0;
+    const bestCount = mostFrequent
+      ? typeof mostFrequent.count === "number"
+        ? mostFrequent.count
+        : 0
+      : 0;
+    return !mostFrequent || currentCount > bestCount ? bin : mostFrequent;
+  },
   null
 );
 const healthScore = Math.max(
   0,
   Math.round(
-    100 - peakInflight * 0.23 - (highestErrorRoute?.value ?? 0) * 8 - averageRetryRate * 14
+    100 -
+      peakInflight * 0.23 -
+      (typeof highestErrorRoute?.value === "number" ? highestErrorRoute.value : 0) * 8 -
+      averageRetryRate * 14
   )
 );
 
@@ -227,7 +224,7 @@ function App(): JSX.Element {
         <StoryStat label="Peak inflight load" value={`${peakInflight} requests`} />
         <StoryStat
           label="Highest error route"
-          value={`${highestErrorRoute?.label ?? "unknown"} (${(highestErrorRoute?.value ?? 0).toFixed(1)}%)`}
+          value={`${highestErrorRoute?.label ?? "unknown"} (${(typeof highestErrorRoute?.value === "number" ? highestErrorRoute.value : 0).toFixed(1)}%)`}
         />
         <StoryStat label="Mean retry rate" value={`${averageRetryRate.toFixed(2)}%`} />
         <StoryStat label="Incident health score" value={`${healthScore}/100`} />
@@ -362,8 +359,8 @@ function App(): JSX.Element {
       </section>
 
       <footer className="footer-note">
-        Data source: synthetic OTLP metrics in <code>examples/demo/src/demo-data.ts</code>. Advanced
-        pattern: processor + ring buffer diagnostics API.
+        Data source: deterministic metrics in <code>examples/demo/src/demo-store.ts</code>, stored
+        in a RowGroupStore and queried via ScanEngine.
       </footer>
     </main>
   );

--- a/examples/echarts/package.json
+++ b/examples/echarts/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@otlpkit/adapters": "file:../../packages/adapters",
-    "@otlpkit/views": "file:../../packages/views",
+    "o11ytsdb": "file:../../packages/o11ytsdb",
     "echarts": "^6.0.0"
   }
 }

--- a/examples/echarts/src/main.ts
+++ b/examples/echarts/src/main.ts
@@ -1,15 +1,14 @@
 import {
-  toEChartsViewHistogramOption,
-  toEChartsViewLatestValuesOption,
-  toEChartsViewTimeSeriesOption,
+  toEChartsHistogramOption,
+  toEChartsLatestValuesOption,
+  toEChartsTimeSeriesOption,
 } from "@otlpkit/adapters/echarts";
-import { buildHistogramFrame, buildLatestValuesFrame, buildTimeSeriesFrame } from "@otlpkit/views";
 import { BarChart, LineChart } from "echarts/charts";
 import { GridComponent, LegendComponent, TooltipComponent } from "echarts/components";
 import { init, use } from "echarts/core";
 import { CanvasRenderer } from "echarts/renderers";
 
-import { sampleMetricsDocument } from "../../shared/sample.js";
+import { query } from "../../shared/store.js";
 
 use([CanvasRenderer, GridComponent, LegendComponent, LineChart, BarChart, TooltipComponent]);
 
@@ -21,27 +20,13 @@ function requireContainer(selector: string): HTMLDivElement {
   return container;
 }
 
-const timeSeriesFrame = buildTimeSeriesFrame(sampleMetricsDocument, {
-  metricName: "logfwd.inflight_batches",
-  intervalMs: 1000,
-  splitBy: "output",
-  title: "Inflight batches by output",
-});
-const latestValuesFrame = buildLatestValuesFrame(sampleMetricsDocument, {
-  metricName: "logfwd.inflight_batches",
-  splitBy: "output",
-  title: "Latest inflight batches by output",
-});
-const histogramFrame = buildHistogramFrame(sampleMetricsDocument, {
-  metricName: "logfwd.output.duration",
-  title: "Output duration histogram",
-  binCount: 6,
-});
+// Query the RowGroupStore via ScanEngine
+const result = query();
 
 for (const [selector, option] of [
-  ["#time-series", toEChartsViewTimeSeriesOption(timeSeriesFrame)],
-  ["#latest-values", toEChartsViewLatestValuesOption(latestValuesFrame)],
-  ["#histogram", toEChartsViewHistogramOption(histogramFrame)],
+  ["#time-series", toEChartsTimeSeriesOption(result, { timestampUnit: "nanoseconds" })],
+  ["#latest-values", toEChartsLatestValuesOption(result, { timestampUnit: "nanoseconds" })],
+  ["#histogram", toEChartsHistogramOption(result, { timestampUnit: "nanoseconds" })],
 ] as const) {
   init(requireContainer(selector)).setOption(option);
 }

--- a/examples/recharts/package.json
+++ b/examples/recharts/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@otlpkit/adapters": "file:../../packages/adapters",
-    "@otlpkit/views": "file:../../packages/views",
+    "o11ytsdb": "file:../../packages/o11ytsdb",
     "react": "^19.2.6",
     "react-dom": "^19.2.5",
     "recharts": "^3.8.1"

--- a/examples/recharts/src/main.tsx
+++ b/examples/recharts/src/main.tsx
@@ -1,9 +1,8 @@
 import {
-  toRechartsViewHistogramData,
-  toRechartsViewLatestValuesData,
-  toRechartsViewTimeSeriesData,
+  toRechartsHistogramData,
+  toRechartsLatestValuesData,
+  toRechartsTimeSeriesData,
 } from "@otlpkit/adapters/recharts";
-import { buildHistogramFrame, buildLatestValuesFrame, buildTimeSeriesFrame } from "@otlpkit/views";
 import type { JSX } from "react";
 import { createRoot } from "react-dom/client";
 import {
@@ -19,27 +18,14 @@ import {
   YAxis,
 } from "recharts";
 
-import { sampleMetricsDocument } from "../../shared/sample.js";
+import { query } from "../../shared/store.js";
 
-const frame = buildTimeSeriesFrame(sampleMetricsDocument, {
-  metricName: "logfwd.inflight_batches",
-  intervalMs: 1000,
-  splitBy: "output",
-  title: "Inflight batches by output",
-});
-const latestValuesFrame = buildLatestValuesFrame(sampleMetricsDocument, {
-  metricName: "logfwd.inflight_batches",
-  splitBy: "output",
-  title: "Latest inflight batches by output",
-});
-const histogramFrame = buildHistogramFrame(sampleMetricsDocument, {
-  metricName: "logfwd.output.duration",
-  title: "Output duration histogram",
-  binCount: 6,
-});
-const timeSeriesModel = toRechartsViewTimeSeriesData(frame);
-const latestValuesModel = toRechartsViewLatestValuesData(latestValuesFrame);
-const histogramModel = toRechartsViewHistogramData(histogramFrame);
+// Query the RowGroupStore via ScanEngine
+const result = query();
+
+const timeSeriesModel = toRechartsTimeSeriesData(result, { timestampUnit: "nanoseconds" });
+const latestValuesModel = toRechartsLatestValuesData(result, { timestampUnit: "nanoseconds" });
+const histogramModel = toRechartsHistogramData(result, { timestampUnit: "nanoseconds" });
 
 function App(): JSX.Element {
   return (
@@ -78,11 +64,7 @@ function App(): JSX.Element {
               <YAxis unit={latestValuesModel.unit ?? ""} />
               <Tooltip />
               <Legend />
-              <Bar
-                dataKey={latestValuesModel.valueKey}
-                fill="#4c8bf5"
-                name={latestValuesFrame.title}
-              />
+              <Bar dataKey={latestValuesModel.valueKey} fill="#4c8bf5" name="Latest duration" />
             </BarChart>
           </ResponsiveContainer>
         </div>
@@ -97,7 +79,7 @@ function App(): JSX.Element {
               <YAxis unit={histogramModel.unit ?? ""} />
               <Tooltip />
               <Legend />
-              <Bar dataKey={histogramModel.valueKey} fill="#0f9d58" name={histogramFrame.title} />
+              <Bar dataKey={histogramModel.valueKey} fill="#0f9d58" name="Duration histogram" />
             </BarChart>
           </ResponsiveContainer>
         </div>

--- a/examples/shared/store.ts
+++ b/examples/shared/store.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared example store: ingests deterministic sample metrics into a
+ * RowGroupStore and exposes helpers for querying via ScanEngine.
+ *
+ * Gallery contract: every example starts from real o11ytsdb storage +
+ * ScanEngine.query(...) using the optimized RowGroupStore path.
+ */
+
+import type { QueryOpts, QueryResult, ValuesCodec } from "o11ytsdb";
+import { RowGroupStore, ScanEngine } from "o11ytsdb";
+
+// ── Minimal values codec (f64 plain) ────────────────────────────────
+const valuesCodec: ValuesCodec = {
+  name: "f64-plain",
+  encodeValues(values: Float64Array): Uint8Array {
+    const out = new Uint8Array(4 + values.byteLength);
+    new DataView(out.buffer).setUint32(0, values.length, true);
+    out.set(new Uint8Array(values.buffer, values.byteOffset, values.byteLength), 4);
+    return out;
+  },
+  decodeValues(buf: Uint8Array): Float64Array {
+    if (buf.byteLength < 4) return new Float64Array(0);
+    const count = new DataView(buf.buffer, buf.byteOffset, buf.byteLength).getUint32(0, true);
+    return new Float64Array(buf.buffer, buf.byteOffset + 4, count);
+  },
+};
+
+// ── Sample metric constants ─────────────────────────────────────────
+const METRIC_NAME = "http.request.duration_ms";
+const START_MS = 1_714_200_000_000; // deterministic epoch
+const STEP_MS = 10_000; // 10-second intervals
+const POINTS = 30; // 30 data points per series
+const NS_PER_MS = 1_000_000n;
+
+const SERIES = [
+  { service: "checkout", route: "/cart", status: "2xx", base: 74, phase: 0.2 },
+  { service: "checkout", route: "/pay", status: "5xx", base: 108, phase: 1.8 },
+  { service: "api", route: "/search", status: "2xx", base: 62, phase: 2.4 },
+  { service: "worker", route: "/jobs", status: "2xx", base: 88, phase: 3.1 },
+];
+
+function sampleValue(
+  series: (typeof SERIES)[number],
+  seriesIndex: number,
+  sampleIndex: number
+): number {
+  return series.base + 20 * Math.sin(series.phase + sampleIndex * 0.4 + seriesIndex * 0.7);
+}
+
+// ── Build the store ─────────────────────────────────────────────────
+const store: RowGroupStore = new RowGroupStore(valuesCodec, 64, () => 0, 32, "example-store");
+
+const seriesIds = SERIES.map((s) =>
+  store.getOrCreateSeries(
+    new Map([
+      ["__name__", METRIC_NAME],
+      ["service", s.service],
+      ["route", s.route],
+      ["status_class", s.status],
+    ])
+  )
+);
+
+// Append all samples
+for (let i = 0; i < POINTS; i++) {
+  const timestamp = BigInt(START_MS + i * STEP_MS) * NS_PER_MS;
+  store.append(
+    new BigInt64Array([timestamp]),
+    seriesIds.map((id, seriesIndex) => ({
+      id,
+      values: new Float64Array([sampleValue(SERIES[seriesIndex]!, seriesIndex, i)]),
+    }))
+  );
+}
+
+// ── Exports ─────────────────────────────────────────────────────────
+export const engine: ScanEngine = new ScanEngine();
+export { store };
+
+/** Full time range query for the sample metric. */
+export const defaultQuery: QueryOpts = {
+  metric: METRIC_NAME,
+  start: BigInt(START_MS) * NS_PER_MS,
+  end: BigInt(START_MS + (POINTS - 1) * STEP_MS) * NS_PER_MS,
+};
+
+/** Query the store with optional overrides. */
+export function query(opts?: Partial<QueryOpts>): QueryResult {
+  return engine.query(store, { ...defaultQuery, ...opts });
+}

--- a/examples/shared/store.ts
+++ b/examples/shared/store.ts
@@ -20,8 +20,15 @@ const valuesCodec: ValuesCodec = {
   },
   decodeValues(buf: Uint8Array): Float64Array {
     if (buf.byteLength < 4) return new Float64Array(0);
-    const count = new DataView(buf.buffer, buf.byteOffset, buf.byteLength).getUint32(0, true);
-    return new Float64Array(buf.buffer, buf.byteOffset + 4, count);
+    const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+    const count = dv.getUint32(0, true);
+    const requiredBytes = 4 + count * 8;
+    if (buf.byteLength < requiredBytes) return new Float64Array(0);
+    const result = new Float64Array(count);
+    for (let i = 0; i < count; i++) {
+      result[i] = dv.getFloat64(4 + i * 8, true);
+    }
+    return result;
   },
 };
 

--- a/examples/uplot/package.json
+++ b/examples/uplot/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@otlpkit/adapters": "file:../../packages/adapters",
-    "@otlpkit/views": "file:../../packages/views",
+    "o11ytsdb": "file:../../packages/o11ytsdb",
     "uplot": "^1.6.31"
   }
 }

--- a/examples/uplot/src/main.ts
+++ b/examples/uplot/src/main.ts
@@ -1,9 +1,8 @@
-import { toUPlotViewLatestValuesArgs, toUPlotViewTimeSeriesArgs } from "@otlpkit/adapters/uplot";
-import { buildLatestValuesFrame, buildTimeSeriesFrame } from "@otlpkit/views";
+import { toUPlotLatestValuesArgs, toUPlotTimeSeriesArgs } from "@otlpkit/adapters/uplot";
 import uPlot, { type AlignedData, type Options, type Series } from "uplot";
 import "uplot/dist/uPlot.min.css";
 
-import { sampleMetricsDocument } from "../../shared/sample.js";
+import { query } from "../../shared/store.js";
 
 function requireContainer(selector: string): HTMLDivElement {
   const container = document.querySelector<HTMLDivElement>(selector);
@@ -13,20 +12,17 @@ function requireContainer(selector: string): HTMLDivElement {
   return container;
 }
 
-const timeSeriesFrame = buildTimeSeriesFrame(sampleMetricsDocument, {
-  metricName: "logfwd.inflight_batches",
-  intervalMs: 1000,
-  splitBy: "output",
-  title: "Inflight batches by output",
-});
-const latestValuesFrame = buildLatestValuesFrame(sampleMetricsDocument, {
-  metricName: "logfwd.inflight_batches",
-  splitBy: "output",
-  title: "Latest inflight batches by output",
-});
+// Query the RowGroupStore via ScanEngine
+const result = query();
 
-const timeSeriesModel = toUPlotViewTimeSeriesArgs(timeSeriesFrame);
-const latestValuesModel = toUPlotViewLatestValuesArgs(latestValuesFrame);
+const timeSeriesModel = toUPlotTimeSeriesArgs(result, {
+  timestampUnit: "nanoseconds",
+  title: "HTTP request duration by route",
+});
+const latestValuesModel = toUPlotLatestValuesArgs(result, {
+  timestampUnit: "nanoseconds",
+  title: "Latest values by route",
+});
 
 const timeSeriesOptions: Options = {
   width: 960,

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,15 +67,15 @@
       "name": "@otlpkit/example-chartjs",
       "dependencies": {
         "@otlpkit/adapters": "file:../../packages/adapters",
-        "@otlpkit/views": "file:../../packages/views",
-        "chart.js": "^4.5.1"
+        "chart.js": "^4.5.1",
+        "o11ytsdb": "file:../../packages/o11ytsdb"
       }
     },
     "examples/demo": {
       "name": "@otlpkit/example-demo",
       "dependencies": {
         "@otlpkit/adapters": "file:../../packages/adapters",
-        "@otlpkit/views": "file:../../packages/views",
+        "o11ytsdb": "file:../../packages/o11ytsdb",
         "react": "^19.2.6",
         "react-dom": "^19.2.5",
         "recharts": "^3.8.1",
@@ -90,15 +90,15 @@
       "name": "@otlpkit/example-echarts",
       "dependencies": {
         "@otlpkit/adapters": "file:../../packages/adapters",
-        "@otlpkit/views": "file:../../packages/views",
-        "echarts": "^6.0.0"
+        "echarts": "^6.0.0",
+        "o11ytsdb": "file:../../packages/o11ytsdb"
       }
     },
     "examples/recharts": {
       "name": "@otlpkit/example-recharts",
       "dependencies": {
         "@otlpkit/adapters": "file:../../packages/adapters",
-        "@otlpkit/views": "file:../../packages/views",
+        "o11ytsdb": "file:../../packages/o11ytsdb",
         "react": "^19.2.6",
         "react-dom": "^19.2.5",
         "recharts": "^3.8.1"
@@ -112,7 +112,7 @@
       "name": "@otlpkit/example-uplot",
       "dependencies": {
         "@otlpkit/adapters": "file:../../packages/adapters",
-        "@otlpkit/views": "file:../../packages/views",
+        "o11ytsdb": "file:../../packages/o11ytsdb",
         "uplot": "^1.6.31"
       }
     },


### PR DESCRIPTION
## Summary

Rewrites all 5 gallery examples to comply with the gallery contract defined in AGENTS.md.

### Before (contract violation)
All examples bypassed o11ytsdb storage and went directly:
```
OTLP document → @otlpkit/views → view adapters → chart library
```

### After (contract-compliant)
```
RowGroupStore → ScanEngine.query() → engine adapters → chart library
```

### Changes
- **New `examples/shared/store.ts`**: Shared RowGroupStore with deterministic sample metrics (4 series × 30 points), queried via ScanEngine
- **New `examples/demo/src/demo-store.ts`**: Demo-specific multi-metric store (5 metrics for the incident timeline story)
- **Rewritten examples**: chartjs, echarts, uplot, recharts, demo — all now use engine-path adapter functions (`toChartJsTimeSeriesConfig`, `toEChartsTimeSeriesOption`, etc.) instead of view-path functions
- **Updated `package.json` deps**: Replaced `@otlpkit/views` with `o11ytsdb` (file: link to workspace package)

### Verification
All 5 examples pass `tsc --noEmit` with their respective tsconfigs.

The old `@otlpkit/views` path is still valid for users who don't need storage persistence, but the gallery contract requires demonstrating the full TSDB pipeline.

Closes #254