### PR TITLE
feat: OTLP ingest bridge, restore exports, fix bugs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -18,5 +18,11 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [
+    "@otlpkit/example-chartjs",
+    "@otlpkit/example-demo",
+    "@otlpkit/example-echarts",
+    "@otlpkit/example-recharts",
+    "@otlpkit/example-uplot"
+  ]
 }

--- a/octo11y/packages/adapters/CHANGELOG.md
+++ b/octo11y/packages/adapters/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @octo11y/adapters
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial release

--- a/octo11y/packages/chart/CHANGELOG.md
+++ b/octo11y/packages/chart/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @octo11y/chart
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial release

--- a/octo11y/packages/core/CHANGELOG.md
+++ b/octo11y/packages/core/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @octo11y/core
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial release

--- a/octo11y/packages/dashboard/CHANGELOG.md
+++ b/octo11y/packages/dashboard/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @octo11y/dashboard
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial release

--- a/octo11y/packages/format/CHANGELOG.md
+++ b/octo11y/packages/format/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @octo11y/format
+
+## 0.0.1
+
+### Patch Changes
+
+- Initial release

--- a/packages/o11ylogsdb/README.md
+++ b/packages/o11ylogsdb/README.md
@@ -24,7 +24,7 @@ executor that never materializes proportional-to-N.
 | **M2 — Drain template extractor** | **graduated** to `packages/o11y-codec-rt/drain/`. ARI = 1.0 vs the published Python reference on five public log corpora. TS port at `src/drain.ts` is bit-identical and integrated via `DrainChunkPolicy`, `ColumnarDrainPolicy`, `TypedColumnarDrainPolicy`. Configurable masker + persistable state pending — see [`dev-docs/drain-prototype.md`](./dev-docs/drain-prototype.md). |
 | **M3 — Per-stream chunk format** | **scaffolded** (`src/chunk.ts` v1 wire format, `src/stream.ts` registry, `ChunkPolicy` plug-in surface with preEncode/postDecode + codecMeta round-trip). Per-column refinement pending. |
 | **M4 — Per-column codec dispatch** | **first cut shipped** (`ColumnarDrainPolicy`, `ColumnarRawPolicy`, `TypedColumnarDrainPolicy`). Per-column codec specialization (ALP for ints, FSST for strings, BF16 for identifiers) pending. |
-| M5 — OTLP logs ingest pipeline | not started |
+| **M5 — OTLP logs ingest pipeline** | **shipped** (`src/ingest.ts`). `ingestOtlpLogs(store, doc)` walks the OTLP JSON envelope, converts types, appends to LogStore. `iterOtlpLogRecords(doc)` streaming variant. `attributeEquals` query predicate also added. |
 | M6 — Indexes | severity zone-map shipped; BF8 / BF16 / Roaring-lite pending |
 | **M7 — Streaming query executor** | **first cut shipped** (`src/query.ts` streaming executor with chunk-level pruning by zone-map and severity range; `src/compact.ts` re-encodes chunks to a different policy). Builder API + cache pending. |
 | M8 — Worker isolation + public API | not started |

--- a/packages/o11ylogsdb/src/engine.ts
+++ b/packages/o11ylogsdb/src/engine.ts
@@ -120,9 +120,10 @@ export class LogStore {
       builder = new ChunkBuilder(resource, scope, this.policyFor(id), this.registry);
       this.inflight.set(id, builder);
     }
-    // Body classifier output is currently only consumed by future codec
-    // policies; we still call it so plugged-in classifiers can record state.
-    void this.classifier.classify(record);
+    // Note: body classification is handled internally by each policy
+    // (e.g. DrainChunkPolicy calls drain.matchOrAdd() during encode).
+    // The engine-level classifier is available for external consumers
+    // who need pre-classification stats but is not part of the codec path.
     builder.append(record);
     if (builder.size() >= this.rowsPerChunk) {
       this.streams.appendChunk(id, builder.freeze());

--- a/packages/o11ylogsdb/src/index.ts
+++ b/packages/o11ylogsdb/src/index.ts
@@ -51,6 +51,8 @@ export {
 } from "./drain.js";
 export type { IngestStats, LogStoreConfig, StoreStats } from "./engine.js";
 export { LogStore } from "./engine.js";
+export type { IngestResult, OtlpLogsDocument } from "./ingest.js";
+export { ingestOtlpLogs, iterOtlpLogRecords } from "./ingest.js";
 export type { QueryResult, QuerySpec, QueryStats } from "./query.js";
 export { query, queryStream } from "./query.js";
 export { StreamRegistry } from "./stream.js";

--- a/packages/o11ylogsdb/src/ingest.ts
+++ b/packages/o11ylogsdb/src/ingest.ts
@@ -1,0 +1,263 @@
+/**
+ * OTLP JSON ingest bridge (M5).
+ *
+ * Converts an `OtlpLogsDocument` (the OTLP/JSON wire format parsed by
+ * `@otlpkit/otlpjson`) into `LogStore.append()` calls. This is the
+ * primary adoption surface — callers who receive OTLP payloads from
+ * OTel SDKs or collectors can feed them directly into the engine.
+ *
+ * Design choices:
+ *   - Zero intermediate allocation beyond the `LogRecord` objects
+ *     themselves. We walk the OTLP envelope in-place.
+ *   - Resource/Scope are converted to `stardb` types and passed to
+ *     `append()` which handles stream-key interning.
+ *   - Timestamps: OTLP/JSON encodes nanos as strings (uint64 exceeds
+ *     JSON's `Number.MAX_SAFE_INTEGER`). We parse to `bigint`.
+ *   - Body: recursively converted from OTLP wire shape to `AnyValue`.
+ *   - Attributes: `OtlpKeyValue[]` → `KeyValue[]`.
+ *   - Hex trace_id / span_id → `Uint8Array`.
+ */
+
+import type { LogStore } from "./engine.js";
+import type { AnyValue, InstrumentationScope, KeyValue, LogRecord, Resource } from "./types.js";
+
+// ── OTLP wire types (subset needed for logs ingest) ─────────────────
+
+/** OTLP/JSON `AnyValue` wire shape. */
+interface OtlpAnyValue {
+  readonly stringValue?: string;
+  readonly boolValue?: boolean;
+  readonly intValue?: string | number;
+  readonly doubleValue?: number;
+  readonly bytesValue?: string; // base64
+  readonly arrayValue?: { readonly values?: readonly OtlpAnyValue[] };
+  readonly kvlistValue?: { readonly values?: readonly OtlpKeyValue[] };
+}
+
+interface OtlpKeyValue {
+  readonly key: string;
+  readonly value?: OtlpAnyValue;
+}
+
+/**
+ * Canonical OTLP/JSON `ExportLogsServiceRequest` shape — the document
+ * that an OTLP exporter sends. Same as `OtlpLogsDocument` from
+ * `@otlpkit/otlpjson`; redefined here to avoid a hard dependency.
+ */
+export interface OtlpLogsDocument {
+  readonly resourceLogs: readonly {
+    readonly resource?: {
+      readonly attributes?: readonly OtlpKeyValue[];
+      readonly droppedAttributesCount?: number;
+    };
+    readonly scopeLogs?: readonly {
+      readonly scope?: {
+        readonly name?: string;
+        readonly version?: string;
+        readonly attributes?: readonly OtlpKeyValue[];
+      };
+      readonly logRecords?: readonly {
+        readonly timeUnixNano?: string | number;
+        readonly observedTimeUnixNano?: string | number;
+        readonly severityNumber?: number;
+        readonly severityText?: string;
+        readonly body?: OtlpAnyValue;
+        readonly attributes?: readonly OtlpKeyValue[];
+        readonly droppedAttributesCount?: number;
+        readonly traceId?: string;
+        readonly spanId?: string;
+        readonly flags?: number;
+      }[];
+    }[];
+  }[];
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+export interface IngestResult {
+  recordsIngested: number;
+  chunksClosed: number;
+}
+
+/**
+ * Ingest a full OTLP/JSON logs document into a LogStore.
+ *
+ * Walks `resourceLogs[].scopeLogs[].logRecords[]`, converts each
+ * record to the engine's `LogRecord` shape, and appends it. Returns
+ * aggregate stats for the batch.
+ *
+ * @example
+ * ```ts
+ * import { LogStore, ingestOtlpLogs } from "o11ylogsdb";
+ *
+ * const store = new LogStore();
+ * const payload = JSON.parse(otlpJsonBody);
+ * const result = ingestOtlpLogs(store, payload);
+ * console.log(`Ingested ${result.recordsIngested} records`);
+ * ```
+ */
+export function ingestOtlpLogs(store: LogStore, doc: OtlpLogsDocument): IngestResult {
+  let recordsIngested = 0;
+  let chunksClosed = 0;
+
+  for (const rl of doc.resourceLogs) {
+    const resource = convertResource(rl.resource);
+    for (const sl of rl.scopeLogs ?? []) {
+      const scope = convertScope(sl.scope);
+      for (const lr of sl.logRecords ?? []) {
+        const record = convertLogRecord(lr);
+        const stats = store.append(resource, scope, record);
+        chunksClosed = stats.chunksClosed;
+        recordsIngested++;
+      }
+    }
+  }
+
+  return { recordsIngested, chunksClosed };
+}
+
+/**
+ * Streaming variant: yields converted `LogRecord` objects without
+ * appending them to a store. Useful when callers need to inspect
+ * records before ingest or route them to multiple stores.
+ */
+export function* iterOtlpLogRecords(doc: OtlpLogsDocument): Generator<{
+  resource: Resource;
+  scope: InstrumentationScope;
+  record: LogRecord;
+}> {
+  for (const rl of doc.resourceLogs) {
+    const resource = convertResource(rl.resource);
+    for (const sl of rl.scopeLogs ?? []) {
+      const scope = convertScope(sl.scope);
+      for (const lr of sl.logRecords ?? []) {
+        yield { resource, scope, record: convertLogRecord(lr) };
+      }
+    }
+  }
+}
+
+// ── Conversion helpers ───────────────────────────────────────────────
+
+function convertResource(raw?: {
+  readonly attributes?: readonly OtlpKeyValue[];
+  readonly droppedAttributesCount?: number;
+}): Resource {
+  return {
+    attributes: convertKeyValues(raw?.attributes),
+    ...(raw?.droppedAttributesCount ? { droppedAttributesCount: raw.droppedAttributesCount } : {}),
+  };
+}
+
+function convertScope(raw?: {
+  readonly name?: string;
+  readonly version?: string;
+  readonly attributes?: readonly OtlpKeyValue[];
+}): InstrumentationScope {
+  return {
+    name: raw?.name ?? "",
+    ...(raw?.version ? { version: raw.version } : {}),
+    ...(raw?.attributes?.length ? { attributes: convertKeyValues(raw.attributes) } : {}),
+  };
+}
+
+function convertLogRecord(raw: {
+  readonly timeUnixNano?: string | number;
+  readonly observedTimeUnixNano?: string | number;
+  readonly severityNumber?: number;
+  readonly severityText?: string;
+  readonly body?: OtlpAnyValue;
+  readonly attributes?: readonly OtlpKeyValue[];
+  readonly droppedAttributesCount?: number;
+  readonly traceId?: string;
+  readonly spanId?: string;
+  readonly flags?: number;
+}): LogRecord {
+  const record: LogRecord = {
+    timeUnixNano: parseNanos(raw.timeUnixNano),
+    severityNumber: raw.severityNumber ?? 9, // default INFO
+    severityText: (raw.severityText ?? "INFO") as LogRecord["severityText"],
+    body: convertAnyValue(raw.body),
+    attributes: convertKeyValues(raw.attributes),
+  };
+
+  if (raw.observedTimeUnixNano !== undefined) {
+    record.observedTimeUnixNano = parseNanos(raw.observedTimeUnixNano);
+  }
+  if (raw.droppedAttributesCount) {
+    record.droppedAttributesCount = raw.droppedAttributesCount;
+  }
+  if (raw.flags !== undefined) {
+    record.flags = raw.flags;
+  }
+  if (raw.traceId) {
+    const bytes = hexToBytes(raw.traceId, 16);
+    if (bytes) record.traceId = bytes;
+  }
+  if (raw.spanId) {
+    const bytes = hexToBytes(raw.spanId, 8);
+    if (bytes) record.spanId = bytes;
+  }
+
+  return record;
+}
+
+function convertKeyValues(raw?: readonly OtlpKeyValue[]): KeyValue[] {
+  if (!raw || raw.length === 0) return [];
+  return raw.map((kv) => ({ key: kv.key, value: convertAnyValue(kv.value) }));
+}
+
+function convertAnyValue(v?: OtlpAnyValue): AnyValue {
+  if (v === undefined || v === null) return null;
+  if (v.stringValue !== undefined) return v.stringValue;
+  if (v.boolValue !== undefined) return v.boolValue;
+  if (v.intValue !== undefined) {
+    // OTLP/JSON encodes int64 as string to avoid precision loss
+    if (typeof v.intValue === "string") return BigInt(v.intValue);
+    return v.intValue;
+  }
+  if (v.doubleValue !== undefined) return v.doubleValue;
+  if (v.bytesValue !== undefined) return base64ToBytes(v.bytesValue);
+  if (v.arrayValue !== undefined) {
+    return (v.arrayValue.values ?? []).map((el) => convertAnyValue(el));
+  }
+  if (v.kvlistValue !== undefined) {
+    const obj: { [key: string]: AnyValue } = {};
+    for (const kv of v.kvlistValue.values ?? []) {
+      obj[kv.key] = convertAnyValue(kv.value);
+    }
+    return obj;
+  }
+  return null;
+}
+
+/** Parse nanosecond timestamp (string or number) to bigint. */
+function parseNanos(v?: string | number): bigint {
+  if (v === undefined || v === null) return 0n;
+  if (typeof v === "string") return v === "" ? 0n : BigInt(v);
+  return BigInt(v);
+}
+
+/** Hex string to Uint8Array with expected length validation. */
+function hexToBytes(hex: string, expectedLen: number): Uint8Array | undefined {
+  if (!hex || hex === "0".repeat(expectedLen * 2)) return undefined;
+  const bytes = new Uint8Array(expectedLen);
+  for (let i = 0; i < expectedLen; i++) {
+    bytes[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/** Base64 string to Uint8Array. */
+function base64ToBytes(b64: string): Uint8Array {
+  if (typeof globalThis.atob === "function") {
+    const binary = globalThis.atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+  // Node.js fallback
+  return new Uint8Array(Buffer.from(b64, "base64"));
+}

--- a/packages/o11ylogsdb/src/query.ts
+++ b/packages/o11ylogsdb/src/query.ts
@@ -67,6 +67,12 @@ export interface QuerySpec {
    * needed for failures.
    */
   resourceEquals?: Record<string, string>;
+  /**
+   * Log-record attribute equality filters. Each (key, value) pair must
+   * match in the record's `attributes` array for the record to pass.
+   * Per-record post-decode check (no index acceleration yet).
+   */
+  attributeEquals?: Record<string, string | number | boolean>;
   /** Maximum records to emit. */
   limit?: number;
 }
@@ -171,12 +177,14 @@ export function* queryStream(
         for (let i = 0; i < filtered.length; i++) {
           const record = filtered[i];
           if (record === undefined) continue;
-          // Body already verified; still check time range + severity
+          // Body already verified; still check time range + severity + attributes
           if (spec.range) {
             if (record.timeUnixNano < spec.range.from) continue;
             if (record.timeUnixNano >= spec.range.to) continue;
           }
           if (spec.severityGte !== undefined && record.severityNumber < spec.severityGte) continue;
+          if (spec.attributeEquals !== undefined && !attributeMatches(record, spec.attributeEquals))
+            continue;
           stats.recordsEmitted++;
           yield record;
           emitted++;
@@ -316,6 +324,27 @@ function recordMatches(record: LogRecord, spec: QuerySpec): boolean {
       const actual = leafGet(body as Record<string, unknown>, path);
       if (actual !== expected) return false;
     }
+  }
+  if (spec.attributeEquals !== undefined) {
+    if (!attributeMatches(record, spec.attributeEquals)) return false;
+  }
+  return true;
+}
+
+/** Check if record.attributes contains all specified key-value pairs. */
+function attributeMatches(
+  record: LogRecord,
+  attrSpec: Record<string, string | number | boolean>
+): boolean {
+  for (const [key, expected] of Object.entries(attrSpec)) {
+    let found = false;
+    for (const kv of record.attributes) {
+      if (kv.key === key && kv.value === expected) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) return false;
   }
   return true;
 }

--- a/packages/o11ylogsdb/test/attribute-query.test.ts
+++ b/packages/o11ylogsdb/test/attribute-query.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the `attributeEquals` query predicate.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { OtlpLogsDocument } from "../src/index.js";
+import { ingestOtlpLogs, LogStore, query } from "../src/index.js";
+
+const DOC: OtlpLogsDocument = {
+  resourceLogs: [
+    {
+      resource: {
+        attributes: [{ key: "service.name", value: { stringValue: "orders" } }],
+      },
+      scopeLogs: [
+        {
+          scope: { name: "http" },
+          logRecords: [
+            {
+              timeUnixNano: "1700000001000000000",
+              severityNumber: 9,
+              severityText: "INFO",
+              body: { stringValue: "GET /orders 200" },
+              attributes: [
+                { key: "http.method", value: { stringValue: "GET" } },
+                { key: "http.route", value: { stringValue: "/orders" } },
+                { key: "http.status_code", value: { intValue: 200 } },
+              ],
+            },
+            {
+              timeUnixNano: "1700000002000000000",
+              severityNumber: 9,
+              severityText: "INFO",
+              body: { stringValue: "POST /orders 201" },
+              attributes: [
+                { key: "http.method", value: { stringValue: "POST" } },
+                { key: "http.route", value: { stringValue: "/orders" } },
+                { key: "http.status_code", value: { intValue: 201 } },
+              ],
+            },
+            {
+              timeUnixNano: "1700000003000000000",
+              severityNumber: 17,
+              severityText: "ERROR",
+              body: { stringValue: "DELETE /orders/5 403" },
+              attributes: [
+                { key: "http.method", value: { stringValue: "DELETE" } },
+                { key: "http.route", value: { stringValue: "/orders/:id" } },
+                { key: "http.status_code", value: { intValue: 403 } },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe("attributeEquals predicate", () => {
+  function makeStore() {
+    const store = new LogStore({ rowsPerChunk: 100 });
+    ingestOtlpLogs(store, DOC);
+    store.flush();
+    return store;
+  }
+
+  it("filters by single string attribute", () => {
+    const store = makeStore();
+    const result = query(store, { attributeEquals: { "http.method": "GET" } });
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0]!.body).toBe("GET /orders 200");
+  });
+
+  it("filters by multiple attributes (AND semantics)", () => {
+    const store = makeStore();
+    const result = query(store, {
+      attributeEquals: { "http.method": "POST", "http.route": "/orders" },
+    });
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0]!.body).toBe("POST /orders 201");
+  });
+
+  it("returns empty when attribute value does not match", () => {
+    const store = makeStore();
+    const result = query(store, { attributeEquals: { "http.method": "PATCH" } });
+    expect(result.records).toHaveLength(0);
+  });
+
+  it("returns empty when attribute key does not exist", () => {
+    const store = makeStore();
+    const result = query(store, { attributeEquals: { "nonexistent.key": "value" } });
+    expect(result.records).toHaveLength(0);
+  });
+
+  it("combines with severity filter", () => {
+    const store = makeStore();
+    const result = query(store, {
+      attributeEquals: { "http.route": "/orders/:id" },
+      severityGte: 17,
+    });
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0]!.body).toBe("DELETE /orders/5 403");
+  });
+
+  it("combines with bodyContains", () => {
+    const store = makeStore();
+    const result = query(store, {
+      bodyContains: "200",
+      attributeEquals: { "http.method": "GET" },
+    });
+    expect(result.records).toHaveLength(1);
+  });
+});

--- a/packages/o11ylogsdb/test/ingest.test.ts
+++ b/packages/o11ylogsdb/test/ingest.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for the OTLP ingest bridge (`ingest.ts`).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { OtlpLogsDocument } from "../src/index.js";
+import { ingestOtlpLogs, iterOtlpLogRecords, LogStore, query } from "../src/index.js";
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const MINIMAL_DOC: OtlpLogsDocument = {
+  resourceLogs: [
+    {
+      resource: {
+        attributes: [{ key: "service.name", value: { stringValue: "checkout" } }],
+      },
+      scopeLogs: [
+        {
+          scope: { name: "my-library", version: "1.2.3" },
+          logRecords: [
+            {
+              timeUnixNano: "1700000000000000000",
+              severityNumber: 9,
+              severityText: "INFO",
+              body: { stringValue: "Order placed successfully" },
+              attributes: [
+                { key: "order.id", value: { stringValue: "abc-123" } },
+                { key: "user.id", value: { intValue: "42" } },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const MULTI_RECORD_DOC: OtlpLogsDocument = {
+  resourceLogs: [
+    {
+      resource: {
+        attributes: [{ key: "service.name", value: { stringValue: "api" } }],
+      },
+      scopeLogs: [
+        {
+          scope: { name: "http" },
+          logRecords: [
+            {
+              timeUnixNano: "1700000001000000000",
+              severityNumber: 9,
+              severityText: "INFO",
+              body: { stringValue: "GET /users 200 45ms" },
+              attributes: [
+                { key: "http.method", value: { stringValue: "GET" } },
+                { key: "http.status_code", value: { intValue: 200 } },
+              ],
+            },
+            {
+              timeUnixNano: "1700000002000000000",
+              severityNumber: 13,
+              severityText: "WARN",
+              body: { stringValue: "GET /users 429 rate limited" },
+              attributes: [
+                { key: "http.method", value: { stringValue: "GET" } },
+                { key: "http.status_code", value: { intValue: 429 } },
+              ],
+            },
+            {
+              timeUnixNano: "1700000003000000000",
+              severityNumber: 17,
+              severityText: "ERROR",
+              body: { stringValue: "POST /orders 500 internal error" },
+              attributes: [
+                { key: "http.method", value: { stringValue: "POST" } },
+                { key: "http.status_code", value: { intValue: 500 } },
+              ],
+              traceId: "0af7651916cd43dd8448eb211c80319c",
+              spanId: "b7ad6b7169203331",
+              flags: 1,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const KVLIST_BODY_DOC: OtlpLogsDocument = {
+  resourceLogs: [
+    {
+      resource: { attributes: [] },
+      scopeLogs: [
+        {
+          scope: { name: "structured" },
+          logRecords: [
+            {
+              timeUnixNano: "1700000000000000000",
+              severityNumber: 9,
+              severityText: "INFO",
+              body: {
+                kvlistValue: {
+                  values: [
+                    { key: "action", value: { stringValue: "login" } },
+                    { key: "duration_ms", value: { doubleValue: 42.5 } },
+                  ],
+                },
+              },
+              attributes: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("ingestOtlpLogs", () => {
+  it("ingests a minimal document", () => {
+    const store = new LogStore({ rowsPerChunk: 100 });
+    const result = ingestOtlpLogs(store, MINIMAL_DOC);
+
+    expect(result.recordsIngested).toBe(1);
+    store.flush();
+    const stats = store.stats();
+    expect(stats.totalLogs).toBe(1);
+    expect(stats.streams).toBe(1);
+  });
+
+  it("preserves timestamp as bigint", () => {
+    const store = new LogStore({ rowsPerChunk: 100 });
+    ingestOtlpLogs(store, MINIMAL_DOC);
+    store.flush();
+
+    const records = [...store.iterRecords()].flatMap((s) => s.records);
+    expect(records[0]!.timeUnixNano).toBe(1700000000000000000n);
+  });
+
+  it("converts string body", () => {
+    const store = new LogStore({ rowsPerChunk: 100 });
+    ingestOtlpLogs(store, MINIMAL_DOC);
+    store.flush();
+
+    const records = [...store.iterRecords()].flatMap((s) => s.records);
+    expect(records[0]!.body).toBe("Order placed successfully");
+  });
+
+  it("converts attributes to KeyValue[]", () => {
+    const store = new LogStore({ rowsPerChunk: 100 });
+    ingestOtlpLogs(store, MINIMAL_DOC);
+    store.flush();
+
+    const records = [...store.iterRecords()].flatMap((s) => s.records);
+    const attrs = records[0]!.attributes;
+    expect(attrs).toHaveLength(2);
+    expect(attrs[0]).toEqual({ key: "order.id", value: "abc-123" });
+    expect(attrs[1]).toEqual({ key: "user.id", value: 42n });
+  });
+
+  it("ingests multiple records across a batch", () => {
+    const store = new LogStore({ rowsPerChunk: 100 });
+    const result = ingestOtlpLogs(store, MULTI_RECORD_DOC);
+
+    expect(result.recordsIngested).toBe(3);
+    store.flush();
+    expect(store.stats().totalLogs).toBe(3);
+  });
+
+  it("converts trace_id and span_id hex to Uint8Array", () => {
+    const store = new LogStore({ rowsPerChunk: 100 });
+    ingestOtlpLogs(store, MULTI_RECORD_DOC);
+    store.flush();
+
+    const records = [...store.iterRecords()].flatMap((s) => s.records);
+    const errorRecord = records.find((r) => r.severityNumber === 17)!;
+    expect(errorRecord.traceId).toBeInstanceOf(Uint8Array);
+    expect(errorRecord.traceId!.length).toBe(16);
+    expect(errorRecord.spanId).toBeInstanceOf(Uint8Array);
+    expect(errorRecord.spanId!.length).toBe(8);
+    expect(errorRecord.flags).toBe(1);
+  });
+
+  it("converts KVList body to object AnyValue", () => {
+    const store = new LogStore({ rowsPerChunk: 100 });
+    ingestOtlpLogs(store, KVLIST_BODY_DOC);
+    store.flush();
+
+    const records = [...store.iterRecords()].flatMap((s) => s.records);
+    expect(records[0]!.body).toEqual({ action: "login", duration_ms: 42.5 });
+  });
+
+  it("handles missing optional fields gracefully", () => {
+    const doc: OtlpLogsDocument = {
+      resourceLogs: [
+        {
+          resource: undefined,
+          scopeLogs: [
+            {
+              scope: undefined,
+              logRecords: [
+                {
+                  timeUnixNano: "1700000000000000000",
+                  body: { stringValue: "bare record" },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const store = new LogStore({ rowsPerChunk: 100 });
+    const result = ingestOtlpLogs(store, doc);
+    expect(result.recordsIngested).toBe(1);
+    store.flush();
+
+    const records = [...store.iterRecords()].flatMap((s) => s.records);
+    expect(records[0]!.body).toBe("bare record");
+    expect(records[0]!.severityNumber).toBe(9); // default INFO
+  });
+
+  it("handles numeric timeUnixNano", () => {
+    const doc: OtlpLogsDocument = {
+      resourceLogs: [
+        {
+          scopeLogs: [
+            {
+              logRecords: [
+                {
+                  timeUnixNano: 1700000000000,
+                  severityNumber: 5,
+                  severityText: "DEBUG",
+                  body: { stringValue: "numeric ts" },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const store = new LogStore({ rowsPerChunk: 100 });
+    ingestOtlpLogs(store, doc);
+    store.flush();
+
+    const records = [...store.iterRecords()].flatMap((s) => s.records);
+    expect(records[0]!.timeUnixNano).toBe(1700000000000n);
+  });
+});
+
+describe("iterOtlpLogRecords", () => {
+  it("yields resource, scope, and record for each log", () => {
+    const items = [...iterOtlpLogRecords(MULTI_RECORD_DOC)];
+    expect(items).toHaveLength(3);
+    expect(items[0]!.resource.attributes[0]!.key).toBe("service.name");
+    expect(items[0]!.scope.name).toBe("http");
+    expect(items[0]!.record.body).toBe("GET /users 200 45ms");
+  });
+});
+
+describe("ingest + query integration", () => {
+  it("ingested records are queryable by body substring", () => {
+    const store = new LogStore({ rowsPerChunk: 100 });
+    ingestOtlpLogs(store, MULTI_RECORD_DOC);
+    store.flush();
+
+    const result = query(store, { bodyContains: "rate limited" });
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0]!.severityNumber).toBe(13);
+  });
+
+  it("ingested records are queryable by severity", () => {
+    const store = new LogStore({ rowsPerChunk: 100 });
+    ingestOtlpLogs(store, MULTI_RECORD_DOC);
+    store.flush();
+
+    const result = query(store, { severityGte: 13 });
+    expect(result.records).toHaveLength(2); // WARN + ERROR
+  });
+
+  it("ingested records are queryable by resource attribute", () => {
+    const store = new LogStore({ rowsPerChunk: 100 });
+    ingestOtlpLogs(store, MULTI_RECORD_DOC);
+    store.flush();
+
+    const result = query(store, { resourceEquals: { "service.name": "api" } });
+    expect(result.records).toHaveLength(3);
+
+    const miss = query(store, { resourceEquals: { "service.name": "web" } });
+    expect(miss.records).toHaveLength(0);
+  });
+
+  it("ingested records are queryable by time range", () => {
+    const store = new LogStore({ rowsPerChunk: 100 });
+    ingestOtlpLogs(store, MULTI_RECORD_DOC);
+    store.flush();
+
+    const result = query(store, {
+      range: { from: 1700000002000000000n, to: 1700000003000000001n },
+    });
+    expect(result.records).toHaveLength(2); // WARN + ERROR
+  });
+});

--- a/packages/o11ytracesdb/src/engine.ts
+++ b/packages/o11ytracesdb/src/engine.ts
@@ -152,21 +152,23 @@ export class TraceStore {
    */
   private evict(): void {
     const now = Date.now();
-    while (this.chunkOrder.length > 0) {
-      const oldest = this.chunkOrder[0];
+    let evicted = 0;
+    while (evicted < this.chunkOrder.length) {
+      const oldest = this.chunkOrder[evicted];
       if (!oldest) break;
       const overBytes = this.totalPayloadBytes > this.maxPayloadBytes;
-      const overCount = this.chunkOrder.length > this.maxChunks;
+      const overCount = this.chunkOrder.length - evicted > this.maxChunks;
       const overTTL = now - oldest.sealedAt > this.ttlMs;
 
       if (!overBytes && !overCount && !overTTL) break;
 
-      this.chunkOrder.shift();
       this.registry.removeChunk(oldest.streamId, oldest.chunk);
       this.totalPayloadBytes -= oldest.chunk.header.payloadBytes;
       this._evictedChunks++;
       this._evictedSpans += oldest.chunk.header.nSpans;
+      evicted++;
     }
+    if (evicted > 0) this.chunkOrder.splice(0, evicted);
   }
 
   /** Get the stream registry for query access. */

--- a/packages/o11ytsdb/src/index.ts
+++ b/packages/o11ytsdb/src/index.ts
@@ -34,10 +34,18 @@ export {
   floatToBits,
 } from "./codec.js";
 export { FlatStore } from "./flat-store.js";
-// TODO(#178): Ingest exports removed — API mismatch with @otlpkit/otlpjson.
-// Re-export once the ingest module is fixed.
-// export type { IngestResult, OtlpMetricsDocument, ParsedOtlpResult, PendingSeriesSamples } from "./ingest.js";
-// export { flushSamplesToStorage, ingestOtlpJson, ingestOtlpObject, parseOtlpToSamples } from "./ingest.js";
+export type {
+  IngestResult,
+  OtlpMetricsDocument,
+  ParsedOtlpResult,
+  PendingSeriesSamples,
+} from "./ingest.js";
+export {
+  flushSamplesToStorage,
+  ingestOtlpJson,
+  ingestOtlpObject,
+  parseOtlpToSamples,
+} from "./ingest.js";
 // Label index — shared label management for storage backends
 export { LabelIndex } from "./label-index.js";
 export { MemPostings } from "./postings.js";
@@ -73,10 +81,8 @@ export type {
   TransformOp,
   ValuesCodec,
 } from "./types.js";
-// TODO(#179): WASM codec exports removed — binaries not in repo.
-// Re-export once WASM binaries are available.
-// export type { WasmCodecs } from "./wasm-codecs.js";
-// export { initWasmCodecs } from "./wasm-codecs.js";
+export type { WasmCodecs } from "./wasm-codecs.js";
+export { initWasmCodecs } from "./wasm-codecs.js";
 export { WorkerClient } from "./worker-client.js";
 export type {
   BatchIngestRequest,

--- a/packages/otlpjson/src/index.ts
+++ b/packages/otlpjson/src/index.ts
@@ -587,7 +587,16 @@ export function toUnixNanos(value: unknown): bigint | null {
     return value;
   }
   if (typeof value === "number") {
-    return Number.isFinite(value) ? BigInt(Math.trunc(value)) : null;
+    if (!Number.isFinite(value)) return null;
+    const truncated = Math.trunc(value);
+    // Heuristic: values in the millisecond-epoch range (1e10 to 1e15) are
+    // assumed to be milliseconds (e.g. from Date.now()) and scaled to nanos.
+    // Values >= 1e15 are valid nanosecond timestamps. Values < 1e10 are passed
+    // through as-is (relative offsets or synthetic values).
+    if (truncated >= 1e10 && truncated < 1e15) {
+      return BigInt(truncated) * 1_000_000n;
+    }
+    return BigInt(truncated);
   }
   if (value instanceof Date) {
     return BigInt(value.getTime()) * 1_000_000n;


### PR DESCRIPTION
## Summary

Multi-faceted improvements across the monorepo: new LogsDB OTLP ingest, restored o11ytsdb exports, performance fix, bug fix, and CI fixes.

### LogsDB: OTLP JSON Ingest Bridge (M5)

- **`ingestOtlpLogs(store, doc)`** — walks the full OTLP JSON envelope (resourceLogs → scopeLogs → logRecords), converts types, and appends to the LogStore
- **`iterOtlpLogRecords(doc)`** — streaming variant yielding `{resource, scope, record}` tuples
- **`attributeEquals`** query predicate — filters by attribute key-value pairs (AND semantics)
- Removed dead `classifier.classify()` call in engine.ts
- 20 new tests (14 ingest, 6 attribute query) — all 270 LogsDB tests pass

### o11ytsdb: Restore Exports

- Re-enable OTLP metrics ingest exports (TODO #178 — API mismatch was stale)
- Re-enable WASM codec exports (TODO #179 — fixes deploy CI `initWasmCodecs` missing export)

### o11ytracesdb: Fix O(n) Eviction (fixes #199, #224)

- Replace per-item `shift()` with batched `splice(0, evicted)` — O(1) amortized instead of O(n²)

### otlpjson: Fix toUnixNanos (fixes #222)

- Detect millisecond-range numbers (1e10–1e15) and auto-scale to nanoseconds
- Numbers ≥1e15 treated as nanos, <1e10 passed through as-is

### CI/Release Fixes

- Add missing CHANGELOG.md files for octo11y packages (fixes release workflow ENOENT)
- Add example packages to changeset `ignore` list (fixes `file:` dep validation errors)
- Update o11ylogsdb README to mark M5 as shipped

### Test Results

- o11ylogsdb: 270 passed
- o11ytsdb: 300 passed  
- o11ytracesdb: 169 passed
- otlpjson: 14 passed
- Full monorepo typecheck: clean